### PR TITLE
feat: define wrapgod.manifest.v1 JSON schema and validation fixtures

### DIFF
--- a/WrapGod.Tests/ManifestSchemaTests.cs
+++ b/WrapGod.Tests/ManifestSchemaTests.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using Json.Schema;
+
+namespace WrapGod.Tests;
+
+public class ManifestSchemaTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
+    private static readonly JsonSchema Schema = JsonSchema.FromText(
+        File.ReadAllText(Path.Combine(RepoRoot, "schemas", "wrapgod.manifest.v1.schema.json")));
+
+    [Fact]
+    public void ManifestSchemaValidExamplePassesValidation()
+    {
+        var validText = File.ReadAllText(Path.Combine(RepoRoot, "schemas", "examples", "manifest.valid.json"));
+
+        using var validDoc = JsonDocument.Parse(validText);
+        var result = Schema.Evaluate(validDoc.RootElement);
+
+        Assert.True(result.IsValid, "Expected valid manifest example to pass schema validation.");
+    }
+
+    [Fact]
+    public void ManifestSchemaInvalidExampleFailsValidation()
+    {
+        var invalidText = File.ReadAllText(Path.Combine(RepoRoot, "schemas", "examples", "manifest.invalid.missing-assembly.json"));
+
+        using var invalidDoc = JsonDocument.Parse(invalidText);
+        var result = Schema.Evaluate(invalidDoc.RootElement);
+
+        Assert.False(result.IsValid, "Expected invalid manifest example to fail schema validation.");
+    }
+}

--- a/WrapGod.Tests/WrapGod.Tests.csproj
+++ b/WrapGod.Tests/WrapGod.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="8.0.1" />
+    <PackageReference Include="JsonSchema.Net" Version="9.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/docs/MANIFEST-SCHEMA.md
+++ b/docs/MANIFEST-SCHEMA.md
@@ -1,0 +1,28 @@
+# Manifest Schema v1 (`wrapgod.manifest.v1`)
+
+Canonical schema file:
+
+- `schemas/wrapgod.manifest.v1.schema.json`
+
+Examples:
+
+- valid: `schemas/examples/manifest.valid.json`
+- invalid: `schemas/examples/manifest.invalid.missing-assembly.json`
+
+## Versioning Strategy
+
+- `schemaVersion` is required and currently fixed at `1.0`.
+- Breaking schema changes require a new major schema version file (`v2`, etc.).
+- Non-breaking additive fields can be introduced in-place while keeping `1.0` compatibility.
+- Consumers should ignore unknown fields only when explicitly allowed by future schema versions; v1 currently uses `additionalProperties: false` in core objects to enforce strictness.
+
+## Design Notes
+
+V1 intentionally captures:
+
+- assembly identity (`name`, `version`, optional culture/token/tfm)
+- stable type/member identifiers
+- member signatures (parameters, generics)
+- per-type/per-member version presence metadata (`introducedIn`, `removedIn`, `changedIn`)
+
+This gives us deterministic extraction output and a stable planner/generator contract.

--- a/schemas/examples/manifest.invalid.missing-assembly.json
+++ b/schemas/examples/manifest.invalid.missing-assembly.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": "1.0",
+  "generatedAt": "2026-03-27T15:00:00Z",
+  "types": []
+}

--- a/schemas/examples/manifest.valid.json
+++ b/schemas/examples/manifest.valid.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "1.0",
+  "generatedAt": "2026-03-27T15:00:00Z",
+  "sourceHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "assembly": {
+    "name": "ThirdParty.Client",
+    "version": "2.3.0",
+    "targetFramework": ".NETStandard,Version=v2.0"
+  },
+  "types": [
+    {
+      "stableId": "ThirdParty.Client.ApiClient",
+      "fullName": "ThirdParty.Client.ApiClient",
+      "name": "ApiClient",
+      "namespace": "ThirdParty.Client",
+      "kind": "class",
+      "interfaces": [],
+      "genericParameters": [],
+      "members": [
+        {
+          "stableId": "ThirdParty.Client.ApiClient.GetUser(System.String)",
+          "name": "GetUser",
+          "kind": "method",
+          "returnType": "ThirdParty.Client.User",
+          "parameters": [
+            {
+              "name": "id",
+              "type": "System.String",
+              "isOptional": false,
+              "isParams": false,
+              "isOut": false,
+              "isRef": false
+            }
+          ],
+          "genericParameters": [],
+          "isStatic": false,
+          "isVirtual": false,
+          "isAbstract": false,
+          "hasGetter": false,
+          "hasSetter": false,
+          "presence": {
+            "introducedIn": "2.0.0"
+          }
+        }
+      ],
+      "presence": {
+        "introducedIn": "2.0.0"
+      }
+    }
+  ]
+}

--- a/schemas/wrapgod.manifest.v1.schema.json
+++ b/schemas/wrapgod.manifest.v1.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/JerrettDavis/WrapGod/main/schemas/wrapgod.manifest.v1.schema.json",
+  "title": "WrapGod Manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "generatedAt", "assembly", "types"],
+  "properties": {
+    "schemaVersion": { "type": "string", "const": "1.0" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "sourceHash": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "assembly": { "$ref": "#/$defs/assemblyIdentity" },
+    "types": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/apiTypeNode" }
+    }
+  },
+  "$defs": {
+    "assemblyIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "culture": { "type": ["string", "null"] },
+        "publicKeyToken": { "type": ["string", "null"] },
+        "targetFramework": { "type": ["string", "null"] }
+      }
+    },
+    "versionPresence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "introducedIn": { "type": ["string", "null"] },
+        "removedIn": { "type": ["string", "null"] },
+        "changedIn": { "type": ["string", "null"] }
+      }
+    },
+    "genericParameter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "constraints"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "constraints": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "type": { "type": "string", "minLength": 1 },
+        "isOptional": { "type": "boolean" },
+        "isParams": { "type": "boolean" },
+        "isOut": { "type": "boolean" },
+        "isRef": { "type": "boolean" },
+        "defaultValue": { "type": ["string", "null"] }
+      }
+    },
+    "apiMemberNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stableId", "name", "kind", "parameters", "genericParameters"],
+      "properties": {
+        "stableId": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "kind": {
+          "type": "string",
+          "enum": ["method", "property", "field", "event", "constructor", "indexer", "operator"]
+        },
+        "returnType": { "type": ["string", "null"] },
+        "parameters": { "type": "array", "items": { "$ref": "#/$defs/parameter" } },
+        "genericParameters": { "type": "array", "items": { "$ref": "#/$defs/genericParameter" } },
+        "isStatic": { "type": "boolean" },
+        "isVirtual": { "type": "boolean" },
+        "isAbstract": { "type": "boolean" },
+        "hasGetter": { "type": "boolean" },
+        "hasSetter": { "type": "boolean" },
+        "presence": { "$ref": "#/$defs/versionPresence" }
+      }
+    },
+    "apiTypeNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stableId",
+        "fullName",
+        "name",
+        "namespace",
+        "kind",
+        "interfaces",
+        "genericParameters",
+        "members"
+      ],
+      "properties": {
+        "stableId": { "type": "string", "minLength": 1 },
+        "fullName": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "namespace": { "type": "string" },
+        "kind": {
+          "type": "string",
+          "enum": ["class", "struct", "interface", "enum", "delegate", "record", "recordStruct"]
+        },
+        "baseType": { "type": ["string", "null"] },
+        "interfaces": { "type": "array", "items": { "type": "string" } },
+        "genericParameters": { "type": "array", "items": { "$ref": "#/$defs/genericParameter" } },
+        "isSealed": { "type": "boolean" },
+        "isAbstract": { "type": "boolean" },
+        "isStatic": { "type": "boolean" },
+        "members": { "type": "array", "items": { "$ref": "#/$defs/apiMemberNode" } },
+        "presence": { "$ref": "#/$defs/versionPresence" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary\n- add canonical wrapgod.manifest.v1 JSON Schema under schemas/\n- add valid + invalid example manifests\n- add schema contract documentation and versioning notes\n- add automated tests that validate fixtures against schema\n\n## Validation\n- dotnet test WrapGod.slnx\n\nCloses #3