### PR TITLE
feat: compatibility generation modes (LCD, targeted, adaptive)

### DIFF
--- a/WrapGod.Generator/CompatibilityFilter.cs
+++ b/WrapGod.Generator/CompatibilityFilter.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+
+namespace WrapGod.Generator;
+
+/// <summary>
+/// Filters a <see cref="GenerationPlan"/> based on a <see cref="CompatibilityMode"/>.
+/// </summary>
+internal static class CompatibilityFilter
+{
+    /// <summary>
+    /// Apply the given compatibility mode to a generation plan, returning a
+    /// new plan that contains only the types and members appropriate for the mode.
+    /// </summary>
+    /// <param name="plan">The full generation plan with version metadata.</param>
+    /// <param name="mode">The compatibility mode to apply.</param>
+    /// <param name="versions">Ordered list of all known versions (earliest first).</param>
+    /// <param name="targetVersion">
+    /// Required when <paramref name="mode"/> is <see cref="CompatibilityMode.Targeted"/>;
+    /// ignored otherwise.
+    /// </param>
+    public static GenerationPlan Apply(
+        GenerationPlan plan,
+        CompatibilityMode mode,
+        IReadOnlyList<string> versions,
+        string? targetVersion = null)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+        if (versions is null || versions.Count == 0) throw new ArgumentException("At least one version is required.", nameof(versions));
+
+        if (mode == CompatibilityMode.Targeted && string.IsNullOrEmpty(targetVersion))
+        {
+            throw new ArgumentException("A target version must be specified for Targeted mode.", nameof(targetVersion));
+        }
+
+        string earliestVersion = versions[0];
+
+        var filteredTypes = new List<TypePlan>();
+
+        foreach (var type in plan.Types)
+        {
+            TypePlan? filtered = FilterType(type, mode, versions, earliestVersion, targetVersion);
+            if (filtered != null)
+            {
+                filteredTypes.Add(filtered);
+            }
+        }
+
+        return new GenerationPlan(plan.AssemblyName, filteredTypes);
+    }
+
+    private static TypePlan? FilterType(
+        TypePlan type,
+        CompatibilityMode mode,
+        IReadOnlyList<string> versions,
+        string earliestVersion,
+        string? targetVersion)
+    {
+        // Check type-level presence
+        if (mode == CompatibilityMode.Lcd)
+        {
+            // LCD: type must be present in all versions (introduced at earliest, never removed)
+            if (!IsLcdPresent(type.IntroducedIn, type.RemovedIn, earliestVersion))
+                return null;
+        }
+        else if (mode == CompatibilityMode.Targeted)
+        {
+            if (!IsPresentInVersion(type.IntroducedIn, type.RemovedIn, targetVersion!, versions))
+                return null;
+        }
+        // Adaptive: keep all types
+
+        var filteredMembers = new List<MemberPlan>();
+
+        foreach (var member in type.Members)
+        {
+            if (mode == CompatibilityMode.Lcd)
+            {
+                if (IsLcdPresent(member.IntroducedIn, member.RemovedIn, earliestVersion))
+                {
+                    filteredMembers.Add(member);
+                }
+            }
+            else if (mode == CompatibilityMode.Targeted)
+            {
+                if (IsPresentInVersion(member.IntroducedIn, member.RemovedIn, targetVersion!, versions))
+                {
+                    filteredMembers.Add(member);
+                }
+            }
+            else
+            {
+                // Adaptive: keep all members (version metadata is already on the MemberPlan)
+                filteredMembers.Add(member);
+            }
+        }
+
+        return new TypePlan(type.FullName, type.Name, type.Namespace, filteredMembers, type.IntroducedIn, type.RemovedIn);
+    }
+
+    /// <summary>
+    /// LCD rule: present in all versions means introduced at the earliest
+    /// version and never removed.
+    /// </summary>
+    private static bool IsLcdPresent(string? introducedIn, string? removedIn, string earliestVersion)
+    {
+        // If no version metadata, treat as present in all versions
+        if (introducedIn is null)
+            return true;
+
+        return introducedIn == earliestVersion && removedIn is null;
+    }
+
+    /// <summary>
+    /// Targeted rule: the member must have been introduced at or before the
+    /// target version and not removed at or before the target version.
+    /// </summary>
+    private static bool IsPresentInVersion(
+        string? introducedIn,
+        string? removedIn,
+        string targetVersion,
+        IReadOnlyList<string> versions)
+    {
+        // If no version metadata, treat as present in all versions
+        if (introducedIn is null)
+            return true;
+
+        int targetIndex = IndexOf(versions, targetVersion);
+        int introducedIndex = IndexOf(versions, introducedIn);
+
+        // Not introduced yet at the target version
+        if (introducedIndex < 0 || targetIndex < 0)
+            return false;
+
+        if (introducedIndex > targetIndex)
+            return false;
+
+        // Check if removed before or at the target version
+        if (removedIn != null)
+        {
+            int removedIndex = IndexOf(versions, removedIn);
+            if (removedIndex >= 0 && removedIndex <= targetIndex)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static int IndexOf(IReadOnlyList<string> list, string value)
+    {
+        for (int i = 0; i < list.Count; i++)
+        {
+            if (string.Equals(list[i], value, StringComparison.Ordinal))
+                return i;
+        }
+
+        return -1;
+    }
+}

--- a/WrapGod.Generator/CompatibilityMode.cs
+++ b/WrapGod.Generator/CompatibilityMode.cs
@@ -1,0 +1,25 @@
+namespace WrapGod.Generator;
+
+/// <summary>
+/// Controls how the generator handles members that exist in only a subset
+/// of the targeted API versions.
+/// </summary>
+internal enum CompatibilityMode
+{
+    /// <summary>
+    /// Lowest Common Denominator: emit only members present in ALL versions
+    /// (introduced in the earliest version and never removed).
+    /// </summary>
+    Lcd,
+
+    /// <summary>
+    /// Targeted: emit members present in a single selected version.
+    /// </summary>
+    Targeted,
+
+    /// <summary>
+    /// Adaptive: emit all members, decorating version-specific ones with
+    /// runtime availability guards so callers can branch on version.
+    /// </summary>
+    Adaptive,
+}

--- a/WrapGod.Generator/GeneratorModels.cs
+++ b/WrapGod.Generator/GeneratorModels.cs
@@ -57,12 +57,32 @@ internal sealed class TypePlan : IEquatable<TypePlan>
     public string Namespace { get; }
     public IReadOnlyList<MemberPlan> Members { get; }
 
-    public TypePlan(string fullName, string name, string ns, IReadOnlyList<MemberPlan> members)
+    /// <summary>
+    /// Version in which this type first appeared, or <c>null</c> when
+    /// version metadata is not available.
+    /// </summary>
+    public string? IntroducedIn { get; }
+
+    /// <summary>
+    /// Version in which this type was removed, or <c>null</c> if it is
+    /// still present in the latest version.
+    /// </summary>
+    public string? RemovedIn { get; }
+
+    public TypePlan(
+        string fullName,
+        string name,
+        string ns,
+        IReadOnlyList<MemberPlan> members,
+        string? introducedIn = null,
+        string? removedIn = null)
     {
         FullName = fullName;
         Name = name;
         Namespace = ns;
         Members = members;
+        IntroducedIn = introducedIn;
+        RemovedIn = removedIn;
     }
 
     public bool Equals(TypePlan? other)
@@ -70,6 +90,7 @@ internal sealed class TypePlan : IEquatable<TypePlan>
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
         if (FullName != other.FullName || Name != other.Name || Namespace != other.Namespace) return false;
+        if (IntroducedIn != other.IntroducedIn || RemovedIn != other.RemovedIn) return false;
         if (Members.Count != other.Members.Count) return false;
 
         for (int i = 0; i < Members.Count; i++)
@@ -87,6 +108,8 @@ internal sealed class TypePlan : IEquatable<TypePlan>
         int hash = FullName.GetHashCode();
         hash = (hash * 397) ^ Name.GetHashCode();
         hash = (hash * 397) ^ Namespace.GetHashCode();
+        if (IntroducedIn != null) hash = (hash * 397) ^ IntroducedIn.GetHashCode();
+        if (RemovedIn != null) hash = (hash * 397) ^ RemovedIn.GetHashCode();
         foreach (var m in Members)
         {
             hash = (hash * 397) ^ m.GetHashCode();
@@ -110,6 +133,18 @@ internal sealed class MemberPlan : IEquatable<MemberPlan>
     public bool IsStatic { get; }
     public IReadOnlyList<string> GenericParameters { get; }
 
+    /// <summary>
+    /// Version in which this member first appeared, or <c>null</c> when
+    /// version metadata is not available.
+    /// </summary>
+    public string? IntroducedIn { get; }
+
+    /// <summary>
+    /// Version in which this member was removed, or <c>null</c> if it is
+    /// still present in the latest version.
+    /// </summary>
+    public string? RemovedIn { get; }
+
     public MemberPlan(
         string name,
         string kind,
@@ -118,7 +153,9 @@ internal sealed class MemberPlan : IEquatable<MemberPlan>
         bool hasGetter,
         bool hasSetter,
         bool isStatic = false,
-        IReadOnlyList<string>? genericParameters = null)
+        IReadOnlyList<string>? genericParameters = null,
+        string? introducedIn = null,
+        string? removedIn = null)
     {
         Name = name;
         Kind = kind;
@@ -128,6 +165,8 @@ internal sealed class MemberPlan : IEquatable<MemberPlan>
         HasSetter = hasSetter;
         IsStatic = isStatic;
         GenericParameters = genericParameters ?? Array.Empty<string>();
+        IntroducedIn = introducedIn;
+        RemovedIn = removedIn;
     }
 
     public bool Equals(MemberPlan? other)
@@ -137,6 +176,7 @@ internal sealed class MemberPlan : IEquatable<MemberPlan>
         if (Name != other.Name || Kind != other.Kind || ReturnType != other.ReturnType) return false;
         if (HasGetter != other.HasGetter || HasSetter != other.HasSetter) return false;
         if (IsStatic != other.IsStatic) return false;
+        if (IntroducedIn != other.IntroducedIn || RemovedIn != other.RemovedIn) return false;
         if (Parameters.Count != other.Parameters.Count) return false;
         if (GenericParameters.Count != other.GenericParameters.Count) return false;
 
@@ -161,6 +201,8 @@ internal sealed class MemberPlan : IEquatable<MemberPlan>
         hash = (hash * 397) ^ Kind.GetHashCode();
         hash = (hash * 397) ^ ReturnType.GetHashCode();
         hash = (hash * 397) ^ IsStatic.GetHashCode();
+        if (IntroducedIn != null) hash = (hash * 397) ^ IntroducedIn.GetHashCode();
+        if (RemovedIn != null) hash = (hash * 397) ^ RemovedIn.GetHashCode();
         return hash;
     }
 }

--- a/WrapGod.Generator/SourceEmitter.cs
+++ b/WrapGod.Generator/SourceEmitter.cs
@@ -13,6 +13,12 @@ internal static class SourceEmitter
     private const string GeneratedNamespace = "WrapGod.Generated";
 
     /// <summary>
+    /// When <c>true</c>, the emitter wraps version-specific facade members
+    /// with runtime availability checks (used in Adaptive mode).
+    /// </summary>
+    public static bool AdaptiveMode { get; set; }
+
+    /// <summary>
     /// Emits an interface source file for the given type plan.
     /// The interface name follows the pattern <c>IWrapped{TypeName}</c>.
     /// </summary>
@@ -108,6 +114,8 @@ internal static class SourceEmitter
 
     private static void EmitFacadeMember(StringBuilder sb, MemberPlan member)
     {
+        bool needsGuard = AdaptiveMode && member.IntroducedIn != null;
+
         if (member.Kind == "property")
         {
             sb.Append("    public ").Append(member.ReturnType).Append(' ').Append(member.Name);
@@ -115,30 +123,129 @@ internal static class SourceEmitter
             sb.AppendLine("    {");
             if (member.HasGetter)
             {
-                sb.Append("        get => _inner.").Append(member.Name).AppendLine(";");
+                if (needsGuard)
+                {
+                    EmitVersionGuardedPropertyGetter(sb, member);
+                }
+                else
+                {
+                    sb.Append("        get => _inner.").Append(member.Name).AppendLine(";");
+                }
             }
 
             if (member.HasSetter)
             {
-                sb.Append("        set => _inner.").Append(member.Name).AppendLine(" = value;");
+                if (needsGuard)
+                {
+                    EmitVersionGuardedPropertySetter(sb, member);
+                }
+                else
+                {
+                    sb.Append("        set => _inner.").Append(member.Name).AppendLine(" = value;");
+                }
             }
 
             sb.AppendLine("    }");
         }
         else
         {
-            // Method -- expression-bodied forwarding works for both void and non-void
-            sb.Append("    public ").Append(member.ReturnType).Append(' ').Append(member.Name);
-            AppendGenericParameters(sb, member.GenericParameters);
-            sb.Append('(');
-            AppendParameters(sb, member.Parameters);
-            sb.AppendLine(")");
-            sb.Append("        => _inner.").Append(member.Name);
-            AppendGenericParameters(sb, member.GenericParameters);
-            sb.Append('(');
-            AppendArguments(sb, member.Parameters);
-            sb.AppendLine(");");
+            if (needsGuard)
+            {
+                EmitVersionGuardedMethod(sb, member);
+            }
+            else
+            {
+                // Method -- expression-bodied forwarding works for both void and non-void
+                sb.Append("    public ").Append(member.ReturnType).Append(' ').Append(member.Name);
+                AppendGenericParameters(sb, member.GenericParameters);
+                sb.Append('(');
+                AppendParameters(sb, member.Parameters);
+                sb.AppendLine(")");
+                sb.Append("        => _inner.").Append(member.Name);
+                AppendGenericParameters(sb, member.GenericParameters);
+                sb.Append('(');
+                AppendArguments(sb, member.Parameters);
+                sb.AppendLine(");");
+            }
         }
+    }
+
+    private static string BuildAvailabilityComment(MemberPlan member)
+    {
+        var parts = new StringBuilder();
+        parts.Append("Available since ").Append(member.IntroducedIn);
+        if (member.RemovedIn != null)
+        {
+            parts.Append(", removed in ").Append(member.RemovedIn);
+        }
+
+        return parts.ToString();
+    }
+
+    private static void EmitVersionGuardedPropertyGetter(StringBuilder sb, MemberPlan member)
+    {
+        sb.Append("        // ").AppendLine(BuildAvailabilityComment(member));
+        sb.AppendLine("        get");
+        sb.AppendLine("        {");
+        sb.Append("            if (!WrapGodVersionHelper.IsMemberAvailable(\"")
+            .Append(member.IntroducedIn).Append("\", ");
+        if (member.RemovedIn != null)
+            sb.Append('"').Append(member.RemovedIn).Append('"');
+        else
+            sb.Append("null");
+        sb.AppendLine("))");
+        sb.Append("                throw new System.PlatformNotSupportedException(\"")
+            .Append(member.Name).AppendLine(" is not available in the current version.\");");
+        sb.Append("            return _inner.").Append(member.Name).AppendLine(";");
+        sb.AppendLine("        }");
+    }
+
+    private static void EmitVersionGuardedPropertySetter(StringBuilder sb, MemberPlan member)
+    {
+        sb.Append("        // ").AppendLine(BuildAvailabilityComment(member));
+        sb.AppendLine("        set");
+        sb.AppendLine("        {");
+        sb.Append("            if (!WrapGodVersionHelper.IsMemberAvailable(\"")
+            .Append(member.IntroducedIn).Append("\", ");
+        if (member.RemovedIn != null)
+            sb.Append('"').Append(member.RemovedIn).Append('"');
+        else
+            sb.Append("null");
+        sb.AppendLine("))");
+        sb.Append("                throw new System.PlatformNotSupportedException(\"")
+            .Append(member.Name).AppendLine(" is not available in the current version.\");");
+        sb.Append("            _inner.").Append(member.Name).AppendLine(" = value;");
+        sb.AppendLine("        }");
+    }
+
+    private static void EmitVersionGuardedMethod(StringBuilder sb, MemberPlan member)
+    {
+        sb.Append("    // ").AppendLine(BuildAvailabilityComment(member));
+        sb.Append("    public ").Append(member.ReturnType).Append(' ').Append(member.Name);
+        AppendGenericParameters(sb, member.GenericParameters);
+        sb.Append('(');
+        AppendParameters(sb, member.Parameters);
+        sb.AppendLine(")");
+        sb.AppendLine("    {");
+        sb.Append("        if (!WrapGodVersionHelper.IsMemberAvailable(\"")
+            .Append(member.IntroducedIn).Append("\", ");
+        if (member.RemovedIn != null)
+            sb.Append('"').Append(member.RemovedIn).Append('"');
+        else
+            sb.Append("null");
+        sb.AppendLine("))");
+        sb.Append("            throw new System.PlatformNotSupportedException(\"")
+            .Append(member.Name).AppendLine(" is not available in the current version.\");");
+
+        bool isVoid = member.ReturnType == "void" || member.ReturnType == "System.Void";
+        sb.Append("        ");
+        if (!isVoid) sb.Append("return ");
+        sb.Append("_inner.").Append(member.Name);
+        AppendGenericParameters(sb, member.GenericParameters);
+        sb.Append('(');
+        AppendArguments(sb, member.Parameters);
+        sb.AppendLine(");");
+        sb.AppendLine("    }");
     }
 
     private static void AppendGenericParameters(StringBuilder sb, IReadOnlyList<string> genericParameters)

--- a/WrapGod.Generator/WrapGod.Generator.csproj
+++ b/WrapGod.Generator/WrapGod.Generator.csproj
@@ -18,4 +18,8 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="WrapGod.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/WrapGod.Tests/CompatibilityModeTests.cs
+++ b/WrapGod.Tests/CompatibilityModeTests.cs
@@ -1,0 +1,260 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Generator;
+using Xunit.Abstractions;
+using GenerationPlan = WrapGod.Generator.GenerationPlan;
+using TypePlan = WrapGod.Generator.TypePlan;
+using MemberPlan = WrapGod.Generator.MemberPlan;
+using ParameterPlan = WrapGod.Generator.ParameterPlan;
+
+namespace WrapGod.Tests;
+
+[Feature("Compatibility generation modes: LCD, targeted, adaptive")]
+public sealed class CompatibilityModeTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static readonly string[] Versions = ["1.0", "2.0", "3.0"];
+
+    /// <summary>
+    /// Creates a plan with three members:
+    /// - CommonMethod: introduced in 1.0, never removed (present in all)
+    /// - NewMethod: introduced in 2.0, never removed (present in 2.0+)
+    /// - DeprecatedMethod: introduced in 1.0, removed in 3.0 (present in 1.0 and 2.0)
+    /// </summary>
+    private static GenerationPlan CreateTestPlan()
+    {
+        var members = new List<MemberPlan>
+        {
+            new MemberPlan(
+                name: "CommonMethod",
+                kind: "method",
+                returnType: "void",
+                parameters: Array.Empty<ParameterPlan>(),
+                hasGetter: false,
+                hasSetter: false,
+                introducedIn: "1.0",
+                removedIn: null),
+            new MemberPlan(
+                name: "NewMethod",
+                kind: "method",
+                returnType: "string",
+                parameters: Array.Empty<ParameterPlan>(),
+                hasGetter: false,
+                hasSetter: false,
+                introducedIn: "2.0",
+                removedIn: null),
+            new MemberPlan(
+                name: "DeprecatedMethod",
+                kind: "method",
+                returnType: "int",
+                parameters: Array.Empty<ParameterPlan>(),
+                hasGetter: false,
+                hasSetter: false,
+                introducedIn: "1.0",
+                removedIn: "3.0"),
+        };
+
+        var type = new TypePlan(
+            "MyNamespace.MyClass", "MyClass", "MyNamespace", members,
+            introducedIn: "1.0", removedIn: null);
+
+        return new GenerationPlan("TestAssembly", new[] { type });
+    }
+
+    /// <summary>
+    /// Creates a plan with two types:
+    /// - StableType: present in all versions
+    /// - NewType: introduced in 2.0 only
+    /// </summary>
+    private static GenerationPlan CreateMultiTypePlan()
+    {
+        var stableMembers = new List<MemberPlan>
+        {
+            new MemberPlan("Run", "method", "void", Array.Empty<ParameterPlan>(),
+                false, false, introducedIn: "1.0", removedIn: null),
+        };
+        var newMembers = new List<MemberPlan>
+        {
+            new MemberPlan("Execute", "method", "void", Array.Empty<ParameterPlan>(),
+                false, false, introducedIn: "2.0", removedIn: null),
+        };
+
+        var stableType = new TypePlan(
+            "MyNamespace.StableType", "StableType", "MyNamespace", stableMembers,
+            introducedIn: "1.0", removedIn: null);
+        var newType = new TypePlan(
+            "MyNamespace.NewType", "NewType", "MyNamespace", newMembers,
+            introducedIn: "2.0", removedIn: null);
+
+        return new GenerationPlan("TestAssembly", new[] { stableType, newType });
+    }
+
+    private static GenerationPlan ApplyLcd()
+    {
+        return CompatibilityFilter.Apply(CreateTestPlan(), CompatibilityMode.Lcd, Versions);
+    }
+
+    private static GenerationPlan ApplyTargetedV2()
+    {
+        return CompatibilityFilter.Apply(CreateTestPlan(), CompatibilityMode.Targeted, Versions, "2.0");
+    }
+
+    private static GenerationPlan ApplyTargetedV1()
+    {
+        return CompatibilityFilter.Apply(CreateTestPlan(), CompatibilityMode.Targeted, Versions, "1.0");
+    }
+
+    private static GenerationPlan ApplyAdaptive()
+    {
+        return CompatibilityFilter.Apply(CreateTestPlan(), CompatibilityMode.Adaptive, Versions);
+    }
+
+    private static GenerationPlan ApplyLcdMultiType()
+    {
+        return CompatibilityFilter.Apply(CreateMultiTypePlan(), CompatibilityMode.Lcd, Versions);
+    }
+
+    // ── LCD Scenarios ────────────────────────────────────────────────
+
+    [Scenario("LCD mode filters to only members present in all versions")]
+    [Fact]
+    public Task Lcd_FiltersToCommonMembers()
+        => Given("a plan with common, new, and deprecated members", ApplyLcd)
+            .Then("only one member remains", plan =>
+                plan.Types.Count == 1 && plan.Types[0].Members.Count == 1)
+            .And("the remaining member is CommonMethod", plan =>
+                plan.Types[0].Members[0].Name == "CommonMethod")
+            .AssertPassed();
+
+    [Scenario("LCD mode filters out types not present in all versions")]
+    [Fact]
+    public Task Lcd_FiltersOutNewTypes()
+        => Given("a plan with a stable type and a type introduced in 2.0", ApplyLcdMultiType)
+            .Then("only the stable type remains", plan =>
+                plan.Types.Count == 1 && plan.Types[0].Name == "StableType")
+            .AssertPassed();
+
+    // ── Targeted Scenarios ───────────────────────────────────────────
+
+    [Scenario("Targeted mode keeps only members present in the target version")]
+    [Fact]
+    public Task Targeted_KeepsTargetVersionMembers()
+        => Given("a plan filtered for version 2.0", ApplyTargetedV2)
+            .Then("all three members remain (all present at 2.0)", plan =>
+                plan.Types[0].Members.Count == 3)
+            .And("CommonMethod is included", plan =>
+                plan.Types[0].Members.Any(m => m.Name == "CommonMethod"))
+            .And("NewMethod is included", plan =>
+                plan.Types[0].Members.Any(m => m.Name == "NewMethod"))
+            .And("DeprecatedMethod is included (not yet removed at 2.0)", plan =>
+                plan.Types[0].Members.Any(m => m.Name == "DeprecatedMethod"))
+            .AssertPassed();
+
+    [Scenario("Targeted mode for v1 excludes members not yet introduced")]
+    [Fact]
+    public Task Targeted_V1_ExcludesNewMembers()
+        => Given("a plan filtered for version 1.0", ApplyTargetedV1)
+            .Then("two members remain (CommonMethod and DeprecatedMethod)", plan =>
+                plan.Types[0].Members.Count == 2)
+            .And("NewMethod is excluded", plan =>
+                !plan.Types[0].Members.Any(m => m.Name == "NewMethod"))
+            .AssertPassed();
+
+    [Scenario("Targeted mode throws when no target version is specified")]
+    [Fact]
+    public Task Targeted_ThrowsWithoutTargetVersion()
+        => Given("a plan and targeted mode with no target version", CreateTestPlan)
+            .Then("an ArgumentException is thrown", plan =>
+            {
+                try
+                {
+                    CompatibilityFilter.Apply(plan, CompatibilityMode.Targeted, Versions);
+                    return false;
+                }
+                catch (ArgumentException)
+                {
+                    return true;
+                }
+            })
+            .AssertPassed();
+
+    // ── Adaptive Scenarios ───────────────────────────────────────────
+
+    [Scenario("Adaptive mode includes all members with version metadata")]
+    [Fact]
+    public Task Adaptive_IncludesAllMembers()
+        => Given("a plan filtered in adaptive mode", ApplyAdaptive)
+            .Then("all three members remain", plan =>
+                plan.Types[0].Members.Count == 3)
+            .And("NewMethod retains its IntroducedIn metadata", plan =>
+                plan.Types[0].Members.Any(m =>
+                    m.Name == "NewMethod" && m.IntroducedIn == "2.0"))
+            .And("DeprecatedMethod retains its RemovedIn metadata", plan =>
+                plan.Types[0].Members.Any(m =>
+                    m.Name == "DeprecatedMethod" && m.RemovedIn == "3.0"))
+            .AssertPassed();
+
+    [Scenario("Adaptive mode emits runtime version guards in facade source")]
+    [Fact]
+    public Task Adaptive_EmitsVersionGuards()
+        => Given("a type plan with version-specific members", () =>
+            {
+                var members = new List<MemberPlan>
+                {
+                    new MemberPlan("NewMethod", "method", "string",
+                        Array.Empty<ParameterPlan>(), false, false,
+                        introducedIn: "2.0", removedIn: null),
+                };
+                return new TypePlan("MyNamespace.MyClass", "MyClass", "MyNamespace", members,
+                    introducedIn: "1.0", removedIn: null);
+            })
+            .Then("the facade source contains a version availability check", type =>
+            {
+                bool previousMode = SourceEmitter.AdaptiveMode;
+                try
+                {
+                    SourceEmitter.AdaptiveMode = true;
+                    string source = SourceEmitter.EmitFacade(type);
+                    return source.Contains("WrapGodVersionHelper.IsMemberAvailable")
+                        && source.Contains("PlatformNotSupportedException")
+                        && source.Contains("Available since 2.0");
+                }
+                finally
+                {
+                    SourceEmitter.AdaptiveMode = previousMode;
+                }
+            })
+            .AssertPassed();
+
+    [Scenario("Non-adaptive mode does not emit version guards")]
+    [Fact]
+    public Task NonAdaptive_NoVersionGuards()
+        => Given("a type plan with version-specific members", () =>
+            {
+                var members = new List<MemberPlan>
+                {
+                    new MemberPlan("NewMethod", "method", "string",
+                        Array.Empty<ParameterPlan>(), false, false,
+                        introducedIn: "2.0", removedIn: null),
+                };
+                return new TypePlan("MyNamespace.MyClass", "MyClass", "MyNamespace", members,
+                    introducedIn: "1.0", removedIn: null);
+            })
+            .Then("the facade source does not contain version guards", type =>
+            {
+                bool previousMode = SourceEmitter.AdaptiveMode;
+                try
+                {
+                    SourceEmitter.AdaptiveMode = false;
+                    string source = SourceEmitter.EmitFacade(type);
+                    return !source.Contains("WrapGodVersionHelper.IsMemberAvailable")
+                        && !source.Contains("PlatformNotSupportedException");
+                }
+                finally
+                {
+                    SourceEmitter.AdaptiveMode = previousMode;
+                }
+            })
+            .AssertPassed();
+}


### PR DESCRIPTION
## Summary
- Add `CompatibilityMode` enum (LCD, Targeted, Adaptive) and `CompatibilityFilter` that filters a `GenerationPlan` based on mode
- LCD keeps only members present in all versions (introduced at earliest, never removed); Targeted keeps members present in a single selected version; Adaptive keeps all members with runtime version-availability guards
- Extend `TypePlan` and `MemberPlan` with `IntroducedIn`/`RemovedIn` version metadata; update `SourceEmitter` to emit `WrapGodVersionHelper.IsMemberAvailable` guards and `PlatformNotSupportedException` throws in adaptive mode
- Add `InternalsVisibleTo` for test access and 8 TinyBDD scenarios covering all three modes plus emitter guard behavior

## Test plan
- [x] LCD mode filters to common members only
- [x] LCD mode filters out types not present in all versions
- [x] Targeted mode keeps all members present at target version
- [x] Targeted mode for v1 excludes members not yet introduced
- [x] Targeted mode throws without a target version
- [x] Adaptive mode includes all members with version metadata
- [x] Adaptive mode emits runtime version guards in facade source
- [x] Non-adaptive mode does not emit version guards
- [x] All 69 existing tests continue to pass

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)