### PR TITLE
feat: Extractor MVP - assembly extraction and manifest serialization

### DIFF
--- a/WrapGod.Extractor/AssemblyExtractor.cs
+++ b/WrapGod.Extractor/AssemblyExtractor.cs
@@ -1,0 +1,361 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using WrapGod.Manifest;
+
+namespace WrapGod.Extractor;
+
+/// <summary>
+/// Extracts the public API surface of a .NET assembly into an <see cref="ApiManifest"/>.
+/// Uses <see cref="MetadataLoadContext"/> for safe, reflection-only loading.
+/// </summary>
+public static class AssemblyExtractor
+{
+    /// <summary>
+    /// Extracts an <see cref="ApiManifest"/> from the assembly at <paramref name="assemblyPath"/>.
+    /// </summary>
+    /// <param name="assemblyPath">Absolute path to the .NET assembly DLL.</param>
+    /// <returns>A fully-populated, deterministically-sorted manifest.</returns>
+    /// <exception cref="FileNotFoundException">Thrown when the assembly file does not exist.</exception>
+    public static ApiManifest Extract(string assemblyPath)
+    {
+        if (!File.Exists(assemblyPath))
+        {
+            throw new FileNotFoundException("Assembly file not found.", assemblyPath);
+        }
+
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var resolver = new PathAssemblyResolver(
+            Directory.GetFiles(runtimeDir, "*.dll")
+                .Append(assemblyPath));
+
+        using var mlc = new MetadataLoadContext(resolver);
+        var assembly = mlc.LoadFromAssemblyPath(assemblyPath);
+
+        var manifest = new ApiManifest
+        {
+            SchemaVersion = "1.0",
+            GeneratedAt = DateTimeOffset.UtcNow,
+            SourceHash = ComputeFileHash(assemblyPath),
+            Assembly = ExtractIdentity(assembly),
+            Types = ExtractTypes(assembly)
+                .OrderBy(t => t.StableId, StringComparer.Ordinal)
+                .ToList(),
+        };
+
+        return manifest;
+    }
+
+    private static string ComputeFileHash(string filePath)
+    {
+        using var stream = File.OpenRead(filePath);
+        var hash = SHA256.HashData(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static AssemblyIdentity ExtractIdentity(Assembly assembly)
+    {
+        var name = assembly.GetName();
+        var token = name.GetPublicKeyToken();
+
+        return new AssemblyIdentity
+        {
+            Name = name.Name ?? string.Empty,
+            Version = name.Version?.ToString() ?? string.Empty,
+            Culture = string.IsNullOrEmpty(name.CultureName) ? null : name.CultureName,
+            PublicKeyToken = token is { Length: > 0 }
+                ? Convert.ToHexString(token).ToLowerInvariant()
+                : null,
+            TargetFramework = assembly.CustomAttributes
+                .Where(a => a.AttributeType.FullName ==
+                    "System.Runtime.Versioning.TargetFrameworkAttribute")
+                .SelectMany(a => a.ConstructorArguments)
+                .Select(a => a.Value?.ToString())
+                .FirstOrDefault(),
+        };
+    }
+
+    private static IEnumerable<ApiTypeNode> ExtractTypes(Assembly assembly)
+    {
+        Type[] types;
+        try
+        {
+            types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types.Where(t => t is not null).ToArray()!;
+        }
+
+        foreach (var type in types)
+        {
+            if (!type.IsPublic && !type.IsNestedPublic)
+                continue;
+
+            yield return ExtractType(type);
+        }
+    }
+
+    private static ApiTypeNode ExtractType(Type type)
+    {
+        var stableId = BuildTypeStableId(type);
+
+        var node = new ApiTypeNode
+        {
+            StableId = stableId,
+            FullName = FormatTypeName(type),
+            Name = type.Name,
+            Namespace = type.Namespace ?? string.Empty,
+            Kind = ClassifyType(type),
+            BaseType = type.BaseType is { } bt && bt.FullName != "System.Object"
+                ? FormatTypeName(bt)
+                : null,
+            Interfaces = type.GetInterfaces()
+                .Select(FormatTypeName)
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToList(),
+            GenericParameters = ExtractGenericParameters(type),
+            IsSealed = type.IsSealed && !type.IsValueType,
+            IsAbstract = type.IsAbstract && !type.IsInterface,
+            IsStatic = type.IsAbstract && type.IsSealed,
+            Members = ExtractMembers(type, stableId)
+                .OrderBy(m => m.StableId, StringComparer.Ordinal)
+                .ToList(),
+        };
+
+        return node;
+    }
+
+    private static string BuildTypeStableId(Type type)
+    {
+        // For nested types, include declaring type chain to ensure uniqueness.
+        if (type.DeclaringType is not null)
+        {
+            return $"{BuildTypeStableId(type.DeclaringType)}+{type.Name}";
+        }
+
+        var ns = type.Namespace ?? string.Empty;
+        var name = type.Name;
+
+        return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+    }
+
+    private static string FormatTypeName(Type type)
+    {
+        if (type.IsByRef)
+            return FormatTypeName(type.GetElementType()!) + "&";
+
+        if (type.IsArray)
+        {
+            var rank = type.GetArrayRank();
+            var suffix = rank == 1 ? "[]" : "[" + new string(',', rank - 1) + "]";
+            return FormatTypeName(type.GetElementType()!) + suffix;
+        }
+
+        if (type.IsPointer)
+            return FormatTypeName(type.GetElementType()!) + "*";
+
+        if (type.IsGenericParameter)
+            return type.Name;
+
+        if (type.IsGenericType)
+        {
+            var def = type.GetGenericTypeDefinition();
+            var baseName = (def.FullName ?? def.Name).Split('`')[0];
+            var args = type.GetGenericArguments().Select(FormatTypeName);
+            return $"{baseName}<{string.Join(", ", args)}>";
+        }
+
+        return type.FullName ?? type.Name;
+    }
+
+    private static ApiTypeKind ClassifyType(Type type)
+    {
+        if (type.IsEnum) return ApiTypeKind.Enum;
+        if (type.IsInterface) return ApiTypeKind.Interface;
+
+        if (type.BaseType?.FullName == "System.MulticastDelegate")
+            return ApiTypeKind.Delegate;
+
+        if (type.IsValueType) return ApiTypeKind.Struct;
+
+        return ApiTypeKind.Class;
+    }
+
+    private static List<GenericParameterInfo> ExtractGenericParameters(Type type)
+    {
+        if (!type.IsGenericTypeDefinition)
+            return [];
+
+        return type.GetGenericArguments()
+            .Select(g => new GenericParameterInfo
+            {
+                Name = g.Name,
+                Constraints = g.GetGenericParameterConstraints()
+                    .Select(FormatTypeName)
+                    .OrderBy(c => c, StringComparer.Ordinal)
+                    .ToList(),
+            })
+            .ToList();
+    }
+
+    private static List<GenericParameterInfo> ExtractGenericParameters(MethodInfo method)
+    {
+        if (!method.IsGenericMethodDefinition)
+            return [];
+
+        return method.GetGenericArguments()
+            .Select(g => new GenericParameterInfo
+            {
+                Name = g.Name,
+                Constraints = g.GetGenericParameterConstraints()
+                    .Select(FormatTypeName)
+                    .OrderBy(c => c, StringComparer.Ordinal)
+                    .ToList(),
+            })
+            .ToList();
+    }
+
+    private static IEnumerable<ApiMemberNode> ExtractMembers(Type type, string typeStableId)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance |
+                                   BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+        // Constructors
+        foreach (var ctor in type.GetConstructors(flags))
+        {
+            var paramSig = BuildParameterSignature(ctor.GetParameters());
+            yield return new ApiMemberNode
+            {
+                StableId = $"{typeStableId}..ctor({paramSig})",
+                Name = ".ctor",
+                Kind = ApiMemberKind.Constructor,
+                IsStatic = ctor.IsStatic,
+                Parameters = ExtractParameters(ctor.GetParameters()),
+            };
+        }
+
+        // Methods (excluding property accessors, event accessors, operator overloads handled separately)
+        foreach (var method in type.GetMethods(flags))
+        {
+            if (method.IsSpecialName)
+            {
+                // Handle operators
+                if (method.Name.StartsWith("op_", StringComparison.Ordinal))
+                {
+                    var paramSig = BuildParameterSignature(method.GetParameters());
+                    yield return new ApiMemberNode
+                    {
+                        StableId = $"{typeStableId}.{method.Name}({paramSig})",
+                        Name = method.Name,
+                        Kind = ApiMemberKind.Operator,
+                        ReturnType = FormatTypeName(method.ReturnType),
+                        IsStatic = method.IsStatic,
+                        IsVirtual = method.IsVirtual && !method.IsFinal,
+                        IsAbstract = method.IsAbstract,
+                        Parameters = ExtractParameters(method.GetParameters()),
+                        GenericParameters = ExtractGenericParameters(method),
+                    };
+                }
+
+                continue;
+            }
+
+            var mParamSig = BuildParameterSignature(method.GetParameters());
+            var genericSuffix = method.IsGenericMethodDefinition
+                ? $"`{method.GetGenericArguments().Length}"
+                : string.Empty;
+
+            yield return new ApiMemberNode
+            {
+                StableId = $"{typeStableId}.{method.Name}{genericSuffix}({mParamSig})",
+                Name = method.Name,
+                Kind = ApiMemberKind.Method,
+                ReturnType = FormatTypeName(method.ReturnType),
+                IsStatic = method.IsStatic,
+                IsVirtual = method.IsVirtual && !method.IsFinal,
+                IsAbstract = method.IsAbstract,
+                Parameters = ExtractParameters(method.GetParameters()),
+                GenericParameters = ExtractGenericParameters(method),
+            };
+        }
+
+        // Properties
+        foreach (var prop in type.GetProperties(flags))
+        {
+            var indexParams = prop.GetIndexParameters();
+            var kind = indexParams.Length > 0 ? ApiMemberKind.Indexer : ApiMemberKind.Property;
+            var paramSig = indexParams.Length > 0
+                ? BuildParameterSignature(indexParams)
+                : string.Empty;
+
+            var getter = prop.GetGetMethod();
+            var setter = prop.GetSetMethod();
+
+            yield return new ApiMemberNode
+            {
+                StableId = kind == ApiMemberKind.Indexer
+                    ? $"{typeStableId}.Item[{paramSig}]"
+                    : $"{typeStableId}.{prop.Name}",
+                Name = prop.Name,
+                Kind = kind,
+                ReturnType = FormatTypeName(prop.PropertyType),
+                IsStatic = (getter?.IsStatic ?? setter?.IsStatic) == true,
+                IsVirtual = (getter?.IsVirtual ?? setter?.IsVirtual) == true,
+                IsAbstract = (getter?.IsAbstract ?? setter?.IsAbstract) == true,
+                HasGetter = getter is not null,
+                HasSetter = setter is not null,
+                Parameters = kind == ApiMemberKind.Indexer
+                    ? ExtractParameters(indexParams)
+                    : [],
+            };
+        }
+
+        // Fields
+        foreach (var field in type.GetFields(flags))
+        {
+            yield return new ApiMemberNode
+            {
+                StableId = $"{typeStableId}.{field.Name}",
+                Name = field.Name,
+                Kind = ApiMemberKind.Field,
+                ReturnType = FormatTypeName(field.FieldType),
+                IsStatic = field.IsStatic,
+            };
+        }
+
+        // Events
+        foreach (var evt in type.GetEvents(flags))
+        {
+            yield return new ApiMemberNode
+            {
+                StableId = $"{typeStableId}.{evt.Name}",
+                Name = evt.Name,
+                Kind = ApiMemberKind.Event,
+                ReturnType = evt.EventHandlerType is { } eht ? FormatTypeName(eht) : null,
+                IsStatic = evt.AddMethod?.IsStatic == true,
+            };
+        }
+    }
+
+    private static string BuildParameterSignature(ParameterInfo[] parameters)
+    {
+        return string.Join(", ", parameters.Select(p => FormatTypeName(p.ParameterType)));
+    }
+
+    private static List<ApiParameterInfo> ExtractParameters(ParameterInfo[] parameters)
+    {
+        return parameters.Select(p => new ApiParameterInfo
+        {
+            Name = p.Name ?? string.Empty,
+            Type = FormatTypeName(p.ParameterType),
+            IsOptional = p.IsOptional,
+            IsParams = p.CustomAttributes.Any(a =>
+                a.AttributeType.FullName == "System.ParamArrayAttribute"),
+            IsOut = p.IsOut,
+            IsRef = p.ParameterType.IsByRef && !p.IsOut,
+            DefaultValue = p.HasDefaultValue
+                ? p.RawDefaultValue?.ToString()
+                : null,
+        }).ToList();
+    }
+}

--- a/WrapGod.Extractor/WrapGod.Extractor.csproj
+++ b/WrapGod.Extractor/WrapGod.Extractor.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\WrapGod.Manifest\WrapGod.Manifest.csproj" />
     <ProjectReference Include="..\WrapGod.Abstractions\WrapGod.Abstractions.csproj" />
   </ItemGroup>

--- a/WrapGod.Manifest/ManifestSerializer.cs
+++ b/WrapGod.Manifest/ManifestSerializer.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WrapGod.Manifest;
+
+/// <summary>
+/// JSON serialization helpers for <see cref="ApiManifest"/>.
+/// Uses camelCase naming, enum-as-string, and deterministic formatting.
+/// </summary>
+public static class ManifestSerializer
+{
+    private static readonly JsonSerializerOptions Options = CreateOptions();
+
+    /// <summary>Serializes a manifest to a JSON string.</summary>
+    public static string Serialize(ApiManifest manifest)
+    {
+        return JsonSerializer.Serialize(manifest, Options);
+    }
+
+    /// <summary>Deserializes a manifest from a JSON string.</summary>
+    public static ApiManifest? Deserialize(string json)
+    {
+        return JsonSerializer.Deserialize<ApiManifest>(json, Options);
+    }
+
+    /// <summary>Returns the shared serializer options.</summary>
+    public static JsonSerializerOptions GetOptions() => Options;
+
+    private static JsonSerializerOptions CreateOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        return options;
+    }
+}

--- a/WrapGod.Manifest/WrapGod.Manifest.csproj
+++ b/WrapGod.Manifest/WrapGod.Manifest.csproj
@@ -2,6 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="9.0.4" />
+  </ItemGroup>
 
 </Project>

--- a/WrapGod.Tests/ExtractorTests.cs
+++ b/WrapGod.Tests/ExtractorTests.cs
@@ -1,0 +1,115 @@
+using WrapGod.Extractor;
+using WrapGod.Manifest;
+
+namespace WrapGod.Tests;
+
+public class ExtractorTests
+{
+    private static readonly string CoreLibPath = typeof(object).Assembly.Location;
+
+    [Fact]
+    public void Extract_CoreLib_ProducesNonEmptyManifest()
+    {
+        var manifest = AssemblyExtractor.Extract(CoreLibPath);
+
+        Assert.NotNull(manifest);
+        Assert.NotEmpty(manifest.Types);
+        Assert.NotNull(manifest.SourceHash);
+        Assert.NotEmpty(manifest.SourceHash);
+    }
+
+    [Fact]
+    public void Extract_CoreLib_AssemblyIdentityIsPopulated()
+    {
+        var manifest = AssemblyExtractor.Extract(CoreLibPath);
+
+        Assert.False(string.IsNullOrEmpty(manifest.Assembly.Name));
+        Assert.False(string.IsNullOrEmpty(manifest.Assembly.Version));
+    }
+
+    [Fact]
+    public void Extract_CoreLib_TypesHaveStableIds()
+    {
+        var manifest = AssemblyExtractor.Extract(CoreLibPath);
+
+        foreach (var type in manifest.Types)
+        {
+            Assert.False(string.IsNullOrEmpty(type.StableId),
+                $"Type {type.FullName} has no stable ID.");
+        }
+    }
+
+    [Fact]
+    public void Extract_CoreLib_MembersHaveStableIds()
+    {
+        var manifest = AssemblyExtractor.Extract(CoreLibPath);
+
+        var members = manifest.Types.SelectMany(t => t.Members).Take(200).ToList();
+        Assert.NotEmpty(members);
+
+        foreach (var member in members)
+        {
+            Assert.False(string.IsNullOrEmpty(member.StableId),
+                $"Member {member.Name} has no stable ID.");
+        }
+    }
+
+    [Fact]
+    public void Extract_IsDeterministic()
+    {
+        var manifest1 = AssemblyExtractor.Extract(CoreLibPath);
+        var manifest2 = AssemblyExtractor.Extract(CoreLibPath);
+
+        var json1 = ManifestSerializer.Serialize(manifest1);
+        var json2 = ManifestSerializer.Serialize(manifest2);
+
+        // The only non-deterministic field is GeneratedAt; normalize it for comparison.
+        // Instead, compare the structural content: types, members, hash.
+        Assert.Equal(manifest1.SourceHash, manifest2.SourceHash);
+        Assert.Equal(manifest1.Types.Count, manifest2.Types.Count);
+
+        for (int i = 0; i < manifest1.Types.Count; i++)
+        {
+            Assert.Equal(manifest1.Types[i].StableId, manifest2.Types[i].StableId);
+            Assert.Equal(manifest1.Types[i].Members.Count, manifest2.Types[i].Members.Count);
+
+            for (int j = 0; j < manifest1.Types[i].Members.Count; j++)
+            {
+                Assert.Equal(
+                    manifest1.Types[i].Members[j].StableId,
+                    manifest2.Types[i].Members[j].StableId);
+            }
+        }
+    }
+
+    [Fact]
+    public void Extract_CoreLib_TypeIdsAreUnique()
+    {
+        var manifest = AssemblyExtractor.Extract(CoreLibPath);
+
+        var ids = manifest.Types.Select(t => t.StableId).ToList();
+        var uniqueIds = ids.Distinct().ToList();
+
+        Assert.Equal(ids.Count, uniqueIds.Count);
+    }
+
+    [Fact]
+    public void Extract_MissingAssembly_ThrowsFileNotFoundException()
+    {
+        Assert.Throws<FileNotFoundException>(
+            () => AssemblyExtractor.Extract("/nonexistent/path/fake.dll"));
+    }
+
+    [Fact]
+    public void ManifestSerializer_RoundTrips()
+    {
+        var manifest = AssemblyExtractor.Extract(CoreLibPath);
+
+        var json = ManifestSerializer.Serialize(manifest);
+        var deserialized = ManifestSerializer.Deserialize(json);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(manifest.Types.Count, deserialized.Types.Count);
+        Assert.Equal(manifest.Assembly.Name, deserialized.Assembly.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- **AssemblyExtractor**: Reads .NET assembly DLLs via `System.Reflection.MetadataLoadContext` and produces a fully-populated `ApiManifest` with deterministic sorting, stable IDs, SHA-256 file hashing, and support for generics, by-ref, arrays, optional params, nested types, operators, and indexers
- **ManifestSerializer**: JSON serialization/deserialization for `ApiManifest` using `System.Text.Json` with camelCase naming, enum-as-string, and null suppression
- **ExtractorTests**: 8 xUnit tests covering non-empty extraction, identity population, stable IDs on types/members, determinism, type ID uniqueness, missing file error, and serializer round-tripping

## Changes
- `WrapGod.Extractor/AssemblyExtractor.cs` — new static extractor class
- `WrapGod.Extractor/WrapGod.Extractor.csproj` — added `System.Reflection.MetadataLoadContext` package reference
- `WrapGod.Manifest/ManifestSerializer.cs` — new static serializer class
- `WrapGod.Manifest/WrapGod.Manifest.csproj` — added `System.Text.Json` package reference and `LangVersion` for netstandard2.0
- `WrapGod.Tests/ExtractorTests.cs` — new test class

## Test plan
- [x] `dotnet build WrapGod.slnx` passes with 0 errors
- [x] `dotnet test WrapGod.Tests/WrapGod.Tests.csproj` passes all 11 tests (3 existing + 8 new)
- [ ] CI pipeline passes on push

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)