### PR TITLE
feat: generator expansion for methods, properties, constructors

### DIFF
--- a/WrapGod.Generator/GeneratorModels.cs
+++ b/WrapGod.Generator/GeneratorModels.cs
@@ -107,6 +107,8 @@ internal sealed class MemberPlan : IEquatable<MemberPlan>
     public IReadOnlyList<ParameterPlan> Parameters { get; }
     public bool HasGetter { get; }
     public bool HasSetter { get; }
+    public bool IsStatic { get; }
+    public IReadOnlyList<string> GenericParameters { get; }
 
     public MemberPlan(
         string name,
@@ -114,7 +116,9 @@ internal sealed class MemberPlan : IEquatable<MemberPlan>
         string returnType,
         IReadOnlyList<ParameterPlan> parameters,
         bool hasGetter,
-        bool hasSetter)
+        bool hasSetter,
+        bool isStatic = false,
+        IReadOnlyList<string>? genericParameters = null)
     {
         Name = name;
         Kind = kind;
@@ -122,6 +126,8 @@ internal sealed class MemberPlan : IEquatable<MemberPlan>
         Parameters = parameters;
         HasGetter = hasGetter;
         HasSetter = hasSetter;
+        IsStatic = isStatic;
+        GenericParameters = genericParameters ?? Array.Empty<string>();
     }
 
     public bool Equals(MemberPlan? other)
@@ -130,11 +136,18 @@ internal sealed class MemberPlan : IEquatable<MemberPlan>
         if (ReferenceEquals(this, other)) return true;
         if (Name != other.Name || Kind != other.Kind || ReturnType != other.ReturnType) return false;
         if (HasGetter != other.HasGetter || HasSetter != other.HasSetter) return false;
+        if (IsStatic != other.IsStatic) return false;
         if (Parameters.Count != other.Parameters.Count) return false;
+        if (GenericParameters.Count != other.GenericParameters.Count) return false;
 
         for (int i = 0; i < Parameters.Count; i++)
         {
             if (!Parameters[i].Equals(other.Parameters[i])) return false;
+        }
+
+        for (int i = 0; i < GenericParameters.Count; i++)
+        {
+            if (GenericParameters[i] != other.GenericParameters[i]) return false;
         }
 
         return true;
@@ -147,6 +160,7 @@ internal sealed class MemberPlan : IEquatable<MemberPlan>
         int hash = Name.GetHashCode();
         hash = (hash * 397) ^ Kind.GetHashCode();
         hash = (hash * 397) ^ ReturnType.GetHashCode();
+        hash = (hash * 397) ^ IsStatic.GetHashCode();
         return hash;
     }
 }
@@ -159,23 +173,31 @@ internal sealed class ParameterPlan : IEquatable<ParameterPlan>
     public string Name { get; }
     public string Type { get; }
 
-    public ParameterPlan(string name, string type)
+    /// <summary>
+    /// Parameter modifier: "", "ref", "out", "in", or "params".
+    /// </summary>
+    public string Modifier { get; }
+
+    public ParameterPlan(string name, string type, string modifier = "")
     {
         Name = name;
         Type = type;
+        Modifier = modifier;
     }
 
     public bool Equals(ParameterPlan? other)
     {
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
-        return Name == other.Name && Type == other.Type;
+        return Name == other.Name && Type == other.Type && Modifier == other.Modifier;
     }
 
     public override bool Equals(object? obj) => Equals(obj as ParameterPlan);
 
     public override int GetHashCode()
     {
-        return (Name.GetHashCode() * 397) ^ Type.GetHashCode();
+        int hash = (Name.GetHashCode() * 397) ^ Type.GetHashCode();
+        hash = (hash * 397) ^ Modifier.GetHashCode();
+        return hash;
     }
 }

--- a/WrapGod.Generator/SourceEmitter.cs
+++ b/WrapGod.Generator/SourceEmitter.cs
@@ -29,6 +29,10 @@ internal static class SourceEmitter
 
         foreach (var member in type.Members)
         {
+            // Skip static members -- interfaces model instance contracts
+            if (member.IsStatic)
+                continue;
+
             EmitInterfaceMember(sb, member);
         }
 
@@ -57,11 +61,15 @@ internal static class SourceEmitter
         sb.AppendLine();
         sb.Append("    public ").Append(className).Append('(').Append(type.FullName).AppendLine(" inner)");
         sb.AppendLine("    {");
-        sb.AppendLine("        _inner = inner;");
+        sb.AppendLine("        _inner = inner ?? throw new System.ArgumentNullException(nameof(inner));");
         sb.AppendLine("    }");
 
         foreach (var member in type.Members)
         {
+            // Skip static members -- facade delegates to an instance
+            if (member.IsStatic)
+                continue;
+
             sb.AppendLine();
             EmitFacadeMember(sb, member);
         }
@@ -90,7 +98,9 @@ internal static class SourceEmitter
         else
         {
             // Method
-            sb.Append("    ").Append(member.ReturnType).Append(' ').Append(member.Name).Append('(');
+            sb.Append("    ").Append(member.ReturnType).Append(' ').Append(member.Name);
+            AppendGenericParameters(sb, member.GenericParameters);
+            sb.Append('(');
             AppendParameters(sb, member.Parameters);
             sb.AppendLine(");");
         }
@@ -117,15 +127,33 @@ internal static class SourceEmitter
         }
         else
         {
-            // Method
-            string returnKeyword = member.ReturnType == "void" ? "" : "return ";
-            sb.Append("    public ").Append(member.ReturnType).Append(' ').Append(member.Name).Append('(');
+            // Method -- expression-bodied forwarding works for both void and non-void
+            sb.Append("    public ").Append(member.ReturnType).Append(' ').Append(member.Name);
+            AppendGenericParameters(sb, member.GenericParameters);
+            sb.Append('(');
             AppendParameters(sb, member.Parameters);
             sb.AppendLine(")");
-            sb.Append("        => ").Append(returnKeyword).Append("_inner.").Append(member.Name).Append('(');
+            sb.Append("        => _inner.").Append(member.Name);
+            AppendGenericParameters(sb, member.GenericParameters);
+            sb.Append('(');
             AppendArguments(sb, member.Parameters);
             sb.AppendLine(");");
         }
+    }
+
+    private static void AppendGenericParameters(StringBuilder sb, IReadOnlyList<string> genericParameters)
+    {
+        if (genericParameters.Count == 0)
+            return;
+
+        sb.Append('<');
+        for (int i = 0; i < genericParameters.Count; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(genericParameters[i]);
+        }
+
+        sb.Append('>');
     }
 
     private static void AppendParameters(StringBuilder sb, IReadOnlyList<ParameterPlan> parameters)
@@ -133,6 +161,11 @@ internal static class SourceEmitter
         for (int i = 0; i < parameters.Count; i++)
         {
             if (i > 0) sb.Append(", ");
+            if (parameters[i].Modifier.Length > 0)
+            {
+                sb.Append(parameters[i].Modifier).Append(' ');
+            }
+
             sb.Append(parameters[i].Type).Append(' ').Append(parameters[i].Name);
         }
     }
@@ -142,6 +175,14 @@ internal static class SourceEmitter
         for (int i = 0; i < parameters.Count; i++)
         {
             if (i > 0) sb.Append(", ");
+
+            // ref/out must be forwarded with the same keyword
+            string mod = parameters[i].Modifier;
+            if (mod == "ref" || mod == "out")
+            {
+                sb.Append(mod).Append(' ');
+            }
+
             sb.Append(parameters[i].Name);
         }
     }

--- a/WrapGod.Generator/WrapGodIncrementalGenerator.cs
+++ b/WrapGod.Generator/WrapGodIncrementalGenerator.cs
@@ -122,6 +122,20 @@ public sealed class WrapGodIncrementalGenerator : IIncrementalGenerator
 
         bool hasGetter = GetBoolProperty(memberEl, "hasGetter");
         bool hasSetter = GetBoolProperty(memberEl, "hasSetter");
+        bool isStatic = GetBoolProperty(memberEl, "isStatic");
+
+        var genericParameters = new List<string>();
+        if (memberEl.TryGetProperty("genericParameters", out var gpEl) && gpEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var gp in gpEl.EnumerateArray())
+            {
+                string gpName = GetStringProperty(gp, "name");
+                if (!string.IsNullOrEmpty(gpName))
+                {
+                    genericParameters.Add(gpName);
+                }
+            }
+        }
 
         var parameters = new List<ParameterPlan>();
 
@@ -133,12 +147,20 @@ public sealed class WrapGodIncrementalGenerator : IIncrementalGenerator
                 string paramType = GetStringProperty(paramEl, "type");
                 if (!string.IsNullOrEmpty(paramName) && !string.IsNullOrEmpty(paramType))
                 {
-                    parameters.Add(new ParameterPlan(paramName, paramType));
+                    string modifier = "";
+                    if (GetBoolProperty(paramEl, "isOut"))
+                        modifier = "out";
+                    else if (GetBoolProperty(paramEl, "isRef"))
+                        modifier = "ref";
+                    else if (GetBoolProperty(paramEl, "isParams"))
+                        modifier = "params";
+
+                    parameters.Add(new ParameterPlan(paramName, paramType, modifier));
                 }
             }
         }
 
-        return new MemberPlan(name, kind, returnType, parameters, hasGetter, hasSetter);
+        return new MemberPlan(name, kind, returnType, parameters, hasGetter, hasSetter, isStatic, genericParameters);
     }
 
     private static string GetStringProperty(JsonElement el, string name, string defaultValue = "")

--- a/WrapGod.Tests/GeneratorExpansionTests.cs
+++ b/WrapGod.Tests/GeneratorExpansionTests.cs
@@ -1,0 +1,386 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Generator;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("Generator expansion: methods, properties, constructors")]
+public sealed class GeneratorExpansionTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // -- Helpers -------------------------------------------------------
+
+    private static GeneratorDriverRunResult RunGeneratorWithManifest(string manifest)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText("namespace Placeholder; public class Marker { }");
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        IIncrementalGenerator generator = new WrapGodIncrementalGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: new[] { generator.AsSourceGenerator() },
+            additionalTexts: new[]
+            {
+                new InMemoryAdditionalText("test.wrapgod.json", manifest),
+            });
+
+        driver = driver.RunGenerators(compilation);
+        return driver.GetRunResult();
+    }
+
+    private static string GetFacadeSource(GeneratorDriverRunResult result, string typeName)
+        => result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(s => s.HintName == typeName + "Facade.g.cs")
+            .SourceText.ToString();
+
+    private static string GetInterfaceSource(GeneratorDriverRunResult result, string typeName)
+        => result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .First(s => s.HintName == "IWrapped" + typeName + ".g.cs")
+            .SourceText.ToString();
+
+    // -- Manifests ----------------------------------------------------
+
+    private static readonly string MethodWithParametersManifest = """
+        {
+          "schemaVersion": "1.0",
+          "generatedAt": "2026-03-27T00:00:00Z",
+          "assembly": { "name": "Acme.Lib", "version": "1.0.0" },
+          "types": [
+            {
+              "fullName": "Acme.Lib.Calculator",
+              "name": "Calculator",
+              "namespace": "Acme.Lib",
+              "kind": "class",
+              "members": [
+                {
+                  "name": "Add",
+                  "kind": "method",
+                  "returnType": "int",
+                  "parameters": [
+                    { "name": "a", "type": "int" },
+                    { "name": "b", "type": "int" }
+                  ],
+                  "genericParameters": [],
+                  "isStatic": false,
+                  "hasGetter": false,
+                  "hasSetter": false
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static readonly string PropertyManifest = """
+        {
+          "schemaVersion": "1.0",
+          "generatedAt": "2026-03-27T00:00:00Z",
+          "assembly": { "name": "Acme.Lib", "version": "1.0.0" },
+          "types": [
+            {
+              "fullName": "Acme.Lib.Config",
+              "name": "Config",
+              "namespace": "Acme.Lib",
+              "kind": "class",
+              "members": [
+                {
+                  "name": "Timeout",
+                  "kind": "property",
+                  "returnType": "int",
+                  "parameters": [],
+                  "genericParameters": [],
+                  "isStatic": false,
+                  "hasGetter": true,
+                  "hasSetter": true
+                },
+                {
+                  "name": "Name",
+                  "kind": "property",
+                  "returnType": "string",
+                  "parameters": [],
+                  "genericParameters": [],
+                  "isStatic": false,
+                  "hasGetter": true,
+                  "hasSetter": false
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static readonly string VoidMethodManifest = """
+        {
+          "schemaVersion": "1.0",
+          "generatedAt": "2026-03-27T00:00:00Z",
+          "assembly": { "name": "Acme.Lib", "version": "1.0.0" },
+          "types": [
+            {
+              "fullName": "Acme.Lib.Notifier",
+              "name": "Notifier",
+              "namespace": "Acme.Lib",
+              "kind": "class",
+              "members": [
+                {
+                  "name": "Send",
+                  "kind": "method",
+                  "returnType": "void",
+                  "parameters": [
+                    { "name": "message", "type": "string" }
+                  ],
+                  "genericParameters": [],
+                  "isStatic": false,
+                  "hasGetter": false,
+                  "hasSetter": false
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static readonly string GenericMethodManifest = """
+        {
+          "schemaVersion": "1.0",
+          "generatedAt": "2026-03-27T00:00:00Z",
+          "assembly": { "name": "Acme.Lib", "version": "1.0.0" },
+          "types": [
+            {
+              "fullName": "Acme.Lib.Mapper",
+              "name": "Mapper",
+              "namespace": "Acme.Lib",
+              "kind": "class",
+              "members": [
+                {
+                  "name": "Convert",
+                  "kind": "method",
+                  "returnType": "TOut",
+                  "parameters": [
+                    { "name": "input", "type": "TIn" }
+                  ],
+                  "genericParameters": [
+                    { "name": "TIn", "constraints": [] },
+                    { "name": "TOut", "constraints": [] }
+                  ],
+                  "isStatic": false,
+                  "hasGetter": false,
+                  "hasSetter": false
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static readonly string StaticMemberManifest = """
+        {
+          "schemaVersion": "1.0",
+          "generatedAt": "2026-03-27T00:00:00Z",
+          "assembly": { "name": "Acme.Lib", "version": "1.0.0" },
+          "types": [
+            {
+              "fullName": "Acme.Lib.Helper",
+              "name": "Helper",
+              "namespace": "Acme.Lib",
+              "kind": "class",
+              "members": [
+                {
+                  "name": "InstanceMethod",
+                  "kind": "method",
+                  "returnType": "void",
+                  "parameters": [],
+                  "genericParameters": [],
+                  "isStatic": false,
+                  "hasGetter": false,
+                  "hasSetter": false
+                },
+                {
+                  "name": "StaticMethod",
+                  "kind": "method",
+                  "returnType": "void",
+                  "parameters": [],
+                  "genericParameters": [],
+                  "isStatic": true,
+                  "hasGetter": false,
+                  "hasSetter": false
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static readonly string RefOutManifest = """
+        {
+          "schemaVersion": "1.0",
+          "generatedAt": "2026-03-27T00:00:00Z",
+          "assembly": { "name": "Acme.Lib", "version": "1.0.0" },
+          "types": [
+            {
+              "fullName": "Acme.Lib.Parser",
+              "name": "Parser",
+              "namespace": "Acme.Lib",
+              "kind": "class",
+              "members": [
+                {
+                  "name": "TryParse",
+                  "kind": "method",
+                  "returnType": "bool",
+                  "parameters": [
+                    { "name": "input", "type": "string" },
+                    { "name": "result", "type": "int", "isOut": true }
+                  ],
+                  "genericParameters": [],
+                  "isStatic": false,
+                  "hasGetter": false,
+                  "hasSetter": false
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    // -- Scenarios -----------------------------------------------------
+
+    [Scenario("Method with parameters generates correct interface signature")]
+    [Fact]
+    public Task MethodWithParametersGeneratesCorrectSignature()
+        => Given("a manifest with a method taking two int parameters",
+                () => RunGeneratorWithManifest(MethodWithParametersManifest))
+            .Then("the interface declares the correct method signature", result =>
+                GetInterfaceSource(result, "Calculator")
+                    .Contains("int Add(int a, int b);", StringComparison.Ordinal))
+            .And("the facade declares a matching public method", result =>
+                GetFacadeSource(result, "Calculator")
+                    .Contains("public int Add(int a, int b)", StringComparison.Ordinal))
+            .And("the facade forwards arguments to the inner instance", result =>
+                GetFacadeSource(result, "Calculator")
+                    .Contains("_inner.Add(a, b)", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Property generates get/set forwarding")]
+    [Fact]
+    public Task PropertyGeneratesGetSetForwarding()
+        => Given("a manifest with a read-write and a read-only property",
+                () => RunGeneratorWithManifest(PropertyManifest))
+            .Then("the interface declares the read-write property", result =>
+                GetInterfaceSource(result, "Config")
+                    .Contains("int Timeout { get; set; }", StringComparison.Ordinal))
+            .And("the interface declares the read-only property", result =>
+                GetInterfaceSource(result, "Config")
+                    .Contains("string Name { get; }", StringComparison.Ordinal))
+            .And("the facade getter forwards to inner", result =>
+                GetFacadeSource(result, "Config")
+                    .Contains("get => _inner.Timeout;", StringComparison.Ordinal))
+            .And("the facade setter forwards to inner", result =>
+                GetFacadeSource(result, "Config")
+                    .Contains("set => _inner.Timeout = value;", StringComparison.Ordinal))
+            .And("the read-only property has no setter", result =>
+                !GetFacadeSource(result, "Config")
+                    .Contains("_inner.Name = value", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Constructor injects wrapped instance")]
+    [Fact]
+    public Task ConstructorInjectsWrappedInstance()
+        => Given("a manifest with a type",
+                () => RunGeneratorWithManifest(MethodWithParametersManifest))
+            .Then("the facade constructor takes the wrapped type", result =>
+                GetFacadeSource(result, "Calculator")
+                    .Contains("public CalculatorFacade(Acme.Lib.Calculator inner)", StringComparison.Ordinal))
+            .And("the constructor stores the instance in a field", result =>
+                GetFacadeSource(result, "Calculator")
+                    .Contains("_inner = inner ?? throw new System.ArgumentNullException(nameof(inner));",
+                        StringComparison.Ordinal))
+            .And("the field is declared as readonly", result =>
+                GetFacadeSource(result, "Calculator")
+                    .Contains("private readonly Acme.Lib.Calculator _inner;", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Void method forwards correctly without return")]
+    [Fact]
+    public Task VoidMethodForwardsCorrectly()
+        => Given("a manifest with a void method",
+                () => RunGeneratorWithManifest(VoidMethodManifest))
+            .Then("the interface declares a void method", result =>
+                GetInterfaceSource(result, "Notifier")
+                    .Contains("void Send(string message);", StringComparison.Ordinal))
+            .And("the facade forwards without a return keyword", result =>
+                GetFacadeSource(result, "Notifier")
+                    .Contains("=> _inner.Send(message);", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Generic method emits type parameters")]
+    [Fact]
+    public Task GenericMethodEmitsTypeParameters()
+        => Given("a manifest with a generic method",
+                () => RunGeneratorWithManifest(GenericMethodManifest))
+            .Then("the interface includes type parameters", result =>
+                GetInterfaceSource(result, "Mapper")
+                    .Contains("TOut Convert<TIn, TOut>(TIn input);", StringComparison.Ordinal))
+            .And("the facade forwards with type parameters", result =>
+                GetFacadeSource(result, "Mapper")
+                    .Contains("_inner.Convert<TIn, TOut>(input)", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Static members are skipped in generated output")]
+    [Fact]
+    public Task StaticMembersAreSkipped()
+        => Given("a manifest with both static and instance methods",
+                () => RunGeneratorWithManifest(StaticMemberManifest))
+            .Then("the interface contains the instance method", result =>
+                GetInterfaceSource(result, "Helper")
+                    .Contains("void InstanceMethod()", StringComparison.Ordinal))
+            .And("the interface does not contain the static method", result =>
+                !GetInterfaceSource(result, "Helper")
+                    .Contains("StaticMethod", StringComparison.Ordinal))
+            .And("the facade does not contain the static method", result =>
+                !GetFacadeSource(result, "Helper")
+                    .Contains("StaticMethod", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Out parameter generates correct modifier in signature and forwarding")]
+    [Fact]
+    public Task OutParameterGeneratesCorrectModifier()
+        => Given("a manifest with an out parameter",
+                () => RunGeneratorWithManifest(RefOutManifest))
+            .Then("the interface declares the out parameter", result =>
+                GetInterfaceSource(result, "Parser")
+                    .Contains("bool TryParse(string input, out int result);", StringComparison.Ordinal))
+            .And("the facade forwards with the out keyword", result =>
+                GetFacadeSource(result, "Parser")
+                    .Contains("_inner.TryParse(input, out result)", StringComparison.Ordinal))
+            .AssertPassed();
+
+    // -- In-memory AdditionalText for testing --------------------------
+
+    private sealed class InMemoryAdditionalText : AdditionalText
+    {
+        private readonly SourceText _text;
+
+        public InMemoryAdditionalText(string path, string content)
+        {
+            Path = path;
+            _text = SourceText.From(content);
+        }
+
+        public override string Path { get; }
+
+        public override SourceText? GetText(CancellationToken cancellationToken = default) => _text;
+    }
+}


### PR DESCRIPTION
## Summary
- Extended `SourceEmitter` to emit generic type parameters on methods, `ref`/`out`/`params` parameter modifiers, and null-guard in constructor injection
- Updated `WrapGodIncrementalGenerator` to parse `isStatic`, `genericParameters`, `isOut`, `isRef`, and `isParams` from manifest JSON
- Added `IsStatic` and `GenericParameters` to `MemberPlan`, `Modifier` to `ParameterPlan` in `GeneratorModels`
- Static members are now skipped in both interface and facade output
- Added 7 TinyBDD scenario tests covering all acceptance criteria

## Test plan
- [x] Method with parameters generates correct interface and facade signatures
- [x] Property generates get/set forwarding (including read-only)
- [x] Constructor injects wrapped instance with null guard
- [x] Void method forwards correctly via expression body
- [x] Generic method emits type parameters in interface and facade
- [x] Static members are excluded from generated output
- [x] Out parameter modifier propagates to both signature and forwarding call
- [x] All existing tests continue to pass (58 total)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)