### PR TITLE
feat: type mapping core model and planner

### DIFF
--- a/WrapGod.Tests/TypeMappingTests.cs
+++ b/WrapGod.Tests/TypeMappingTests.cs
@@ -1,0 +1,184 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Abstractions.Config;
+using WrapGod.TypeMap;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("Type mapping core")]
+public sealed class TypeMappingTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static TypeMappingPlan BuildObjectMappingPlan()
+    {
+        var config = new WrapGodConfig();
+        config.Types.Add(new TypeConfig
+        {
+            SourceType = "Vendor.Client",
+            Include = true,
+            TargetName = "IClient",
+        });
+        config.Types[0].Members.Add(
+            new MemberConfig { SourceMember = "GetUser", Include = true, TargetName = "FetchUser" });
+        config.Types[0].Members.Add(
+            new MemberConfig { SourceMember = "Timeout", Include = true });
+
+        return TypeMappingPlanner.BuildPlan(config);
+    }
+
+    private static TypeMappingPlan BuildEnumMappingPlan()
+    {
+        var config = new WrapGodConfig();
+        config.Types.Add(new TypeConfig
+        {
+            SourceType = "Vendor.StatusCode",
+            Include = true,
+            TargetName = "StatusCode",
+        });
+
+        var overrides = new List<TypeMappingOverride>
+        {
+            new() { SourceType = "Vendor.StatusCode", Kind = TypeMappingKind.Enum },
+        };
+
+        return TypeMappingPlanner.BuildPlan(config, overrides);
+    }
+
+    private static TypeMappingPlan BuildCollectionMappingPlan()
+    {
+        var config = new WrapGodConfig();
+        config.Types.Add(new TypeConfig
+        {
+            SourceType = "Vendor.ItemList",
+            Include = true,
+            TargetName = "IReadOnlyList<Item>",
+        });
+
+        var overrides = new List<TypeMappingOverride>
+        {
+            new() { SourceType = "Vendor.ItemList", Kind = TypeMappingKind.Collection },
+        };
+
+        return TypeMappingPlanner.BuildPlan(config, overrides);
+    }
+
+    private static TypeMappingPlan BuildNullableMappingPlan()
+    {
+        var config = new WrapGodConfig();
+        config.Types.Add(new TypeConfig
+        {
+            SourceType = "Vendor.NullableInt",
+            Include = true,
+            TargetName = "int?",
+        });
+
+        var overrides = new List<TypeMappingOverride>
+        {
+            new() { SourceType = "Vendor.NullableInt", Kind = TypeMappingKind.Nullable },
+        };
+
+        return TypeMappingPlanner.BuildPlan(config, overrides);
+    }
+
+    private static TypeMappingPlan BuildConverterHookPlan()
+    {
+        var config = new WrapGodConfig();
+        config.Types.Add(new TypeConfig
+        {
+            SourceType = "Vendor.DateTime",
+            Include = true,
+            TargetName = "DateTimeOffset",
+        });
+
+        var overrides = new List<TypeMappingOverride>
+        {
+            new()
+            {
+                SourceType = "Vendor.DateTime",
+                Kind = TypeMappingKind.Custom,
+                Converter = new ConverterRef
+                {
+                    TypeName = "MyApp.Converters.DateTimeConverter",
+                    MethodName = "ToOffset",
+                },
+            },
+        };
+
+        return TypeMappingPlanner.BuildPlan(config, overrides);
+    }
+
+    // ── Scenarios ────────────────────────────────────────────────────
+
+    [Scenario("Object mapping plan records source, destination, and members")]
+    [Fact]
+    public Task ObjectMappingPlanCreation()
+        => Given("a config with an object type and two members", BuildObjectMappingPlan)
+            .Then("there is exactly one mapping", plan => plan.Mappings.Count == 1)
+            .And("the mapping kind is ObjectMapping", plan =>
+                plan.Mappings[0].Kind == TypeMappingKind.ObjectMapping)
+            .And("the source type is correct", plan =>
+                plan.Mappings[0].SourceType == "Vendor.Client")
+            .And("the destination type is correct", plan =>
+                plan.Mappings[0].DestinationType == "IClient")
+            .And("there are two member mappings", plan =>
+                plan.Mappings[0].MemberMappings.Count == 2)
+            .And("the first member is renamed", plan =>
+                plan.Mappings[0].MemberMappings[0].SourceMember == "GetUser"
+                && plan.Mappings[0].MemberMappings[0].DestinationMember == "FetchUser")
+            .And("the second member keeps its name", plan =>
+                plan.Mappings[0].MemberMappings[1].SourceMember == "Timeout"
+                && plan.Mappings[0].MemberMappings[1].DestinationMember == "Timeout")
+            .And("the mapping is findable by source type", plan =>
+                plan.FindBySourceType("Vendor.Client") is not null)
+            .AssertPassed();
+
+    [Scenario("Enum mapping plan uses Enum kind")]
+    [Fact]
+    public Task EnumMappingPlan()
+        => Given("a config with an enum type override", BuildEnumMappingPlan)
+            .Then("there is exactly one mapping", plan => plan.Mappings.Count == 1)
+            .And("the mapping kind is Enum", plan =>
+                plan.Mappings[0].Kind == TypeMappingKind.Enum)
+            .And("the source type is correct", plan =>
+                plan.Mappings[0].SourceType == "Vendor.StatusCode")
+            .And("the destination type is correct", plan =>
+                plan.Mappings[0].DestinationType == "StatusCode")
+            .AssertPassed();
+
+    [Scenario("Collection mapping plan uses Collection kind")]
+    [Fact]
+    public Task CollectionMappingPlan()
+        => Given("a config with a collection type override", BuildCollectionMappingPlan)
+            .Then("there is exactly one mapping", plan => plan.Mappings.Count == 1)
+            .And("the mapping kind is Collection", plan =>
+                plan.Mappings[0].Kind == TypeMappingKind.Collection)
+            .And("the destination type is correct", plan =>
+                plan.Mappings[0].DestinationType == "IReadOnlyList<Item>")
+            .AssertPassed();
+
+    [Scenario("Nullable mapping plan uses Nullable kind")]
+    [Fact]
+    public Task NullableMappingPlan()
+        => Given("a config with a nullable type override", BuildNullableMappingPlan)
+            .Then("there is exactly one mapping", plan => plan.Mappings.Count == 1)
+            .And("the mapping kind is Nullable", plan =>
+                plan.Mappings[0].Kind == TypeMappingKind.Nullable)
+            .And("the destination type is correct", plan =>
+                plan.Mappings[0].DestinationType == "int?")
+            .AssertPassed();
+
+    [Scenario("Converter hook is registered and accessible on the mapping")]
+    [Fact]
+    public Task ConverterHookRegistration()
+        => Given("a config with a custom converter override", BuildConverterHookPlan)
+            .Then("there is exactly one mapping", plan => plan.Mappings.Count == 1)
+            .And("the mapping kind is Custom", plan =>
+                plan.Mappings[0].Kind == TypeMappingKind.Custom)
+            .And("the converter type name is correct", plan =>
+                plan.Mappings[0].Converter is { TypeName: "MyApp.Converters.DateTimeConverter" })
+            .And("the converter method name is correct", plan =>
+                plan.Mappings[0].Converter is { MethodName: "ToOffset" })
+            .AssertPassed();
+}

--- a/WrapGod.Tests/WrapGod.Tests.csproj
+++ b/WrapGod.Tests/WrapGod.Tests.csproj
@@ -28,6 +28,7 @@
     <Using Include="WrapGod.Fluent" />
     <Using Include="WrapGod.Abstractions.Config" />
     <Using Include="WrapGod.Manifest.Config" />
+    <Using Include="WrapGod.TypeMap" />
     <Using Include="Json.Schema" />
     <Using Include="System.Text.Json" />
     <Using Include="TinyBDD" />

--- a/WrapGod.TypeMap/Class1.cs
+++ b/WrapGod.TypeMap/Class1.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace WrapGod.TypeMap
-{
-    public class Class1
-    {
-
-    }
-}

--- a/WrapGod.TypeMap/ConverterRef.cs
+++ b/WrapGod.TypeMap/ConverterRef.cs
@@ -1,0 +1,19 @@
+namespace WrapGod.TypeMap;
+
+/// <summary>
+/// Reference to a user-defined converter method or class that handles
+/// custom type conversion during code generation.
+/// </summary>
+public sealed class ConverterRef
+{
+    /// <summary>
+    /// Fully-qualified name of the converter type (e.g. "MyApp.Converters.DateConverter").
+    /// </summary>
+    public string TypeName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional method name on the converter type. When null, the generator
+    /// will look for a conventional <c>Convert</c> method.
+    /// </summary>
+    public string? MethodName { get; set; }
+}

--- a/WrapGod.TypeMap/MemberMapping.cs
+++ b/WrapGod.TypeMap/MemberMapping.cs
@@ -1,0 +1,20 @@
+namespace WrapGod.TypeMap;
+
+/// <summary>
+/// Describes how a single member on the source type maps to a member
+/// on the destination type, with an optional converter for non-trivial transforms.
+/// </summary>
+public sealed class MemberMapping
+{
+    /// <summary>Name of the member on the source type.</summary>
+    public string SourceMember { get; set; } = string.Empty;
+
+    /// <summary>Name of the member on the destination type.</summary>
+    public string DestinationMember { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional converter reference for members that require custom
+    /// transformation logic (e.g. different types, formatting).
+    /// </summary>
+    public ConverterRef? Converter { get; set; }
+}

--- a/WrapGod.TypeMap/TypeMapping.cs
+++ b/WrapGod.TypeMap/TypeMapping.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace WrapGod.TypeMap;
+
+/// <summary>
+/// Core mapping model that describes how a source type maps to a destination type,
+/// including the mapping kind, per-member mappings, and an optional top-level converter.
+/// </summary>
+public sealed class TypeMapping
+{
+    /// <summary>Fully-qualified source type name.</summary>
+    public string SourceType { get; set; } = string.Empty;
+
+    /// <summary>Fully-qualified destination type name.</summary>
+    public string DestinationType { get; set; } = string.Empty;
+
+    /// <summary>The kind of mapping (ObjectMapping, Enum, Collection, Nullable, Custom).</summary>
+    public TypeMappingKind Kind { get; set; }
+
+    /// <summary>Per-member mappings for Object-kind type mappings.</summary>
+    public IReadOnlyList<MemberMapping> MemberMappings { get; set; } = new List<MemberMapping>();
+
+    /// <summary>
+    /// Optional top-level converter reference. When set, the entire type
+    /// conversion is delegated to this converter instead of member-by-member mapping.
+    /// </summary>
+    public ConverterRef? Converter { get; set; }
+}

--- a/WrapGod.TypeMap/TypeMappingKind.cs
+++ b/WrapGod.TypeMap/TypeMappingKind.cs
@@ -1,0 +1,22 @@
+namespace WrapGod.TypeMap;
+
+/// <summary>
+/// Classifies the kind of type mapping being described.
+/// </summary>
+public enum TypeMappingKind
+{
+    /// <summary>Object-to-object mapping (class/struct/record).</summary>
+    ObjectMapping,
+
+    /// <summary>Enum-to-enum mapping.</summary>
+    Enum,
+
+    /// <summary>Collection-to-collection mapping (e.g. List to IReadOnlyList).</summary>
+    Collection,
+
+    /// <summary>Nullable wrapper mapping (e.g. int? to int?).</summary>
+    Nullable,
+
+    /// <summary>Fully custom mapping handled by a user-provided converter.</summary>
+    Custom,
+}

--- a/WrapGod.TypeMap/TypeMappingPlan.cs
+++ b/WrapGod.TypeMap/TypeMappingPlan.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WrapGod.TypeMap;
+
+/// <summary>
+/// A complete collection of type mappings consumable by the generator and analyzers.
+/// Produced by <see cref="TypeMappingPlanner"/> from config inputs.
+/// </summary>
+public sealed class TypeMappingPlan
+{
+    /// <summary>All type mappings in this plan.</summary>
+    public IReadOnlyList<TypeMapping> Mappings { get; set; } = new List<TypeMapping>();
+
+    /// <summary>
+    /// Look up the mapping for a given source type, or null if no mapping exists.
+    /// </summary>
+    public TypeMapping? FindBySourceType(string sourceType) =>
+        Mappings.FirstOrDefault(m => m.SourceType == sourceType);
+
+    /// <summary>
+    /// Look up the mapping for a given destination type, or null if no mapping exists.
+    /// </summary>
+    public TypeMapping? FindByDestinationType(string destinationType) =>
+        Mappings.FirstOrDefault(m => m.DestinationType == destinationType);
+}

--- a/WrapGod.TypeMap/TypeMappingPlanner.cs
+++ b/WrapGod.TypeMap/TypeMappingPlanner.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using WrapGod.Abstractions.Config;
+
+namespace WrapGod.TypeMap;
+
+/// <summary>
+/// Builds a <see cref="TypeMappingPlan"/> from <see cref="WrapGodConfig"/> type
+/// configurations and optional explicit mapping overrides.
+/// </summary>
+public static class TypeMappingPlanner
+{
+    /// <summary>
+    /// Create a <see cref="TypeMappingPlan"/> from a merged <see cref="WrapGodConfig"/>.
+    /// Each <see cref="TypeConfig"/> with an included type produces a <see cref="TypeMapping"/>
+    /// whose kind is inferred as <see cref="TypeMappingKind.ObjectMapping"/> by default.
+    /// </summary>
+    public static TypeMappingPlan BuildPlan(WrapGodConfig config) =>
+        BuildPlan(config, new List<TypeMappingOverride>());
+
+    /// <summary>
+    /// Create a <see cref="TypeMappingPlan"/> from a merged <see cref="WrapGodConfig"/>
+    /// plus explicit mapping overrides (e.g. from fluent or JSON config).
+    /// </summary>
+    public static TypeMappingPlan BuildPlan(
+        WrapGodConfig config,
+        IReadOnlyList<TypeMappingOverride> overrides)
+    {
+        var overrideMap = new Dictionary<string, TypeMappingOverride>();
+        foreach (var o in overrides)
+        {
+            overrideMap[o.SourceType] = o;
+        }
+
+        var mappings = new List<TypeMapping>();
+
+        foreach (var type in config.Types)
+        {
+            if (type.Include == false)
+            {
+                continue;
+            }
+
+            overrideMap.TryGetValue(type.SourceType, out var over);
+
+            var kind = over?.Kind ?? TypeMappingKind.ObjectMapping;
+            var converter = over?.Converter;
+            var destType = type.TargetName ?? type.SourceType;
+
+            var memberMappings = new List<MemberMapping>();
+            foreach (var member in type.Members)
+            {
+                if (member.Include == false)
+                {
+                    continue;
+                }
+
+                memberMappings.Add(new MemberMapping
+                {
+                    SourceMember = member.SourceMember,
+                    DestinationMember = member.TargetName ?? member.SourceMember,
+                });
+            }
+
+            mappings.Add(new TypeMapping
+            {
+                SourceType = type.SourceType,
+                DestinationType = destType,
+                Kind = kind,
+                MemberMappings = memberMappings,
+                Converter = converter,
+            });
+        }
+
+        return new TypeMappingPlan { Mappings = mappings };
+    }
+}
+
+/// <summary>
+/// An explicit override for a type mapping, allowing callers to specify
+/// the mapping kind and/or a converter reference for a given source type.
+/// </summary>
+public sealed class TypeMappingOverride
+{
+    /// <summary>Fully-qualified source type to override.</summary>
+    public string SourceType { get; set; } = string.Empty;
+
+    /// <summary>Override the inferred mapping kind.</summary>
+    public TypeMappingKind? Kind { get; set; }
+
+    /// <summary>Override with a custom converter reference.</summary>
+    public ConverterRef? Converter { get; set; }
+}

--- a/WrapGod.TypeMap/WrapGod.TypeMap.csproj
+++ b/WrapGod.TypeMap/WrapGod.TypeMap.csproj
@@ -1,7 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WrapGod.Abstractions\WrapGod.Abstractions.csproj" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Replaces `WrapGod.TypeMap/Class1.cs` with full type-mapping model: `TypeMapping`, `TypeMappingPlan`, `MemberMapping`, `TypeMappingKind`, `ConverterRef`, and `TypeMappingPlanner`
- Supports Object, Enum, Collection, Nullable, and Custom mapping kinds with explicit converter hooks via `ConverterRef`
- `TypeMappingPlanner.BuildPlan()` builds a `TypeMappingPlan` from `WrapGodConfig` with optional `TypeMappingOverride` entries for kind/converter overrides
- Adds 5 TinyBDD PatternKit-style tests covering all mapping kinds and converter registration

## Test plan
- [x] `dotnet build WrapGod.slnx --nologo -c Release` -- 0 warnings, 0 errors
- [x] `dotnet test WrapGod.slnx --nologo -c Release` -- 44 tests pass (5 new TypeMapping tests)
- [ ] Verify TypeMappingPlan is consumable by generator and analyzer layers in follow-up issues

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)