### PR TITLE
fix: rewrite TinyBDD tests to PatternKit style

### DIFF
--- a/WrapGod.Tests/ConfigIngestionTests.cs
+++ b/WrapGod.Tests/ConfigIngestionTests.cs
@@ -7,9 +7,9 @@ using Xunit.Abstractions;
 namespace WrapGod.Tests;
 
 [Feature("Configuration ingestion")]
-public partial class ConfigIngestionTests : TinyBddXunitBase
+public sealed class ConfigIngestionTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
-    public ConfigIngestionTests(ITestOutputHelper output) : base(output) { }
+    // ── Helpers ──────────────────────────────────────────────────────
 
     private static readonly string SampleJson = """
         {
@@ -59,66 +59,51 @@ public partial class ConfigIngestionTests : TinyBddXunitBase
         });
     }
 
-    [Scenario("JSON config loader parses type and member rules")]
-    [Fact]
-    public async Task JsonConfigLoaderParsesTypeAndMemberRules()
-    {
-        await Flow.Given("a JSON config string", LoadSampleJson)
-            .Then("one type rule is parsed", config => Assert.Single(config.Types))
-            .And("the source type is correct", config =>
-                Assert.Equal("Vendor.Client", config.Types[0].SourceType))
-            .And("one member rule is parsed with correct source", config =>
-            {
-                Assert.Single(config.Types[0].Members);
-                Assert.Equal("GetUser", config.Types[0].Members[0].SourceMember);
-            })
-            .AssertPassed();
-    }
-
-    [Scenario("Attribute config reader builds type and member rules")]
-    [Fact]
-    public async Task AttributeConfigReaderBuildsTypeAndMemberRules()
-    {
-        await Flow.Given("an assembly with WrapType and WrapMember attributes", ReadAttributeConfig)
-            .Then("the Vendor.Client type rule has target name IClient", config =>
-            {
-                var type = Assert.Single(config.Types, t => t.SourceType == "Vendor.Client");
-                Assert.Equal("IClient", type.TargetName);
-            })
-            .And("the GetUser member rule has target name FetchUser", config =>
-            {
-                var type = Assert.Single(config.Types, t => t.SourceType == "Vendor.Client");
-                var member = Assert.Single(type.Members, m => m.SourceMember == "GetUser");
-                Assert.Equal("FetchUser", member.TargetName);
-            })
-            .AssertPassed();
-    }
-
-    [Scenario("Merge engine uses configured precedence and emits diagnostics on conflict")]
-    [Fact]
-    public async Task MergeEngineUsesConfiguredPrecedenceAndEmitsDiagnosticsOnConflict()
-    {
-        await Flow.Given("conflicting JSON and attribute configs", MergeWithAttributePrecedence)
-            .Then("attribute config wins for type-level settings", mergeResult =>
-            {
-                var type = Assert.Single(mergeResult.Config.Types);
-                Assert.False(type.Include);
-                Assert.Equal("AttrClient", type.TargetName);
-            })
-            .And("attribute config wins for member-level settings", mergeResult =>
-            {
-                var type = Assert.Single(mergeResult.Config.Types);
-                Assert.Equal("AttrGetUser", Assert.Single(type.Members).TargetName);
-            })
-            .And("diagnostics are emitted for the conflict", mergeResult =>
-                Assert.NotEmpty(mergeResult.Diagnostics))
-            .AssertPassed();
-    }
-
     [WrapType("Vendor.Client", TargetName = "IClient")]
     private sealed class AttributedWrapper
     {
         [WrapMember("GetUser", TargetName = "FetchUser")]
         public static string GetUser(string id) => id;
     }
+
+    // ── Scenarios ────────────────────────────────────────────────────
+
+    [Scenario("JSON config loader parses type and member rules")]
+    [Fact]
+    public Task JsonConfigLoaderParsesTypeAndMemberRules()
+        => Given("a JSON config string", LoadSampleJson)
+            .Then("one type rule is parsed", config => config.Types.Count == 1)
+            .And("the source type is correct", config =>
+                config.Types[0].SourceType == "Vendor.Client")
+            .And("one member rule is parsed", config =>
+                config.Types[0].Members.Count == 1)
+            .And("the member source is correct", config =>
+                config.Types[0].Members[0].SourceMember == "GetUser")
+            .AssertPassed();
+
+    [Scenario("Attribute config reader builds type and member rules")]
+    [Fact]
+    public Task AttributeConfigReaderBuildsTypeAndMemberRules()
+        => Given("an assembly with WrapType and WrapMember attributes", ReadAttributeConfig)
+            .Then("the Vendor.Client type rule has target name IClient", config =>
+                config.Types.Single(t => t.SourceType == "Vendor.Client").TargetName == "IClient")
+            .And("the GetUser member rule has target name FetchUser", config =>
+                config.Types.Single(t => t.SourceType == "Vendor.Client")
+                    .Members.Single(m => m.SourceMember == "GetUser").TargetName == "FetchUser")
+            .AssertPassed();
+
+    [Scenario("Merge engine uses configured precedence and emits diagnostics on conflict")]
+    [Fact]
+    public Task MergeEngineUsesConfiguredPrecedenceAndEmitsDiagnosticsOnConflict()
+        => Given("conflicting JSON and attribute configs", MergeWithAttributePrecedence)
+            .Then("attribute config wins for type include", mergeResult =>
+                mergeResult.Config.Types.Count == 1 && mergeResult.Config.Types[0].Include == false)
+            .And("attribute config wins for type target name", mergeResult =>
+                mergeResult.Config.Types[0].TargetName == "AttrClient")
+            .And("attribute config wins for member target name", mergeResult =>
+                mergeResult.Config.Types[0].Members.Count == 1
+                && mergeResult.Config.Types[0].Members[0].TargetName == "AttrGetUser")
+            .And("diagnostics are emitted for the conflict", mergeResult =>
+                mergeResult.Diagnostics.Count > 0)
+            .AssertPassed();
 }

--- a/WrapGod.Tests/ExtractorTests.cs
+++ b/WrapGod.Tests/ExtractorTests.cs
@@ -7,11 +7,11 @@ using Xunit.Abstractions;
 namespace WrapGod.Tests;
 
 [Feature("Assembly extraction")]
-public partial class ExtractorTests : TinyBddXunitBase
+public sealed class ExtractorTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
-    private static readonly string CoreLibPath = typeof(object).Assembly.Location;
+    // ── Helpers ──────────────────────────────────────────────────────
 
-    public ExtractorTests(ITestOutputHelper output) : base(output) { }
+    private static readonly string CoreLibPath = typeof(object).Assembly.Location;
 
     private static ApiManifest ExtractCoreLib() => AssemblyExtractor.Extract(CoreLibPath);
 
@@ -29,131 +29,94 @@ public partial class ExtractorTests : TinyBddXunitBase
 
     private static DeterminismPair ExtractTwice() => new(ExtractCoreLib(), ExtractCoreLib());
 
+    // ── Scenarios ────────────────────────────────────────────────────
+
     [Scenario("Extracting CoreLib produces a non-empty manifest")]
     [Fact]
-    public async Task Extract_CoreLib_ProducesNonEmptyManifest()
-    {
-        await Flow.Given("a CoreLib assembly path", ExtractCoreLib)
-            .Then("the manifest is not null", manifest => Assert.NotNull(manifest))
-            .And("the manifest contains types", manifest => Assert.NotEmpty(manifest.Types))
+    public Task Extract_CoreLib_ProducesNonEmptyManifest()
+        => Given("a CoreLib assembly path", ExtractCoreLib)
+            .Then("the manifest is not null", manifest => manifest is not null)
+            .And("the manifest contains types", manifest => manifest.Types.Count > 0)
             .And("the source hash is populated", manifest =>
-            {
-                Assert.NotNull(manifest.SourceHash);
-                Assert.NotEmpty(manifest.SourceHash);
-            })
+                !string.IsNullOrEmpty(manifest.SourceHash))
             .AssertPassed();
-    }
 
     [Scenario("Extracting CoreLib populates assembly identity")]
     [Fact]
-    public async Task Extract_CoreLib_AssemblyIdentityIsPopulated()
-    {
-        await Flow.Given("a CoreLib manifest", ExtractCoreLib)
+    public Task Extract_CoreLib_AssemblyIdentityIsPopulated()
+        => Given("a CoreLib manifest", ExtractCoreLib)
             .Then("assembly name is populated", manifest =>
-                Assert.False(string.IsNullOrEmpty(manifest.Assembly.Name)))
+                !string.IsNullOrEmpty(manifest.Assembly.Name))
             .And("assembly version is populated", manifest =>
-                Assert.False(string.IsNullOrEmpty(manifest.Assembly.Version)))
+                !string.IsNullOrEmpty(manifest.Assembly.Version))
             .AssertPassed();
-    }
 
     [Scenario("Extracted types have stable IDs")]
     [Fact]
-    public async Task Extract_CoreLib_TypesHaveStableIds()
-    {
-        await Flow.Given("a CoreLib manifest", ExtractCoreLib)
+    public Task Extract_CoreLib_TypesHaveStableIds()
+        => Given("a CoreLib manifest", ExtractCoreLib)
             .Then("every type has a stable ID", manifest =>
-            {
-                foreach (var type in manifest.Types)
-                {
-                    Assert.False(string.IsNullOrEmpty(type.StableId),
-                        $"Type {type.FullName} has no stable ID.");
-                }
-            })
+                manifest.Types.All(t => !string.IsNullOrEmpty(t.StableId)))
             .AssertPassed();
-    }
 
     [Scenario("Extracted members have stable IDs")]
     [Fact]
-    public async Task Extract_CoreLib_MembersHaveStableIds()
-    {
-        await Flow.Given("a CoreLib manifest", ExtractCoreLib)
-            .Then("every member has a stable ID", manifest =>
-            {
-                var members = manifest.Types.SelectMany(t => t.Members).Take(200).ToList();
-                Assert.NotEmpty(members);
-
-                foreach (var member in members)
-                {
-                    Assert.False(string.IsNullOrEmpty(member.StableId),
-                        $"Member {member.Name} has no stable ID.");
-                }
-            })
+    public Task Extract_CoreLib_MembersHaveStableIds()
+        => Given("a CoreLib manifest", ExtractCoreLib)
+            .Then("sampled members all have a stable ID", manifest =>
+                manifest.Types
+                    .SelectMany(t => t.Members)
+                    .Take(200)
+                    .All(m => !string.IsNullOrEmpty(m.StableId)))
             .AssertPassed();
-    }
 
     [Scenario("Extraction is deterministic across runs")]
     [Fact]
-    public async Task Extract_IsDeterministic()
-    {
-        await Flow.Given("two extractions of the same assembly", ExtractTwice)
+    public Task Extract_IsDeterministic()
+        => Given("two extractions of the same assembly", ExtractTwice)
             .Then("source hashes match", pair =>
-                Assert.Equal(pair.First.SourceHash, pair.Second.SourceHash))
+                pair.First.SourceHash == pair.Second.SourceHash)
             .And("type counts match", pair =>
-                Assert.Equal(pair.First.Types.Count, pair.Second.Types.Count))
-            .And("all type stable IDs and member stable IDs match", pair =>
-            {
-                for (int i = 0; i < pair.First.Types.Count; i++)
-                {
-                    Assert.Equal(pair.First.Types[i].StableId, pair.Second.Types[i].StableId);
-                    Assert.Equal(pair.First.Types[i].Members.Count, pair.Second.Types[i].Members.Count);
-
-                    for (int j = 0; j < pair.First.Types[i].Members.Count; j++)
-                    {
-                        Assert.Equal(
-                            pair.First.Types[i].Members[j].StableId,
-                            pair.Second.Types[i].Members[j].StableId);
-                    }
-                }
-            })
+                pair.First.Types.Count == pair.Second.Types.Count)
+            .And("all type stable IDs match", pair =>
+                pair.First.Types.Zip(pair.Second.Types)
+                    .All(p => p.First.StableId == p.Second.StableId))
+            .And("all member counts match per type", pair =>
+                pair.First.Types.Zip(pair.Second.Types)
+                    .All(p => p.First.Members.Count == p.Second.Members.Count))
+            .And("all member stable IDs match", pair =>
+                pair.First.Types.Zip(pair.Second.Types)
+                    .All(p => p.First.Members.Zip(p.Second.Members)
+                        .All(m => m.First.StableId == m.Second.StableId)))
             .AssertPassed();
-    }
 
     [Scenario("Type IDs are unique within an assembly")]
     [Fact]
-    public async Task Extract_CoreLib_TypeIdsAreUnique()
-    {
-        await Flow.Given("a CoreLib manifest", ExtractCoreLib)
+    public Task Extract_CoreLib_TypeIdsAreUnique()
+        => Given("a CoreLib manifest", ExtractCoreLib)
             .Then("all type stable IDs are unique", manifest =>
-            {
-                var ids = manifest.Types.Select(t => t.StableId).ToList();
-                var uniqueIds = ids.Distinct().ToList();
-                Assert.Equal(ids.Count, uniqueIds.Count);
-            })
+                manifest.Types.Select(t => t.StableId).Distinct().Count() == manifest.Types.Count)
             .AssertPassed();
-    }
 
     [Scenario("Missing assembly throws FileNotFoundException")]
     [Fact]
-    public async Task Extract_MissingAssembly_ThrowsFileNotFoundException()
-    {
-        await Flow.Given("a non-existent assembly path", () => "/nonexistent/path/fake.dll")
+    public Task Extract_MissingAssembly_ThrowsFileNotFoundException()
+        => Given("a non-existent assembly path", () => "/nonexistent/path/fake.dll")
             .Then("extraction throws FileNotFoundException", path =>
-                Assert.Throws<FileNotFoundException>(
-                    () => AssemblyExtractor.Extract(path)))
+            {
+                try { AssemblyExtractor.Extract(path); return false; }
+                catch (FileNotFoundException) { return true; }
+            })
             .AssertPassed();
-    }
 
     [Scenario("ManifestSerializer round-trips correctly")]
     [Fact]
-    public async Task ManifestSerializer_RoundTrips()
-    {
-        await Flow.Given("a serialized and deserialized CoreLib manifest", RoundTripSerialize)
-            .Then("deserialized manifest is not null", pair =>
-                Assert.NotNull(pair.Deserialized))
+    public Task ManifestSerializer_RoundTrips()
+        => Given("a serialized and deserialized CoreLib manifest", RoundTripSerialize)
+            .Then("deserialized manifest is not null", pair => pair.Deserialized is not null)
             .And("type counts match", pair =>
-                Assert.Equal(pair.Original.Types.Count, pair.Deserialized.Types.Count))
+                pair.Original.Types.Count == pair.Deserialized.Types.Count)
             .And("assembly names match", pair =>
-                Assert.Equal(pair.Original.Assembly.Name, pair.Deserialized.Assembly.Name))
+                pair.Original.Assembly.Name == pair.Deserialized.Assembly.Name)
             .AssertPassed();
-    }
 }

--- a/WrapGod.Tests/FluentDslTests.cs
+++ b/WrapGod.Tests/FluentDslTests.cs
@@ -6,238 +6,237 @@ using Xunit.Abstractions;
 namespace WrapGod.Tests;
 
 [Feature("Fluent DSL configuration")]
-public partial class FluentDslTests : TinyBddXunitBase
+public sealed class FluentDslTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
-    public FluentDslTests(ITestOutputHelper output) : base(output) { }
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static GenerationPlan BuildFullPlan() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("Vendor.Lib")
+            .WrapType("Vendor.Lib.HttpClient")
+                .As("IHttpClient")
+                .WrapMethod("SendAsync").As("SendRequestAsync")
+                .WrapProperty("Timeout")
+                .ExcludeMember("Dispose")
+            .WrapType("Vendor.Lib.Logger")
+                .As("ILogger")
+                .WrapAllPublicMembers()
+            .MapType("Vendor.Lib.Config", "MyApp.Config")
+            .ExcludeType("Vendor.Lib.Internal*")
+            .Build();
+
+    private static GenerationPlan BuildSingleWrappedType() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("TestLib")
+            .WrapType("TestLib.Foo")
+                .As("IFoo")
+            .Build();
+
+    private static GenerationPlan BuildRenamedMethod() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("TestLib")
+            .WrapType("TestLib.Svc")
+                .WrapMethod("DoWork").As("Execute")
+            .Build();
+
+    private static GenerationPlan BuildWrappedProperty() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("TestLib")
+            .WrapType("TestLib.Svc")
+                .WrapProperty("Timeout")
+            .Build();
+
+    private static GenerationPlan BuildExcludedMembers() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("TestLib")
+            .WrapType("TestLib.Svc")
+                .ExcludeMember("Dispose")
+                .ExcludeMember("Finalize")
+            .Build();
+
+    private static GenerationPlan BuildWrapAllPublic() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("TestLib")
+            .WrapType("TestLib.Logger")
+                .WrapAllPublicMembers()
+            .Build();
+
+    private static GenerationPlan BuildTwoTypeMappings() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("TestLib")
+            .MapType("TestLib.Config", "MyApp.Config")
+            .MapType("TestLib.Options", "MyApp.Options")
+            .Build();
+
+    private static GenerationPlan BuildTwoExclusionPatterns() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("TestLib")
+            .ExcludeType("TestLib.Internal*")
+            .ExcludeType("TestLib.Debug*")
+            .Build();
+
+    private static GenerationPlan BuildStrictCompatibility() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("TestLib")
+            .WithCompatibilityMode("strict")
+            .Build();
+
+    private static GenerationPlan BuildDefaultCompatibility() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("TestLib")
+            .Build();
+
+    private static GenerationPlan BuildMixedConfig() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("Vendor.Lib")
+            .WrapType("Vendor.Lib.HttpClient")
+                .As("IHttpClient")
+                .WrapMethod("SendAsync").As("SendRequestAsync")
+                .WrapProperty("Timeout")
+                .ExcludeMember("Dispose")
+            .WrapType("Vendor.Lib.Logger")
+                .As("ILogger")
+                .WrapAllPublicMembers()
+            .Build();
+
+    // ── Scenarios ────────────────────────────────────────────────────
 
     [Scenario("Full fluent configuration produces a valid generation plan")]
     [Fact]
-    public async Task Build_ProducesValidGenerationPlan()
-    {
-        await Flow.Given("a fully configured fluent plan", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("Vendor.Lib")
-                    .WrapType("Vendor.Lib.HttpClient")
-                        .As("IHttpClient")
-                        .WrapMethod("SendAsync").As("SendRequestAsync")
-                        .WrapProperty("Timeout")
-                        .ExcludeMember("Dispose")
-                    .WrapType("Vendor.Lib.Logger")
-                        .As("ILogger")
-                        .WrapAllPublicMembers()
-                    .MapType("Vendor.Lib.Config", "MyApp.Config")
-                    .ExcludeType("Vendor.Lib.Internal*")
-                    .Build())
-            .Then("the plan is not null", plan => Assert.NotNull(plan))
-            .And("the assembly name is correct", plan => Assert.Equal("Vendor.Lib", plan.AssemblyName))
-            .And("there are two type directives", plan => Assert.Equal(2, plan.TypeDirectives.Count))
-            .And("there is one type mapping", plan => Assert.Single(plan.TypeMappings))
-            .And("there is one exclusion pattern", plan => Assert.Single(plan.ExclusionPatterns))
+    public Task Build_ProducesValidGenerationPlan()
+        => Given("a fully configured fluent plan", BuildFullPlan)
+            .Then("the plan is not null", plan => plan is not null)
+            .And("the assembly name is correct", plan => plan.AssemblyName == "Vendor.Lib")
+            .And("there are two type directives", plan => plan.TypeDirectives.Count == 2)
+            .And("there is one type mapping", plan => plan.TypeMappings.Count == 1)
+            .And("there is one exclusion pattern", plan => plan.ExclusionPatterns.Count == 1)
             .AssertPassed();
-    }
 
     [Scenario("Type directives record source and target names")]
     [Fact]
-    public async Task TypeDirectives_RecordSourceAndTargetNames()
-    {
-        await Flow.Given("a plan with a single wrapped type", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("TestLib")
-                    .WrapType("TestLib.Foo")
-                        .As("IFoo")
-                    .Build())
-            .Then("the directive records the source type", plan =>
-            {
-                var directive = Assert.Single(plan.TypeDirectives);
-                Assert.Equal("TestLib.Foo", directive.SourceType);
-                Assert.Equal("IFoo", directive.TargetName);
-            })
+    public Task TypeDirectives_RecordSourceAndTargetNames()
+        => Given("a plan with a single wrapped type", BuildSingleWrappedType)
+            .Then("there is exactly one directive", plan => plan.TypeDirectives.Count == 1)
+            .And("the directive records the source type", plan =>
+                plan.TypeDirectives[0].SourceType == "TestLib.Foo")
+            .And("the directive records the target name", plan =>
+                plan.TypeDirectives[0].TargetName == "IFoo")
             .AssertPassed();
-    }
 
     [Scenario("Method wrapping records rename")]
     [Fact]
-    public async Task MethodWrapping_RecordedWithRename()
-    {
-        await Flow.Given("a plan with a renamed method", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("TestLib")
-                    .WrapType("TestLib.Svc")
-                        .WrapMethod("DoWork").As("Execute")
-                    .Build())
-            .Then("the member directive records source, target, and kind", plan =>
-            {
-                var directive = Assert.Single(plan.TypeDirectives);
-                var member = Assert.Single(directive.MemberDirectives);
-                Assert.Equal("DoWork", member.SourceName);
-                Assert.Equal("Execute", member.TargetName);
-                Assert.Equal(MemberDirectiveKind.Method, member.Kind);
-            })
+    public Task MethodWrapping_RecordedWithRename()
+        => Given("a plan with a renamed method", BuildRenamedMethod)
+            .Then("there is exactly one type directive", plan => plan.TypeDirectives.Count == 1)
+            .And("there is exactly one member directive", plan =>
+                plan.TypeDirectives[0].MemberDirectives.Count == 1)
+            .And("the member source name is correct", plan =>
+                plan.TypeDirectives[0].MemberDirectives[0].SourceName == "DoWork")
+            .And("the member target name is correct", plan =>
+                plan.TypeDirectives[0].MemberDirectives[0].TargetName == "Execute")
+            .And("the member kind is Method", plan =>
+                plan.TypeDirectives[0].MemberDirectives[0].Kind == MemberDirectiveKind.Method)
             .AssertPassed();
-    }
 
     [Scenario("Property wrapping is recorded")]
     [Fact]
-    public async Task PropertyWrapping_Recorded()
-    {
-        await Flow.Given("a plan with a wrapped property", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("TestLib")
-                    .WrapType("TestLib.Svc")
-                        .WrapProperty("Timeout")
-                    .Build())
-            .Then("the member directive records source name and property kind", plan =>
-            {
-                var directive = Assert.Single(plan.TypeDirectives);
-                var member = Assert.Single(directive.MemberDirectives);
-                Assert.Equal("Timeout", member.SourceName);
-                Assert.Null(member.TargetName);
-                Assert.Equal(MemberDirectiveKind.Property, member.Kind);
-            })
+    public Task PropertyWrapping_Recorded()
+        => Given("a plan with a wrapped property", BuildWrappedProperty)
+            .Then("there is exactly one member directive", plan =>
+                plan.TypeDirectives.Count == 1 && plan.TypeDirectives[0].MemberDirectives.Count == 1)
+            .And("the member source name is Timeout", plan =>
+                plan.TypeDirectives[0].MemberDirectives[0].SourceName == "Timeout")
+            .And("the member target name is null", plan =>
+                plan.TypeDirectives[0].MemberDirectives[0].TargetName is null)
+            .And("the member kind is Property", plan =>
+                plan.TypeDirectives[0].MemberDirectives[0].Kind == MemberDirectiveKind.Property)
             .AssertPassed();
-    }
 
     [Scenario("Excluded members are recorded")]
     [Fact]
-    public async Task ExcludeMember_Recorded()
-    {
-        await Flow.Given("a plan with excluded members", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("TestLib")
-                    .WrapType("TestLib.Svc")
-                        .ExcludeMember("Dispose")
-                        .ExcludeMember("Finalize")
-                    .Build())
+    public Task ExcludeMember_Recorded()
+        => Given("a plan with excluded members", BuildExcludedMembers)
             .Then("two members are excluded", plan =>
-            {
-                var directive = Assert.Single(plan.TypeDirectives);
-                Assert.Equal(2, directive.ExcludedMembers.Count);
-                Assert.Contains("Dispose", directive.ExcludedMembers);
-                Assert.Contains("Finalize", directive.ExcludedMembers);
-            })
+                plan.TypeDirectives.Count == 1 && plan.TypeDirectives[0].ExcludedMembers.Count == 2)
+            .And("Dispose is in the exclusion list", plan =>
+                plan.TypeDirectives[0].ExcludedMembers.Contains("Dispose"))
+            .And("Finalize is in the exclusion list", plan =>
+                plan.TypeDirectives[0].ExcludedMembers.Contains("Finalize"))
             .AssertPassed();
-    }
 
     [Scenario("WrapAllPublicMembers flag is set")]
     [Fact]
-    public async Task WrapAllPublicMembers_FlagSet()
-    {
-        await Flow.Given("a plan with WrapAllPublicMembers enabled", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("TestLib")
-                    .WrapType("TestLib.Logger")
-                        .WrapAllPublicMembers()
-                    .Build())
+    public Task WrapAllPublicMembers_FlagSet()
+        => Given("a plan with WrapAllPublicMembers enabled", BuildWrapAllPublic)
             .Then("the flag is true on the directive", plan =>
-            {
-                var directive = Assert.Single(plan.TypeDirectives);
-                Assert.True(directive.WrapAllPublicMembers);
-            })
+                plan.TypeDirectives.Count == 1 && plan.TypeDirectives[0].WrapAllPublicMembers)
             .AssertPassed();
-    }
 
     [Scenario("Type mappings are recorded")]
     [Fact]
-    public async Task TypeMappings_Recorded()
-    {
-        await Flow.Given("a plan with two type mappings", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("TestLib")
-                    .MapType("TestLib.Config", "MyApp.Config")
-                    .MapType("TestLib.Options", "MyApp.Options")
-                    .Build())
-            .Then("both mappings are recorded with correct source and destination", plan =>
-            {
-                Assert.Equal(2, plan.TypeMappings.Count);
-                Assert.Equal("TestLib.Config", plan.TypeMappings[0].SourceType);
-                Assert.Equal("MyApp.Config", plan.TypeMappings[0].DestinationType);
-                Assert.Equal("TestLib.Options", plan.TypeMappings[1].SourceType);
-                Assert.Equal("MyApp.Options", plan.TypeMappings[1].DestinationType);
-            })
+    public Task TypeMappings_Recorded()
+        => Given("a plan with two type mappings", BuildTwoTypeMappings)
+            .Then("two mappings are recorded", plan => plan.TypeMappings.Count == 2)
+            .And("first mapping source is correct", plan =>
+                plan.TypeMappings[0].SourceType == "TestLib.Config")
+            .And("first mapping destination is correct", plan =>
+                plan.TypeMappings[0].DestinationType == "MyApp.Config")
+            .And("second mapping source is correct", plan =>
+                plan.TypeMappings[1].SourceType == "TestLib.Options")
+            .And("second mapping destination is correct", plan =>
+                plan.TypeMappings[1].DestinationType == "MyApp.Options")
             .AssertPassed();
-    }
 
     [Scenario("Exclusion patterns are recorded")]
     [Fact]
-    public async Task ExclusionPatterns_Recorded()
-    {
-        await Flow.Given("a plan with two exclusion patterns", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("TestLib")
-                    .ExcludeType("TestLib.Internal*")
-                    .ExcludeType("TestLib.Debug*")
-                    .Build())
-            .Then("both patterns are recorded", plan =>
-            {
-                Assert.Equal(2, plan.ExclusionPatterns.Count);
-                Assert.Contains("TestLib.Internal*", plan.ExclusionPatterns);
-                Assert.Contains("TestLib.Debug*", plan.ExclusionPatterns);
-            })
+    public Task ExclusionPatterns_Recorded()
+        => Given("a plan with two exclusion patterns", BuildTwoExclusionPatterns)
+            .Then("two patterns are recorded", plan => plan.ExclusionPatterns.Count == 2)
+            .And("Internal pattern is present", plan =>
+                plan.ExclusionPatterns.Contains("TestLib.Internal*"))
+            .And("Debug pattern is present", plan =>
+                plan.ExclusionPatterns.Contains("TestLib.Debug*"))
             .AssertPassed();
-    }
 
     [Scenario("Compatibility mode is recorded")]
     [Fact]
-    public async Task CompatibilityMode_Recorded()
-    {
-        await Flow.Given("a plan with strict compatibility mode", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("TestLib")
-                    .WithCompatibilityMode("strict")
-                    .Build())
+    public Task CompatibilityMode_Recorded()
+        => Given("a plan with strict compatibility mode", BuildStrictCompatibility)
             .Then("the compatibility mode is strict", plan =>
-                Assert.Equal("strict", plan.CompatibilityMode))
+                plan.CompatibilityMode == "strict")
             .AssertPassed();
-    }
 
     [Scenario("Compatibility mode is null by default")]
     [Fact]
-    public async Task CompatibilityMode_NullByDefault()
-    {
-        await Flow.Given("a plan with no compatibility mode set", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("TestLib")
-                    .Build())
+    public Task CompatibilityMode_NullByDefault()
+        => Given("a plan with no compatibility mode set", BuildDefaultCompatibility)
             .Then("the compatibility mode is null", plan =>
-                Assert.Null(plan.CompatibilityMode))
+                plan.CompatibilityMode is null)
             .AssertPassed();
-    }
 
     [Scenario("Multiple types with mixed configuration")]
     [Fact]
-    public async Task MultipleTypes_WithMixedConfig()
-    {
-        await Flow.Given("a plan with two types having different configurations", () =>
-                WrapGodConfiguration.Create()
-                    .ForAssembly("Vendor.Lib")
-                    .WrapType("Vendor.Lib.HttpClient")
-                        .As("IHttpClient")
-                        .WrapMethod("SendAsync").As("SendRequestAsync")
-                        .WrapProperty("Timeout")
-                        .ExcludeMember("Dispose")
-                    .WrapType("Vendor.Lib.Logger")
-                        .As("ILogger")
-                        .WrapAllPublicMembers()
-                    .Build())
+    public Task MultipleTypes_WithMixedConfig()
+        => Given("a plan with two types having different configurations", BuildMixedConfig)
             .Then("there are two type directives", plan =>
-                Assert.Equal(2, plan.TypeDirectives.Count))
-            .And("the HTTP client directive is correct", plan =>
-            {
-                var http = plan.TypeDirectives[0];
-                Assert.Equal("Vendor.Lib.HttpClient", http.SourceType);
-                Assert.Equal("IHttpClient", http.TargetName);
-                Assert.Equal(2, http.MemberDirectives.Count);
-                Assert.Single(http.ExcludedMembers);
-                Assert.False(http.WrapAllPublicMembers);
-            })
-            .And("the Logger directive is correct", plan =>
-            {
-                var logger = plan.TypeDirectives[1];
-                Assert.Equal("Vendor.Lib.Logger", logger.SourceType);
-                Assert.Equal("ILogger", logger.TargetName);
-                Assert.True(logger.WrapAllPublicMembers);
-                Assert.Empty(logger.MemberDirectives);
-            })
+                plan.TypeDirectives.Count == 2)
+            .And("HTTP client source type is correct", plan =>
+                plan.TypeDirectives[0].SourceType == "Vendor.Lib.HttpClient")
+            .And("HTTP client target name is correct", plan =>
+                plan.TypeDirectives[0].TargetName == "IHttpClient")
+            .And("HTTP client has two member directives", plan =>
+                plan.TypeDirectives[0].MemberDirectives.Count == 2)
+            .And("HTTP client has one excluded member", plan =>
+                plan.TypeDirectives[0].ExcludedMembers.Count == 1)
+            .And("HTTP client does not wrap all public members", plan =>
+                !plan.TypeDirectives[0].WrapAllPublicMembers)
+            .And("Logger source type is correct", plan =>
+                plan.TypeDirectives[1].SourceType == "Vendor.Lib.Logger")
+            .And("Logger target name is correct", plan =>
+                plan.TypeDirectives[1].TargetName == "ILogger")
+            .And("Logger wraps all public members", plan =>
+                plan.TypeDirectives[1].WrapAllPublicMembers)
+            .And("Logger has no member directives", plan =>
+                plan.TypeDirectives[1].MemberDirectives.Count == 0)
             .AssertPassed();
-    }
 }

--- a/WrapGod.Tests/ManifestSchemaTests.cs
+++ b/WrapGod.Tests/ManifestSchemaTests.cs
@@ -7,13 +7,13 @@ using Xunit.Abstractions;
 namespace WrapGod.Tests;
 
 [Feature("Manifest JSON schema validation")]
-public partial class ManifestSchemaTests : TinyBddXunitBase
+public sealed class ManifestSchemaTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
+    // ── Helpers ──────────────────────────────────────────────────────
+
     private static readonly string RepoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
     private static readonly JsonSchema Schema = JsonSchema.FromText(
         File.ReadAllText(Path.Combine(RepoRoot, "schemas", "wrapgod.manifest.v1.schema.json")));
-
-    public ManifestSchemaTests(ITestOutputHelper output) : base(output) { }
 
     private static EvaluationResults EvaluateFile(string relativePath)
     {
@@ -28,23 +28,19 @@ public partial class ManifestSchemaTests : TinyBddXunitBase
     private static EvaluationResults EvaluateInvalidManifest() =>
         EvaluateFile("schemas/examples/manifest.invalid.missing-assembly.json");
 
+    // ── Scenarios ────────────────────────────────────────────────────
+
     [Scenario("Valid manifest example passes schema validation")]
     [Fact]
-    public async Task ManifestSchemaValidExamplePassesValidation()
-    {
-        await Flow.Given("the valid manifest evaluated against the schema", EvaluateValidManifest)
-            .Then("the validation passes", result =>
-                Assert.True(result.IsValid, "Expected valid manifest example to pass schema validation."))
+    public Task ManifestSchemaValidExamplePassesValidation()
+        => Given("the valid manifest evaluated against the schema", EvaluateValidManifest)
+            .Then("the validation passes", result => result.IsValid)
             .AssertPassed();
-    }
 
     [Scenario("Invalid manifest example fails schema validation")]
     [Fact]
-    public async Task ManifestSchemaInvalidExampleFailsValidation()
-    {
-        await Flow.Given("the invalid manifest evaluated against the schema", EvaluateInvalidManifest)
-            .Then("the validation fails", result =>
-                Assert.False(result.IsValid, "Expected invalid manifest example to fail schema validation."))
+    public Task ManifestSchemaInvalidExampleFailsValidation()
+        => Given("the invalid manifest evaluated against the schema", EvaluateInvalidManifest)
+            .Then("the validation fails", result => !result.IsValid)
             .AssertPassed();
-    }
 }

--- a/WrapGod.Tests/MultiVersionExtractorTests.cs
+++ b/WrapGod.Tests/MultiVersionExtractorTests.cs
@@ -7,11 +7,11 @@ using Xunit.Abstractions;
 namespace WrapGod.Tests;
 
 [Feature("Multi-version extraction and diffing")]
-public partial class MultiVersionExtractorTests : TinyBddXunitBase
+public sealed class MultiVersionExtractorTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
-    private static readonly string CoreLibPath = typeof(object).Assembly.Location;
+    // ── Helpers ──────────────────────────────────────────────────────
 
-    public MultiVersionExtractorTests(ITestOutputHelper output) : base(output) { }
+    private static readonly string CoreLibPath = typeof(object).Assembly.Location;
 
     private static MultiVersionExtractor.MultiVersionResult ExtractSameAssemblyTwice()
     {
@@ -336,268 +336,202 @@ public partial class MultiVersionExtractorTests : TinyBddXunitBase
             new List<(string, ApiManifest)> { ("1.0", v1), ("2.0", v2), ("3.0", v3) });
     }
 
+    // ── Scenarios ────────────────────────────────────────────────────
+
     [Scenario("Single version produces merged manifest with presence")]
     [Fact]
-    public async Task Extract_SingleVersion_ProducesMergedManifestWithPresence()
-    {
-        await Flow.Given("a single version input", ExtractSingleVersion)
+    public Task Extract_SingleVersion_ProducesMergedManifestWithPresence()
+        => Given("a single version input", ExtractSingleVersion)
             .Then("the merged manifest has types", result =>
-            {
-                Assert.NotNull(result.MergedManifest);
-                Assert.NotEmpty(result.MergedManifest.Types);
-            })
-            .And("every type has presence introduced in the single version", result =>
-            {
-                foreach (var type in result.MergedManifest.Types)
-                {
-                    Assert.NotNull(type.Presence);
-                    Assert.Equal("1.0.0", type.Presence!.IntroducedIn);
-                    Assert.Null(type.Presence.RemovedIn);
-                }
-            })
+                result.MergedManifest is not null && result.MergedManifest.Types.Count > 0)
+            .And("every type is introduced in the single version", result =>
+                result.MergedManifest.Types.All(t =>
+                    t.Presence is not null
+                    && t.Presence.IntroducedIn == "1.0.0"
+                    && t.Presence.RemovedIn is null))
             .AssertPassed();
-    }
 
     [Scenario("Two identical versions produce no diffs")]
     [Fact]
-    public async Task Extract_TwoIdenticalVersions_ProducesNoDiffs()
-    {
-        await Flow.Given("two identical version extractions", ExtractSameAssemblyTwice)
-            .Then("all diff collections are empty", result =>
-            {
-                Assert.Empty(result.Diff.AddedTypes);
-                Assert.Empty(result.Diff.RemovedTypes);
-                Assert.Empty(result.Diff.AddedMembers);
-                Assert.Empty(result.Diff.RemovedMembers);
-                Assert.Empty(result.Diff.ChangedMembers);
-                Assert.Empty(result.Diff.BreakingChanges);
-            })
+    public Task Extract_TwoIdenticalVersions_ProducesNoDiffs()
+        => Given("two identical version extractions", ExtractSameAssemblyTwice)
+            .Then("added types is empty", result => result.Diff.AddedTypes.Count == 0)
+            .And("removed types is empty", result => result.Diff.RemovedTypes.Count == 0)
+            .And("added members is empty", result => result.Diff.AddedMembers.Count == 0)
+            .And("removed members is empty", result => result.Diff.RemovedMembers.Count == 0)
+            .And("changed members is empty", result => result.Diff.ChangedMembers.Count == 0)
+            .And("breaking changes is empty", result => result.Diff.BreakingChanges.Count == 0)
             .AssertPassed();
-    }
 
     [Scenario("Two identical versions assign presence to all types")]
     [Fact]
-    public async Task Extract_TwoIdenticalVersions_AllTypesHavePresence()
-    {
-        await Flow.Given("two identical version extractions", ExtractSameAssemblyTwice)
-            .Then("every type has presence introduced in the first version", result =>
-            {
-                foreach (var type in result.MergedManifest.Types)
-                {
-                    Assert.NotNull(type.Presence);
-                    Assert.Equal("1.0.0", type.Presence!.IntroducedIn);
-                    Assert.Null(type.Presence.RemovedIn);
-                }
-            })
+    public Task Extract_TwoIdenticalVersions_AllTypesHavePresence()
+        => Given("two identical version extractions", ExtractSameAssemblyTwice)
+            .Then("every type is introduced in the first version with no removal", result =>
+                result.MergedManifest.Types.All(t =>
+                    t.Presence is not null
+                    && t.Presence.IntroducedIn == "1.0.0"
+                    && t.Presence.RemovedIn is null))
             .AssertPassed();
-    }
 
     [Scenario("Two identical versions assign presence to all members")]
     [Fact]
-    public async Task Extract_TwoIdenticalVersions_AllMembersHavePresence()
-    {
-        await Flow.Given("two identical version extractions", ExtractSameAssemblyTwice)
-            .Then("sampled members have presence introduced in the first version", result =>
+    public Task Extract_TwoIdenticalVersions_AllMembersHavePresence()
+        => Given("two identical version extractions", ExtractSameAssemblyTwice)
+            .Then("sampled members are introduced in the first version", result =>
             {
                 var members = result.MergedManifest.Types
                     .SelectMany(t => t.Members)
                     .Take(200)
                     .ToList();
-
-                Assert.NotEmpty(members);
-
-                foreach (var member in members)
-                {
-                    Assert.NotNull(member.Presence);
-                    Assert.Equal("1.0.0", member.Presence!.IntroducedIn);
-                }
+                return members.Count > 0
+                    && members.All(m =>
+                        m.Presence is not null
+                        && m.Presence.IntroducedIn == "1.0.0");
             })
             .AssertPassed();
-    }
 
     [Scenario("Diff version list is correct for two versions")]
     [Fact]
-    public async Task Extract_TwoIdenticalVersions_DiffVersionListIsCorrect()
-    {
-        await Flow.Given("two identical version extractions", ExtractSameAssemblyTwice)
+    public Task Extract_TwoIdenticalVersions_DiffVersionListIsCorrect()
+        => Given("two identical version extractions", ExtractSameAssemblyTwice)
             .Then("the diff lists both versions in order", result =>
-            {
-                Assert.Equal(2, result.Diff.Versions.Count);
-                Assert.Equal("1.0.0", result.Diff.Versions[0]);
-                Assert.Equal("2.0.0", result.Diff.Versions[1]);
-            })
+                result.Diff.Versions.Count == 2
+                && result.Diff.Versions[0] == "1.0.0"
+                && result.Diff.Versions[1] == "2.0.0")
             .AssertPassed();
-    }
 
     [Scenario("Empty version list throws ArgumentException")]
     [Fact]
-    public async Task Extract_EmptyVersionList_ThrowsArgumentException()
-    {
-        await Flow.Given("an empty version list", () => new List<MultiVersionExtractor.VersionInput>())
+    public Task Extract_EmptyVersionList_ThrowsArgumentException()
+        => Given("an empty version list", () => new List<MultiVersionExtractor.VersionInput>())
             .Then("extraction throws ArgumentException", versions =>
-                Assert.Throws<ArgumentException>(() => MultiVersionExtractor.Extract(versions)))
+            {
+                try { MultiVersionExtractor.Extract(versions); return false; }
+                catch (ArgumentException) { return true; }
+            })
             .AssertPassed();
-    }
 
     [Scenario("Merge detects an added type")]
     [Fact]
-    public async Task Merge_DetectsAddedType()
-    {
-        await Flow.Given("v1 with no types and v2 with one type", MergeAddedType)
+    public Task Merge_DetectsAddedType()
+        => Given("v1 with no types and v2 with one type", MergeAddedType)
             .Then("one added type is detected", result =>
-            {
-                Assert.Single(result.Diff.AddedTypes);
-                Assert.Equal("MyNamespace.NewClass", result.Diff.AddedTypes[0].StableId);
-                Assert.Equal("2.0.0", result.Diff.AddedTypes[0].IntroducedIn);
-            })
+                result.Diff.AddedTypes.Count == 1
+                && result.Diff.AddedTypes[0].StableId == "MyNamespace.NewClass"
+                && result.Diff.AddedTypes[0].IntroducedIn == "2.0.0")
             .And("the merged manifest type has correct presence", result =>
-            {
-                var mergedType = Assert.Single(result.MergedManifest.Types);
-                Assert.Equal("2.0.0", mergedType.Presence?.IntroducedIn);
-            })
+                result.MergedManifest.Types.Count == 1
+                && result.MergedManifest.Types[0].Presence?.IntroducedIn == "2.0.0")
             .AssertPassed();
-    }
 
     [Scenario("Merge detects a removed type")]
     [Fact]
-    public async Task Merge_DetectsRemovedType()
-    {
-        await Flow.Given("v1 with one type and v2 with no types", MergeRemovedType)
+    public Task Merge_DetectsRemovedType()
+        => Given("v1 with one type and v2 with no types", MergeRemovedType)
             .Then("one removed type is detected", result =>
-            {
-                Assert.Single(result.Diff.RemovedTypes);
-                Assert.Equal("MyNamespace.OldClass", result.Diff.RemovedTypes[0].StableId);
-                Assert.Equal("1.0.0", result.Diff.RemovedTypes[0].LastPresentIn);
-                Assert.Equal("2.0.0", result.Diff.RemovedTypes[0].RemovedIn);
-            })
+                result.Diff.RemovedTypes.Count == 1
+                && result.Diff.RemovedTypes[0].StableId == "MyNamespace.OldClass"
+                && result.Diff.RemovedTypes[0].LastPresentIn == "1.0.0"
+                && result.Diff.RemovedTypes[0].RemovedIn == "2.0.0")
             .And("it is flagged as a breaking change", result =>
-                Assert.Contains(result.Diff.BreakingChanges,
-                    b => b.Kind == BreakingChangeKind.TypeRemoved
-                      && b.StableId == "MyNamespace.OldClass"))
+                result.Diff.BreakingChanges.Any(b =>
+                    b.Kind == BreakingChangeKind.TypeRemoved
+                    && b.StableId == "MyNamespace.OldClass"))
             .AssertPassed();
-    }
 
     [Scenario("Merge detects an added member")]
     [Fact]
-    public async Task Merge_DetectsAddedMember()
-    {
-        await Flow.Given("v1 with an empty class and v2 with a new method", MergeAddedMember)
+    public Task Merge_DetectsAddedMember()
+        => Given("v1 with an empty class and v2 with a new method", MergeAddedMember)
             .Then("one added member is detected", result =>
-            {
-                Assert.Single(result.Diff.AddedMembers);
-                Assert.Equal("MyNamespace.MyClass.NewMethod()", result.Diff.AddedMembers[0].StableId);
-                Assert.Equal("2.0.0", result.Diff.AddedMembers[0].IntroducedIn);
-            })
+                result.Diff.AddedMembers.Count == 1
+                && result.Diff.AddedMembers[0].StableId == "MyNamespace.MyClass.NewMethod()"
+                && result.Diff.AddedMembers[0].IntroducedIn == "2.0.0")
             .AssertPassed();
-    }
 
     [Scenario("Merge detects a removed member")]
     [Fact]
-    public async Task Merge_DetectsRemovedMember()
-    {
-        await Flow.Given("v1 with a method and v2 with the method removed", MergeRemovedMember)
+    public Task Merge_DetectsRemovedMember()
+        => Given("v1 with a method and v2 with the method removed", MergeRemovedMember)
             .Then("one removed member is detected", result =>
-            {
-                Assert.Single(result.Diff.RemovedMembers);
-                Assert.Equal("MyNamespace.MyClass.OldMethod()", result.Diff.RemovedMembers[0].StableId);
-                Assert.Equal("2.0.0", result.Diff.RemovedMembers[0].RemovedIn);
-            })
+                result.Diff.RemovedMembers.Count == 1
+                && result.Diff.RemovedMembers[0].StableId == "MyNamespace.MyClass.OldMethod()"
+                && result.Diff.RemovedMembers[0].RemovedIn == "2.0.0")
             .And("it is flagged as a breaking change", result =>
-                Assert.Contains(result.Diff.BreakingChanges,
-                    b => b.Kind == BreakingChangeKind.MemberRemoved))
+                result.Diff.BreakingChanges.Any(b =>
+                    b.Kind == BreakingChangeKind.MemberRemoved))
             .AssertPassed();
-    }
 
     [Scenario("Merge detects a changed return type")]
     [Fact]
-    public async Task Merge_DetectsChangedReturnType()
-    {
-        await Flow.Given("v1 with Int32 return type and v2 with String return type", MergeChangedReturnType)
+    public Task Merge_DetectsChangedReturnType()
+        => Given("v1 with Int32 return type and v2 with String return type", MergeChangedReturnType)
             .Then("the changed member is detected with correct return types", result =>
-            {
-                Assert.Single(result.Diff.ChangedMembers);
-                var changed = result.Diff.ChangedMembers[0];
-                Assert.Equal("System.Int32", changed.OldReturnType);
-                Assert.Equal("System.String", changed.NewReturnType);
-                Assert.Equal("2.0.0", changed.ChangedIn);
-            })
+                result.Diff.ChangedMembers.Count == 1
+                && result.Diff.ChangedMembers[0].OldReturnType == "System.Int32"
+                && result.Diff.ChangedMembers[0].NewReturnType == "System.String"
+                && result.Diff.ChangedMembers[0].ChangedIn == "2.0.0")
             .And("it is flagged as a breaking change", result =>
-                Assert.Contains(result.Diff.BreakingChanges,
-                    b => b.Kind == BreakingChangeKind.ReturnTypeChanged))
+                result.Diff.BreakingChanges.Any(b =>
+                    b.Kind == BreakingChangeKind.ReturnTypeChanged))
             .AssertPassed();
-    }
 
     [Scenario("Merge detects changed parameter types")]
     [Fact]
-    public async Task Merge_DetectsChangedParameterTypes()
-    {
-        await Flow.Given("v1 with one parameter and v2 with two parameters", MergeChangedParameterTypes)
+    public Task Merge_DetectsChangedParameterTypes()
+        => Given("v1 with one parameter and v2 with two parameters", MergeChangedParameterTypes)
             .Then("the changed member is detected with correct parameter counts", result =>
-            {
-                Assert.Single(result.Diff.ChangedMembers);
-                var changed = result.Diff.ChangedMembers[0];
-                Assert.Single(changed.OldParameterTypes);
-                Assert.Equal(2, changed.NewParameterTypes.Count);
-            })
+                result.Diff.ChangedMembers.Count == 1
+                && result.Diff.ChangedMembers[0].OldParameterTypes.Count == 1
+                && result.Diff.ChangedMembers[0].NewParameterTypes.Count == 2)
             .And("it is flagged as a breaking change", result =>
-                Assert.Contains(result.Diff.BreakingChanges,
-                    b => b.Kind == BreakingChangeKind.ParameterTypesChanged))
+                result.Diff.BreakingChanges.Any(b =>
+                    b.Kind == BreakingChangeKind.ParameterTypesChanged))
             .AssertPassed();
-    }
 
     [Scenario("Three versions track presence across all")]
     [Fact]
-    public async Task Merge_ThreeVersions_TracksPresenceAcrossAll()
-    {
-        await Flow.Given("three versions where TypeA is removed and TypeB is added", MergeThreeVersionsPresence)
+    public Task Merge_ThreeVersions_TracksPresenceAcrossAll()
+        => Given("three versions where TypeA is removed and TypeB is added", MergeThreeVersionsPresence)
             .Then("TypeA was introduced in 1.0 and removed in 3.0", result =>
             {
                 var typeA = result.MergedManifest.Types.First(t => t.StableId == "TypeA");
-                Assert.Equal("1.0", typeA.Presence?.IntroducedIn);
-                Assert.Equal("3.0", typeA.Presence?.RemovedIn);
+                return typeA.Presence?.IntroducedIn == "1.0"
+                    && typeA.Presence?.RemovedIn == "3.0";
             })
             .And("TypeB was introduced in 2.0 and is still present", result =>
             {
                 var typeB = result.MergedManifest.Types.First(t => t.StableId == "TypeB");
-                Assert.Equal("2.0", typeB.Presence?.IntroducedIn);
-                Assert.Null(typeB.Presence?.RemovedIn);
+                return typeB.Presence?.IntroducedIn == "2.0"
+                    && typeB.Presence?.RemovedIn is null;
             })
-            .And("the diff shows TypeB added and TypeA removed", result =>
-            {
-                Assert.Contains(result.Diff.AddedTypes, a => a.StableId == "TypeB" && a.IntroducedIn == "2.0");
-                Assert.Contains(result.Diff.RemovedTypes, r => r.StableId == "TypeA" && r.RemovedIn == "3.0");
-            })
+            .And("the diff shows TypeB added in 2.0", result =>
+                result.Diff.AddedTypes.Any(a => a.StableId == "TypeB" && a.IntroducedIn == "2.0"))
+            .And("the diff shows TypeA removed in 3.0", result =>
+                result.Diff.RemovedTypes.Any(r => r.StableId == "TypeA" && r.RemovedIn == "3.0"))
             .AssertPassed();
-    }
 
     [Scenario("Merged manifest types are sorted by stable ID")]
     [Fact]
-    public async Task Merge_MergedManifestTypesAreSorted()
-    {
-        await Flow.Given("two identical version extractions", ExtractSameAssemblyTwice)
+    public Task Merge_MergedManifestTypesAreSorted()
+        => Given("two identical version extractions", ExtractSameAssemblyTwice)
             .Then("types are sorted by stable ID", result =>
             {
                 var ids = result.MergedManifest.Types.Select(t => t.StableId).ToList();
                 var sorted = ids.OrderBy(id => id, StringComparer.Ordinal).ToList();
-                Assert.Equal(sorted, ids);
+                return ids.SequenceEqual(sorted);
             })
             .AssertPassed();
-    }
 
     [Scenario("Three identical versions produce no diffs")]
     [Fact]
-    public async Task Extract_ThreeIdenticalVersions_ProducesNoDiffs()
-    {
-        await Flow.Given("three identical version extractions", ExtractThreeIdenticalVersions)
-            .Then("all diff collections are empty", result =>
-            {
-                Assert.Empty(result.Diff.AddedTypes);
-                Assert.Empty(result.Diff.RemovedTypes);
-                Assert.Empty(result.Diff.ChangedMembers);
-                Assert.Empty(result.Diff.BreakingChanges);
-            })
-            .And("three versions are listed", result =>
-                Assert.Equal(3, result.Diff.Versions.Count))
+    public Task Extract_ThreeIdenticalVersions_ProducesNoDiffs()
+        => Given("three identical version extractions", ExtractThreeIdenticalVersions)
+            .Then("added types is empty", result => result.Diff.AddedTypes.Count == 0)
+            .And("removed types is empty", result => result.Diff.RemovedTypes.Count == 0)
+            .And("changed members is empty", result => result.Diff.ChangedMembers.Count == 0)
+            .And("breaking changes is empty", result => result.Diff.BreakingChanges.Count == 0)
+            .And("three versions are listed", result => result.Diff.Versions.Count == 3)
             .AssertPassed();
-    }
 }


### PR DESCRIPTION
## Summary
- Rewrite all 5 test files to match PatternKit TinyBDD conventions: `sealed class` with primary constructor, instance `Given()` instead of `Flow.Given()`, boolean predicates in `Then`/`And` instead of `Assert.*`, expression-bodied `Task`-returning scenarios, helpers at top / scenarios at bottom
- Replace multi-assertion `Then` blocks with granular `.And()` chains using boolean expressions
- All 39 tests pass, net -123 lines

## Test plan
- [x] `dotnet build WrapGod.slnx --nologo -c Release` succeeds with 0 warnings/errors
- [x] `dotnet test WrapGod.Tests/WrapGod.Tests.csproj --nologo -v q` passes all 39 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)