### PR TITLE
fix: CI — suppress CA1707 for test names, seal test fixture

### DIFF
--- a/WrapGod.Tests/ConfigIngestionTests.cs
+++ b/WrapGod.Tests/ConfigIngestionTests.cs
@@ -87,7 +87,7 @@ public class ConfigIngestionTests
     }
 
     [WrapType("Vendor.Client", TargetName = "IClient")]
-    private class AttributedWrapper
+    private sealed class AttributedWrapper
     {
         [WrapMember("GetUser", TargetName = "FetchUser")]
         public string GetUser(string id) => id;

--- a/WrapGod.Tests/WrapGod.Tests.csproj
+++ b/WrapGod.Tests/WrapGod.Tests.csproj
@@ -7,6 +7,8 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- Allow underscores in test method names (xUnit convention) -->
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Fix CI build failures across all recent PRs (#19, #20, #21, #22).

- Suppress CA1707 in test project (underscore method names are xUnit convention)
- Seal `AttributedWrapper` test class (CA1852)
- 40/40 tests pass in Release mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)