### PR TITLE
feat: Roslyn analyzers MVP for direct third-party API usage (WG2001/WG2002)

### DIFF
--- a/WrapGod.Analyzers/Class1.cs
+++ b/WrapGod.Analyzers/Class1.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace WrapGod.Analyzers
-{
-    public class Class1
-    {
-
-    }
-}

--- a/WrapGod.Analyzers/DiagnosticDescriptors.cs
+++ b/WrapGod.Analyzers/DiagnosticDescriptors.cs
@@ -1,0 +1,39 @@
+using Microsoft.CodeAnalysis;
+
+namespace WrapGod.Analyzers;
+
+/// <summary>
+/// Diagnostic descriptors for WrapGod analyzers.
+/// </summary>
+internal static class DiagnosticDescriptors
+{
+    private const string Category = "WrapGod.Usage";
+
+    /// <summary>
+    /// WG2001: Direct usage of a third-party type that has a generated wrapper interface.
+    /// </summary>
+    public static readonly DiagnosticDescriptor DirectTypeUsage = new(
+        id: "WG2001",
+        title: "Direct third-party type usage",
+        messageFormat: "Type '{0}' has a generated wrapper interface; use '{1}' instead",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+            "Direct usage of a wrapped third-party type bypasses the abstraction layer. " +
+            "Depend on the generated wrapper interface to keep your code decoupled.");
+
+    /// <summary>
+    /// WG2002: Direct method call on a third-party type that has a generated facade.
+    /// </summary>
+    public static readonly DiagnosticDescriptor DirectMethodCall = new(
+        id: "WG2002",
+        title: "Direct third-party method call",
+        messageFormat: "Method '{0}' on type '{1}' should be called through the facade '{2}'",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+            "Calling methods directly on a wrapped third-party type bypasses the facade layer. " +
+            "Use the generated facade to keep your code decoupled.");
+}

--- a/WrapGod.Analyzers/DirectUsageAnalyzer.cs
+++ b/WrapGod.Analyzers/DirectUsageAnalyzer.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace WrapGod.Analyzers;
+
+/// <summary>
+/// Roslyn analyzer that detects direct usage of third-party types that should
+/// be accessed through WrapGod-generated wrapper interfaces and facades.
+///
+/// Reads wrapped type mappings from an AdditionalFile named
+/// <c>*.wrapgod-types.txt</c> (one mapping per line):
+///   <c>Acme.Lib.FooService -> IWrappedFooService, FooServiceFacade</c>
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DirectUsageAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(
+            DiagnosticDescriptors.DirectTypeUsage,
+            DiagnosticDescriptors.DirectMethodCall);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationStart =>
+        {
+            var mappings = LoadMappings(compilationStart.Options.AdditionalFiles);
+            if (mappings.Count == 0)
+                return;
+
+            // Build a lookup from fully-qualified type name -> mapping info.
+            var lookup = mappings.ToImmutableDictionary(m => m.OriginalType, StringComparer.Ordinal);
+
+            compilationStart.RegisterSyntaxNodeAction(
+                nodeContext => AnalyzeNode(nodeContext, lookup),
+                SyntaxKind.IdentifierName,
+                SyntaxKind.SimpleMemberAccessExpression);
+        });
+    }
+
+    // ── Node analysis ────────────────────────────────────────────────
+
+    private static void AnalyzeNode(
+        SyntaxNodeAnalysisContext context,
+        ImmutableDictionary<string, WrappedTypeMapping> lookup)
+    {
+        var node = context.Node;
+        var semanticModel = context.SemanticModel;
+
+        switch (node)
+        {
+            case IdentifierNameSyntax identifier:
+                AnalyzeIdentifier(context, identifier, semanticModel, lookup);
+                break;
+            case MemberAccessExpressionSyntax memberAccess:
+                AnalyzeMemberAccess(context, memberAccess, semanticModel, lookup);
+                break;
+        }
+    }
+
+    private static void AnalyzeIdentifier(
+        SyntaxNodeAnalysisContext context,
+        IdentifierNameSyntax identifier,
+        SemanticModel semanticModel,
+        ImmutableDictionary<string, WrappedTypeMapping> lookup)
+    {
+        // Skip identifiers that are part of a member access (handled separately).
+        if (identifier.Parent is MemberAccessExpressionSyntax)
+            return;
+
+        var symbolInfo = semanticModel.GetSymbolInfo(identifier, context.CancellationToken);
+        var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+        if (symbol is null)
+            return;
+
+        var typeSymbol = symbol switch
+        {
+            ITypeSymbol ts => ts,
+            ILocalSymbol ls => ls.Type,
+            IParameterSymbol ps => ps.Type,
+            IFieldSymbol fs => fs.Type,
+            IPropertySymbol ps => ps.Type,
+            _ => null
+        };
+
+        if (typeSymbol is null)
+            return;
+
+        var fullName = GetFullyQualifiedName(typeSymbol);
+        if (lookup.TryGetValue(fullName, out var mapping))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.DirectTypeUsage,
+                identifier.GetLocation(),
+                fullName,
+                mapping.WrapperInterface));
+        }
+    }
+
+    private static void AnalyzeMemberAccess(
+        SyntaxNodeAnalysisContext context,
+        MemberAccessExpressionSyntax memberAccess,
+        SemanticModel semanticModel,
+        ImmutableDictionary<string, WrappedTypeMapping> lookup)
+    {
+        // We only care about method invocations.
+        if (memberAccess.Parent is not InvocationExpressionSyntax)
+            return;
+
+        var symbolInfo = semanticModel.GetSymbolInfo(memberAccess, context.CancellationToken);
+        var symbol = symbolInfo.Symbol as IMethodSymbol;
+        if (symbol is null)
+            return;
+
+        var containingType = symbol.ContainingType;
+        if (containingType is null)
+            return;
+
+        var fullName = GetFullyQualifiedName(containingType);
+        if (lookup.TryGetValue(fullName, out var mapping))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.DirectMethodCall,
+                memberAccess.GetLocation(),
+                symbol.Name,
+                fullName,
+                mapping.FacadeType));
+        }
+    }
+
+    // ── Mapping file parsing ─────────────────────────────────────────
+
+    /// <summary>
+    /// Parses additional files matching <c>*.wrapgod-types.txt</c>.
+    /// Each line: <c>Acme.Lib.FooService -&gt; IWrappedFooService, FooServiceFacade</c>
+    /// </summary>
+    private static List<WrappedTypeMapping> LoadMappings(
+        ImmutableArray<AdditionalText> additionalFiles)
+    {
+        var results = new List<WrappedTypeMapping>();
+
+        foreach (var file in additionalFiles)
+        {
+            if (!Path.GetFileName(file.Path).EndsWith(".wrapgod-types.txt", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var text = file.GetText();
+            if (text is null)
+                continue;
+
+            foreach (var line in text.Lines)
+            {
+                var raw = line.ToString().Trim();
+                if (string.IsNullOrEmpty(raw) || raw.StartsWith("#", StringComparison.Ordinal))
+                    continue;
+
+                // Format: OriginalType -> WrapperInterface, FacadeType
+                var arrowIndex = raw.IndexOf("->", StringComparison.Ordinal);
+                if (arrowIndex < 0)
+                    continue;
+
+                var originalType = raw.Substring(0, arrowIndex).Trim();
+                var rightSide = raw.Substring(arrowIndex + 2).Trim();
+                var parts = rightSide.Split(',');
+                if (parts.Length < 2)
+                    continue;
+
+                results.Add(new WrappedTypeMapping(
+                    originalType,
+                    parts[0].Trim(),
+                    parts[1].Trim()));
+            }
+        }
+
+        return results;
+    }
+
+    private static string GetFullyQualifiedName(ITypeSymbol typeSymbol)
+    {
+        return typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+            .Replace("global::", string.Empty);
+    }
+
+    // ── Mapping model ────────────────────────────────────────────────
+
+    internal sealed class WrappedTypeMapping
+    {
+        public string OriginalType { get; }
+        public string WrapperInterface { get; }
+        public string FacadeType { get; }
+
+        public WrappedTypeMapping(string originalType, string wrapperInterface, string facadeType)
+        {
+            OriginalType = originalType;
+            WrapperInterface = wrapperInterface;
+            FacadeType = facadeType;
+        }
+    }
+}

--- a/WrapGod.Analyzers/WrapGod.Analyzers.csproj
+++ b/WrapGod.Analyzers/WrapGod.Analyzers.csproj
@@ -1,13 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- Release tracking not needed for alpha; suppress RS2008 -->
+    <NoWarn>$(NoWarn);RS2008</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\WrapGod.Manifest\WrapGod.Manifest.csproj" />
     <ProjectReference Include="..\WrapGod.Abstractions\WrapGod.Abstractions.csproj" />
     <ProjectReference Include="..\WrapGod.TypeMap\WrapGod.TypeMap.csproj" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
 
 </Project>

--- a/WrapGod.Tests/AnalyzerTests.cs
+++ b/WrapGod.Tests/AnalyzerTests.cs
@@ -1,0 +1,188 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Analyzers;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("Direct usage analyzer")]
+public sealed class AnalyzerTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private const string MappingFileName = "test.wrapgod-types.txt";
+
+    private static readonly string DefaultMappings =
+        "Acme.Lib.FooService -> IWrappedFooService, FooServiceFacade";
+
+    /// <summary>
+    /// Compiles the given source with the <see cref="DirectUsageAnalyzer"/>
+    /// registered and returns the reported diagnostics.
+    /// </summary>
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
+        string source,
+        string? mappings = null)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+            MetadataReference.CreateFromFile(
+                typeof(System.Runtime.AssemblyTargetedPatchBandAttribute).Assembly.Location),
+        };
+
+        // Add the netstandard reference so netstandard2.0 types resolve.
+        var netStandardPath = System.IO.Path.Combine(
+            System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!,
+            "netstandard.dll");
+        var refList = references.ToList();
+        if (System.IO.File.Exists(netStandardPath))
+            refList.Add(MetadataReference.CreateFromFile(netStandardPath));
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { syntaxTree },
+            refList,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var analyzer = new DirectUsageAnalyzer();
+        var additionalTexts = new AdditionalText[]
+        {
+            new InMemoryAdditionalText(MappingFileName, mappings ?? DefaultMappings),
+        };
+
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer),
+            new AnalyzerOptions(additionalTexts.ToImmutableArray()));
+
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    private static ImmutableArray<Diagnostic> RunDiagnostics(string source, string? mappings = null)
+        => GetDiagnosticsAsync(source, mappings).GetAwaiter().GetResult();
+
+    // ── Source snippets ──────────────────────────────────────────────
+
+    private const string AcmeLibDefinition = """
+        namespace Acme.Lib
+        {
+            public class FooService
+            {
+                public string DoWork(string input) => input;
+            }
+        }
+        """;
+
+    private const string DirectTypeUsageSource = AcmeLibDefinition + """
+
+        namespace MyApp
+        {
+            public class Consumer
+            {
+                private Acme.Lib.FooService _svc = new Acme.Lib.FooService();
+            }
+        }
+        """;
+
+    private const string DirectMethodCallSource = AcmeLibDefinition + """
+
+        namespace MyApp
+        {
+            public class Consumer
+            {
+                public void Run()
+                {
+                    var svc = new Acme.Lib.FooService();
+                    svc.DoWork("hello");
+                }
+            }
+        }
+        """;
+
+    private const string WrapperInterfaceUsageSource = AcmeLibDefinition + """
+
+        namespace MyApp
+        {
+            public interface IWrappedFooService
+            {
+                string DoWork(string input);
+            }
+
+            public class Consumer
+            {
+                private readonly IWrappedFooService _svc;
+
+                public Consumer(IWrappedFooService svc)
+                {
+                    _svc = svc;
+                }
+
+                public void Run()
+                {
+                    _svc.DoWork("hello");
+                }
+            }
+        }
+        """;
+
+    // ── Scenarios ────────────────────────────────────────────────────
+
+    [Scenario("Direct type usage reports WG2001")]
+    [Fact]
+    public Task DirectTypeUsage_ReportsWG2001()
+        => Given("source code that uses a wrapped type directly",
+                () => RunDiagnostics(DirectTypeUsageSource))
+            .Then("at least one WG2001 diagnostic is reported", diagnostics =>
+                diagnostics.Any(d => d.Id == "WG2001"))
+            .And("the diagnostic message mentions FooService", diagnostics =>
+                diagnostics.First(d => d.Id == "WG2001")
+                    .GetMessage(System.Globalization.CultureInfo.InvariantCulture).Contains("FooService", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Direct method call reports WG2002")]
+    [Fact]
+    public Task DirectMethodCall_ReportsWG2002()
+        => Given("source code that calls a method on a wrapped type",
+                () => RunDiagnostics(DirectMethodCallSource))
+            .Then("at least one WG2002 diagnostic is reported", diagnostics =>
+                diagnostics.Any(d => d.Id == "WG2002"))
+            .And("the diagnostic message mentions DoWork", diagnostics =>
+                diagnostics.First(d => d.Id == "WG2002")
+                    .GetMessage(System.Globalization.CultureInfo.InvariantCulture).Contains("DoWork", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Usage through wrapper interface reports no diagnostic")]
+    [Fact]
+    public Task WrapperInterfaceUsage_ReportsNoDiagnostic()
+        => Given("source code that uses the wrapper interface",
+                () => RunDiagnostics(WrapperInterfaceUsageSource))
+            .Then("no WG2001 diagnostics are reported", diagnostics =>
+                !diagnostics.Any(d => d.Id == "WG2001"))
+            .And("no WG2002 diagnostics are reported", diagnostics =>
+                !diagnostics.Any(d => d.Id == "WG2002"))
+            .AssertPassed();
+
+    // ── In-memory AdditionalText ─────────────────────────────────────
+
+    private sealed class InMemoryAdditionalText : AdditionalText
+    {
+        private readonly SourceText _text;
+
+        public InMemoryAdditionalText(string path, string content)
+        {
+            Path = path;
+            _text = SourceText.From(content);
+        }
+
+        public override string Path { get; }
+
+        public override SourceText? GetText(CancellationToken cancellationToken = default) => _text;
+    }
+}


### PR DESCRIPTION
## Summary
- **WG2001**: Warns when a wrapped third-party type is used directly instead of through its generated wrapper interface
- **WG2002**: Warns when a method on a wrapped third-party type is called directly instead of through its generated facade
- Mappings are loaded from `*.wrapgod-types.txt` AdditionalFiles (format: `Acme.Lib.FooService -> IWrappedFooService, FooServiceFacade`)
- Added `Microsoft.CodeAnalysis.CSharp` package reference to `WrapGod.Analyzers` project
- 3 TinyBDD/PatternKit-style tests covering direct type usage, direct method call, and clean wrapper interface usage

Closes #13

## Test plan
- [x] `DirectTypeUsage_ReportsWG2001` — direct type reference triggers WG2001
- [x] `DirectMethodCall_ReportsWG2002` — direct method call triggers WG2002
- [x] `WrapperInterfaceUsage_ReportsNoDiagnostic` — usage through interface produces zero diagnostics
- [x] Full test suite passes (61/61)

🤖 Generated with [Claude Code](https://claude.com/claude-code)