### PR TITLE
docs: developer documentation and examples for MVP onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,59 @@
 # WrapGod
 
-WrapGod is a .NET platform for generating wrapper interfaces, facades, adapters, and migration tooling over third-party APIs.
+WrapGod is a .NET platform for generating wrapper interfaces, facades, adapters, and migration tooling over third-party APIs. It gives teams a systematic way to decouple application code from vendor libraries so that upgrades, swaps, and multi-version support become manageable.
 
-## Vision
+## Features
 
-WrapGod helps teams:
+- **Manifest extraction** -- interrogate any .NET assembly and produce a complete JSON manifest of its public API surface (types, members, generics, parameters).
+- **Multi-version support** -- extract and merge manifests from multiple assembly versions with automatic diffing, breaking-change detection, and version presence metadata.
+- **Three configuration surfaces** -- define wrapper rules via JSON config files, C# attributes (`[WrapType]`, `[WrapMember]`), or a fluent DSL, with configurable merge precedence when combining sources.
+- **Incremental source generation** -- a Roslyn incremental generator reads `*.wrapgod.json` manifests and emits `IWrapped{Type}` interfaces and `{Type}Facade` delegating classes at build time.
+- **Compatibility modes** -- control the generated surface with LCD (lowest common denominator), Targeted (single version), or Adaptive (runtime version guards) modes.
+- **Roslyn analyzers and code fixes** -- detect direct usage of wrapped third-party types (`WG2001`) and methods (`WG2002`), then auto-migrate call sites with one-click or Fix All support.
+- **Type mapping** -- plan source-to-destination type transformations for generated wrapper signatures.
 
-- extract full API manifests from external assemblies (including multiple versions)
-- define mapping rules via attributes, fluent config, and JSON
-- source-generate wrappers/facades/proxies onto internal contracts
-- auto-migrate direct third-party usages via Roslyn analyzers + code fixes
-- map third-party types to internal types with generated mappers
+## Quick start
 
-## Solution Structure
+```bash
+# Install packages
+dotnet add package WrapGod.Extractor
+dotnet add package WrapGod.Generator
 
-- `WrapGod.Abstractions` - public attributes and contracts
-- `WrapGod.Manifest` - manifest schema + version/diff models
-- `WrapGod.Extractor` - assembly interrogation + manifest generation
-- `WrapGod.Generator` - incremental source generator for wrappers/facades
-- `WrapGod.TypeMap` - type mapping contracts and mapping planner
-- `WrapGod.Analyzers` - diagnostics and code fixes for migrations
-- `WrapGod.Fluent` - fluent configuration DSL
-- `WrapGod.Runtime` - optional runtime helpers/adapters
-- `WrapGod.Tests` - unit/integration/snapshot tests
+# Extract a manifest
+# (see docs/QUICKSTART.md for the full C# walkthrough)
+```
+
+See the [Quick Start Guide](docs/QUICKSTART.md) for a complete walkthrough
+covering extraction, configuration, generation, and migration.
+
+## Solution structure
+
+| Project | Description |
+|---------|-------------|
+| `WrapGod.Abstractions` | Public attributes (`[WrapType]`, `[WrapMember]`) and config contracts |
+| `WrapGod.Manifest` | Manifest schema, serialization, JSON config loader, attribute reader, merge engine |
+| `WrapGod.Extractor` | Assembly interrogation, single- and multi-version manifest extraction |
+| `WrapGod.Generator` | Roslyn incremental source generator for wrapper interfaces and facades |
+| `WrapGod.TypeMap` | Type mapping contracts and mapping planner |
+| `WrapGod.Analyzers` | Roslyn diagnostics (WG2001, WG2002) and automatic code fixes |
+| `WrapGod.Fluent` | Fluent configuration DSL |
+| `WrapGod.Runtime` | Optional runtime helpers and adapters |
+| `WrapGod.Tests` | Unit, integration, and snapshot tests |
+
+## Documentation
+
+- [Quick Start Guide](docs/QUICKSTART.md) -- end-to-end onboarding walkthrough
+- [Manifest Format Reference](docs/MANIFEST.md) -- schema, type/member nodes, version metadata
+- [Configuration Guide](docs/CONFIGURATION.md) -- JSON, attributes, fluent DSL, merge precedence
+- [Compatibility Modes](docs/COMPATIBILITY.md) -- LCD, Targeted, and Adaptive modes
+- [Analyzer Diagnostics Reference](docs/ANALYZERS.md) -- WG2001, WG2002, code fixes, suppression
 
 ## Engineering
 
-- SDK + build conventions: `docs/ENGINEERING.md`
-- Initial milestones: `docs/PLAN.md` and `docs/WORK-BREAKDOWN.md`
+- SDK and build conventions: [`docs/ENGINEERING.md`](docs/ENGINEERING.md)
+- Architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+- Initial milestones: [`docs/PLAN.md`](docs/PLAN.md) and [`docs/WORK-BREAKDOWN.md`](docs/WORK-BREAKDOWN.md)
+
+## License
+
+MIT

--- a/docs/ANALYZERS.md
+++ b/docs/ANALYZERS.md
@@ -1,0 +1,184 @@
+# Analyzer Diagnostics Reference
+
+WrapGod ships a Roslyn analyzer (`WrapGod.Analyzers`) that detects direct
+usage of third-party types and methods that should be accessed through
+generated wrapper interfaces and facades. It also provides automatic code
+fixes to migrate call sites.
+
+## Setup
+
+### 1. Add the analyzer package
+
+```xml
+<ItemGroup>
+  <PackageReference Include="WrapGod.Analyzers"
+                    OutputItemType="Analyzer"
+                    ReferenceOutputAssembly="false" />
+</ItemGroup>
+```
+
+### 2. Create a type mapping file
+
+The analyzer reads wrapped type mappings from an **AdditionalFile** named
+`*.wrapgod-types.txt`. Each line maps an original type to its generated
+wrapper interface and facade class:
+
+```
+# Format: OriginalType -> WrapperInterface, FacadeType
+Vendor.Lib.HttpClient -> IWrappedHttpClient, HttpClientFacade
+Vendor.Lib.Logger -> IWrappedLogger, LoggerFacade
+```
+
+Lines starting with `#` are treated as comments and ignored. Empty lines
+are skipped.
+
+### 3. Include the mapping file
+
+```xml
+<ItemGroup>
+  <AdditionalFiles Include="vendor-lib.wrapgod-types.txt" />
+</ItemGroup>
+```
+
+## Diagnostics
+
+### WG2001: Direct third-party type usage
+
+| Property | Value |
+|----------|-------|
+| **ID** | `WG2001` |
+| **Category** | `WrapGod.Usage` |
+| **Default severity** | Warning |
+| **Enabled by default** | Yes |
+| **Message format** | `Type '{0}' has a generated wrapper interface; use '{1}' instead` |
+
+**Trigger**: The analyzer reports WG2001 when it encounters an identifier
+that resolves to a type listed in the mapping file. This covers:
+
+- Local variable declarations (`HttpClient client = ...`)
+- Parameter types
+- Field and property types
+- Any other identifier that resolves to the wrapped type's symbol
+
+**Exclusion**: Identifiers that are part of a member access expression
+(e.g. `client.SendAsync`) are handled separately by WG2002 and are not
+double-reported.
+
+### WG2002: Direct third-party method call
+
+| Property | Value |
+|----------|-------|
+| **ID** | `WG2002` |
+| **Category** | `WrapGod.Usage` |
+| **Default severity** | Warning |
+| **Enabled by default** | Yes |
+| **Message format** | `Method '{0}' on type '{1}' should be called through the facade '{2}'` |
+
+**Trigger**: The analyzer reports WG2002 when it encounters a method
+invocation expression where the containing type of the invoked method is
+listed in the mapping file. This fires on patterns like:
+
+```csharp
+client.SendAsync(request);   // WG2002
+HttpClient.CreateDefault();  // WG2002 (static method)
+```
+
+Only method invocations are flagged -- property access and field access
+are not reported by WG2002.
+
+## Code fixes
+
+Both diagnostics come with automatic code fix providers implemented in
+`UseWrapperCodeFixProvider`.
+
+### WG2001 fix: Use wrapper interface
+
+The code fix replaces the type reference with the wrapper interface name
+from the mapping file.
+
+**Before**:
+
+```csharp
+HttpClient client = new HttpClient();
+```
+
+**After**:
+
+```csharp
+IWrappedHttpClient client = new HttpClient();
+```
+
+The fix preserves the original trivia (whitespace, comments) around the
+replaced node.
+
+### WG2002 fix: Use facade
+
+The code fix replaces the receiver expression in the method call with the
+facade type name.
+
+**Before**:
+
+```csharp
+client.SendAsync(request);
+```
+
+**After**:
+
+```csharp
+HttpClientFacade.SendAsync(request);
+```
+
+### Fix All support
+
+Both code fixes support the **Fix All** operation via
+`WellKnownFixAllProviders.BatchFixer`. This allows you to apply all
+WG2001 or WG2002 fixes across a document, project, or entire solution in
+a single action.
+
+**Equivalence keys** (used by the batch fixer to group fixes):
+
+| Diagnostic | Equivalence key |
+|------------|-----------------|
+| WG2001 | `WG2001_UseWrapper` |
+| WG2002 | `WG2002_UseFacade` |
+
+### Applying fixes from the command line
+
+Use `dotnet format` to apply analyzer fixes in CI or from the terminal:
+
+```bash
+# Fix all WrapGod diagnostics in the solution
+dotnet format analyzers --diagnostics WG2001 WG2002
+
+# Fix a specific project
+dotnet format analyzers MyApp.csproj --diagnostics WG2001 WG2002
+```
+
+## Suppression
+
+To suppress a diagnostic for a specific line:
+
+```csharp
+#pragma warning disable WG2001
+HttpClient client = GetClient();  // intentional direct usage
+#pragma warning restore WG2001
+```
+
+Or suppress at the project level in `.editorconfig`:
+
+```ini
+[*.cs]
+dotnet_diagnostic.WG2001.severity = none
+dotnet_diagnostic.WG2002.severity = none
+```
+
+## Architecture notes
+
+- The analyzer uses `RegisterCompilationStartAction` to load mappings
+  once per compilation, then `RegisterSyntaxNodeAction` for efficient
+  per-node analysis.
+- Concurrent execution is enabled for performance.
+- Generated code is excluded from analysis
+  (`GeneratedCodeAnalysisFlags.None`).
+- Symbol resolution uses `SemanticModel.GetSymbolInfo` to accurately
+  resolve types through aliases, usings, and implicit conversions.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,169 @@
+# Compatibility Modes
+
+When working with multi-version manifests, WrapGod's source generator can
+filter the generated API surface based on a **compatibility mode**. This
+determines which types and members make it into the generated interfaces
+and facades.
+
+The `CompatibilityFilter` applies the chosen mode to a `GenerationPlan`,
+producing a new plan with only the appropriate members included.
+
+## Modes
+
+### LCD (Lowest Common Denominator)
+
+```
+CompatibilityMode.Lcd
+```
+
+Emit **only** types and members that are present in **every** extracted
+version. A type/member qualifies when:
+
+- It was introduced in the **earliest** version in the version list, AND
+- It was **never removed** (no `removedIn` metadata).
+
+This is the safest mode: generated code compiles and runs against any
+version you extracted.
+
+**Use case**: you ship a library that must work across all supported
+versions of a vendor dependency.
+
+### Targeted
+
+```
+CompatibilityMode.Targeted
+```
+
+Emit types and members present in a **single selected version**. A
+type/member qualifies when:
+
+- It was introduced **at or before** the target version, AND
+- It was **not removed at or before** the target version.
+
+Requires specifying the `targetVersion` parameter.
+
+**Use case**: your application pins to a specific version of the vendor
+library and you want the generated surface to match exactly.
+
+### Adaptive
+
+```
+CompatibilityMode.Adaptive
+```
+
+Emit **all** types and members from the merged manifest. Members that are
+version-specific are decorated with **runtime availability guards** in the
+generated facade. At runtime, the facade checks
+`WrapGodVersionHelper.IsMemberAvailable(introducedIn, removedIn)` before
+forwarding a call. If the member is not available in the running version,
+a `PlatformNotSupportedException` is thrown.
+
+**Use case**: you want a single compiled binary that adapts its behavior
+based on which version of the vendor library is present at runtime.
+
+## API usage
+
+```csharp
+using WrapGod.Generator;
+
+// Apply LCD mode
+GenerationPlan filtered = CompatibilityFilter.Apply(
+    plan,
+    CompatibilityMode.Lcd,
+    versions: new[] { "1.0.0", "2.0.0", "3.0.0" });
+
+// Apply Targeted mode (pin to v2)
+GenerationPlan filtered = CompatibilityFilter.Apply(
+    plan,
+    CompatibilityMode.Targeted,
+    versions: new[] { "1.0.0", "2.0.0", "3.0.0" },
+    targetVersion: "2.0.0");
+
+// Apply Adaptive mode (keep everything)
+GenerationPlan filtered = CompatibilityFilter.Apply(
+    plan,
+    CompatibilityMode.Adaptive,
+    versions: new[] { "1.0.0", "2.0.0", "3.0.0" });
+```
+
+## Version presence rules
+
+The filter uses `VersionPresence` metadata on each `TypePlan` and
+`MemberPlan`:
+
+| Metadata field | Meaning |
+|---|---|
+| `introducedIn` | The version label when the element first appeared. `null` means it was present from the earliest version. |
+| `removedIn` | The version label when the element was removed. `null` means it is still present in the latest version. |
+
+When both fields are `null`, the element is treated as present in all
+versions and passes every filter mode.
+
+## Runtime version checks (Adaptive mode)
+
+In Adaptive mode, the `SourceEmitter` wraps version-specific members with
+guards:
+
+```csharp
+// Generated facade method (Adaptive mode)
+public Response SendAsync(Request request)
+{
+    if (!WrapGodVersionHelper.IsMemberAvailable("2.0.0", null))
+        throw new System.PlatformNotSupportedException(
+            "SendAsync is not available in the current version.");
+    return _inner.SendAsync(request);
+}
+```
+
+Property getters and setters receive the same treatment:
+
+```csharp
+public int Timeout
+{
+    // Available since 2.0.0
+    get
+    {
+        if (!WrapGodVersionHelper.IsMemberAvailable("2.0.0", null))
+            throw new System.PlatformNotSupportedException(
+                "Timeout is not available in the current version.");
+        return _inner.Timeout;
+    }
+    set
+    {
+        if (!WrapGodVersionHelper.IsMemberAvailable("2.0.0", null))
+            throw new System.PlatformNotSupportedException(
+                "Timeout is not available in the current version.");
+        _inner.Timeout = value;
+    }
+}
+```
+
+Generated code also includes a comment indicating the availability window:
+
+```
+// Available since 2.0.0, removed in 4.0.0
+```
+
+## Choosing a mode
+
+| Concern | LCD | Targeted | Adaptive |
+|---------|-----|----------|----------|
+| Compile-time safety across all versions | Yes | No (target only) | No (runtime checks) |
+| Full API surface | No | Single version | Yes |
+| Single binary for multiple versions | No | No | Yes |
+| Runtime overhead | None | None | Guard check per call |
+| Configuration complexity | Low | Low | Medium |
+
+## Fluent DSL integration
+
+Set the mode via the fluent builder:
+
+```csharp
+var plan = WrapGodConfiguration.Create()
+    .ForAssembly("Vendor.Lib")
+    .WithCompatibilityMode("lcd")   // or "targeted", "adaptive"
+    .WrapType("Vendor.Lib.HttpClient")
+        .As("IHttpClient")
+        .WrapAllPublicMembers()
+    .Build();
+```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,240 @@
+# Configuration Guide
+
+WrapGod provides three configuration surfaces for controlling which types
+and members are wrapped, how they are renamed, and what gets excluded.
+All three produce the same normalized shape and can be combined with
+well-defined merge precedence.
+
+## JSON configuration
+
+Create a `wrapgod.config.json` file (or any `.json` file loaded by
+`JsonConfigLoader`). The format mirrors the `WrapGodConfig` model:
+
+```json
+{
+  "types": [
+    {
+      "sourceType": "Vendor.Lib.HttpClient",
+      "include": true,
+      "targetName": "IHttpClient",
+      "members": [
+        {
+          "sourceMember": "SendAsync",
+          "include": true,
+          "targetName": "SendRequestAsync"
+        },
+        {
+          "sourceMember": "Dispose",
+          "include": false
+        }
+      ]
+    },
+    {
+      "sourceType": "Vendor.Lib.Logger",
+      "include": true,
+      "targetName": "ILogger",
+      "members": []
+    }
+  ]
+}
+```
+
+### Loading JSON config
+
+```csharp
+using WrapGod.Manifest.Config;
+
+// From a file path
+WrapGodConfig config = JsonConfigLoader.LoadFromFile("wrapgod.config.json");
+
+// From a raw JSON string
+WrapGodConfig config = JsonConfigLoader.LoadFromJson(jsonString);
+```
+
+The loader supports comments in JSON (`//` and `/* */`) and
+case-insensitive property names.
+
+### JSON config model
+
+| Type | Property | Type | Description |
+|------|----------|------|-------------|
+| `WrapGodConfig` | `types` | `TypeConfig[]` | Per-type configuration entries. |
+| `TypeConfig` | `sourceType` | `string` | Fully qualified source type name. |
+| | `include` | `bool?` | Whether to include this type in generation. `null` = defer to other config sources. |
+| | `targetName` | `string?` | Rename the generated wrapper (e.g. `"IHttpClient"`). |
+| | `members` | `MemberConfig[]` | Per-member configuration entries. |
+| `MemberConfig` | `sourceMember` | `string` | Source member name. |
+| | `include` | `bool?` | Whether to include this member. |
+| | `targetName` | `string?` | Rename the member on the generated wrapper. |
+
+## Attribute-based configuration
+
+Apply `[WrapType]` and `[WrapMember]` attributes from the
+`WrapGod.Abstractions.Config` namespace directly on your wrapper contracts
+or marker types.
+
+### `[WrapType]`
+
+```csharp
+[WrapType("Vendor.Lib.HttpClient", TargetName = "IHttpClient")]
+public interface IHttpClientWrapper { }
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sourceType` | `string` (ctor) | Fully qualified source type to wrap. |
+| `Include` | `bool` | Include this type in generation (default `true`). |
+| `TargetName` | `string?` | Rename the generated wrapper. |
+
+Can be applied to classes, interfaces, and structs.
+
+### `[WrapMember]`
+
+```csharp
+[WrapMember("SendAsync", TargetName = "SendRequestAsync")]
+Task<Response> SendRequestAsync(Request request);
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sourceMember` | `string` (ctor) | Source member name to wrap. |
+| `Include` | `bool` | Include this member (default `true`). |
+| `TargetName` | `string?` | Rename the member on the wrapper. |
+
+Can be applied to methods and properties.
+
+### Reading attribute config
+
+```csharp
+using WrapGod.Manifest.Config;
+
+WrapGodConfig attrConfig = AttributeConfigReader.ReadFromAssembly(
+    typeof(IHttpClientWrapper).Assembly);
+```
+
+## Fluent DSL
+
+The fluent API in `WrapGod.Fluent` provides a programmatic builder that
+produces a `GenerationPlan` -- the same normalized shape the JSON and
+attribute readers produce.
+
+```csharp
+using WrapGod.Fluent;
+
+GenerationPlan plan = WrapGodConfiguration.Create()
+    .ForAssembly("Vendor.Lib")
+    .WithCompatibilityMode("lcd")
+    .WrapType("Vendor.Lib.HttpClient")
+        .As("IHttpClient")
+        .WrapMethod("SendAsync").As("SendRequestAsync")
+        .WrapProperty("Timeout")
+        .ExcludeMember("Dispose")
+    .WrapType("Vendor.Lib.Logger")
+        .As("ILogger")
+        .WrapAllPublicMembers()
+    .MapType("Vendor.Lib.Config", "MyApp.Config")
+    .ExcludeType("Vendor.Lib.Internal*")
+    .Build();
+```
+
+### Fluent API reference
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `WrapGodConfiguration.Create()` | `WrapGodConfiguration` | Create a new builder. |
+| `.ForAssembly(name)` | `WrapGodConfiguration` | Set the source assembly name. |
+| `.WithCompatibilityMode(mode)` | `WrapGodConfiguration` | Set the compatibility mode (`"lcd"`, `"targeted"`, `"adaptive"`). |
+| `.WrapType(sourceType)` | `TypeDirectiveBuilder` | Begin configuring a type wrapper. |
+| `.MapType(source, dest)` | `WrapGodConfiguration` | Add a source-to-destination type mapping. |
+| `.ExcludeType(pattern)` | `WrapGodConfiguration` | Exclude types matching a glob pattern. |
+| `.Build()` | `GenerationPlan` | Finalize and produce the generation plan. |
+
+**`TypeDirectiveBuilder`**:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `.As(targetName)` | `TypeDirectiveBuilder` | Set the wrapper name. |
+| `.WrapMethod(name)` | `MemberDirectiveBuilder` | Add a method directive. |
+| `.WrapProperty(name)` | `TypeDirectiveBuilder` | Add a property directive. |
+| `.ExcludeMember(name)` | `TypeDirectiveBuilder` | Exclude a member by name. |
+| `.WrapAllPublicMembers()` | `TypeDirectiveBuilder` | Include all public members. |
+| `.WrapType(sourceType)` | `TypeDirectiveBuilder` | Chain to another type (delegates to parent). |
+| `.Build()` | `GenerationPlan` | Finalize (delegates to parent). |
+
+**`MemberDirectiveBuilder`**:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `.As(targetName)` | `TypeDirectiveBuilder` | Rename the member and return to the type builder. |
+
+### `GenerationPlan` output
+
+The `GenerationPlan` contains:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `AssemblyName` | `string` | Source assembly name. |
+| `TypeDirectives` | `TypeDirective[]` | Per-type wrapper directives. |
+| `TypeMappings` | `TypeMapping[]` | Source-to-destination type mappings. |
+| `ExclusionPatterns` | `string[]` | Glob patterns for excluded types. |
+| `CompatibilityMode` | `string?` | Requested compatibility mode. |
+
+## Merge precedence
+
+When both JSON and attribute configuration exist for the same type or
+member, the `ConfigMergeEngine` merges them using a configurable
+precedence rule.
+
+```csharp
+using WrapGod.Abstractions.Config;
+using WrapGod.Manifest.Config;
+
+var result = ConfigMergeEngine.Merge(jsonConfig, attributeConfig, new ConfigMergeOptions
+{
+    HigherPrecedence = ConfigSource.Attributes  // default
+});
+
+WrapGodConfig merged = result.Config;
+List<ConfigDiagnostic> conflicts = result.Diagnostics;
+```
+
+### Precedence rules
+
+- **`ConfigSource.Attributes`** (default): attribute-defined values win
+  over JSON values when both are present.
+- **`ConfigSource.Json`**: JSON-defined values win.
+
+When a conflict is detected (both sources define a different value for the
+same setting), a `ConfigDiagnostic` is emitted:
+
+| Code | Description |
+|------|-------------|
+| `WG6001` | Type `include` conflict. |
+| `WG6002` | Type `targetName` conflict. |
+| `WG6003` | Member `include` conflict. |
+| `WG6004` | Member `targetName` conflict. |
+
+If only one source provides a value, it is used regardless of the
+precedence setting.
+
+## Type mappings
+
+Type mappings define source-to-destination type transformations used during
+generation. They can be specified in the fluent DSL:
+
+```csharp
+.MapType("Vendor.Lib.Config", "MyApp.Config")
+```
+
+Or in the `GenerationPlan.TypeMappings` list:
+
+```csharp
+new TypeMapping
+{
+    SourceType = "Vendor.Lib.Config",
+    DestinationType = "MyApp.Config",
+}
+```
+
+These mappings instruct the generator to replace occurrences of the source
+type with the destination type in generated wrapper signatures.

--- a/docs/MANIFEST.md
+++ b/docs/MANIFEST.md
@@ -1,0 +1,155 @@
+# Manifest Format Reference
+
+The WrapGod manifest is the canonical description of a third-party
+assembly's public API surface. It is serialized as JSON and serves as the
+single source of truth for the source generator, compatibility filter, and
+analyzer tooling.
+
+## Schema overview
+
+Manifests conform to the JSON Schema at
+[`schemas/wrapgod.manifest.v1.schema.json`](../schemas/wrapgod.manifest.v1.schema.json).
+
+Serialization conventions (handled by `ManifestSerializer`):
+
+- Property names use **camelCase**
+- Enums are stored as **lowercase strings**
+- Null-valued properties are **omitted**
+- Output is **indented** for readability
+
+## Root object
+
+| Property | Type | Description |
+|---|---|---|
+| `schemaVersion` | `string` | Always `"1.0"` for this format version. |
+| `generatedAt` | `string` (ISO 8601) | UTC timestamp of extraction. |
+| `sourceHash` | `string` | SHA-256 hex digest of the source assembly file. Used for drift detection. |
+| `assembly` | `AssemblyIdentity` | Metadata identifying the source assembly. |
+| `types` | `ApiTypeNode[]` | All public types, sorted by `stableId`. |
+
+## Assembly identity
+
+| Property | Type | Description |
+|---|---|---|
+| `name` | `string` | Assembly simple name (e.g. `"Vendor.Lib"`). |
+| `version` | `string` | Assembly version string. |
+| `culture` | `string?` | Culture string, or `null` for invariant. |
+| `publicKeyToken` | `string?` | Hex-encoded public key token, or `null` if unsigned. |
+| `targetFramework` | `string?` | Target framework moniker (e.g. `".NETCoreApp,Version=v8.0"`). |
+
+## Type node (`ApiTypeNode`)
+
+Each public type (class, struct, interface, enum, delegate) is represented
+by an `ApiTypeNode`.
+
+| Property | Type | Description |
+|---|---|---|
+| `stableId` | `string` | Stable identifier: `Namespace.TypeName` (including generic arity, e.g. `System.Collections.Generic.List\`1`). Nested types use `+` separator. |
+| `fullName` | `string` | Fully qualified name with generic arguments expanded. |
+| `name` | `string` | Simple type name. |
+| `namespace` | `string` | Namespace (empty string for global types). |
+| `kind` | `string` | One of: `class`, `struct`, `interface`, `enum`, `delegate`, `record`, `recordStruct`. |
+| `baseType` | `string?` | Fully qualified base type, or `null` for interfaces / `System.Object`. |
+| `interfaces` | `string[]` | Implemented interfaces, sorted alphabetically. |
+| `genericParameters` | `GenericParameterInfo[]` | Generic type parameter definitions. |
+| `isSealed` | `bool` | Whether the type is sealed (false for value types). |
+| `isAbstract` | `bool` | Whether the type is abstract (false for interfaces). |
+| `isStatic` | `bool` | Whether the type is static (`abstract sealed`). |
+| `members` | `ApiMemberNode[]` | Public members, sorted by `stableId`. |
+| `presence` | `VersionPresence?` | Version availability metadata (multi-version manifests only). |
+
+## Member node (`ApiMemberNode`)
+
+| Property | Type | Description |
+|---|---|---|
+| `stableId` | `string` | Stable identifier: `TypeStableId.MemberName(ParamTypes)`. |
+| `name` | `string` | Member name (`.ctor` for constructors, `op_*` for operators). |
+| `kind` | `string` | One of: `method`, `property`, `field`, `event`, `constructor`, `indexer`, `operator`. |
+| `returnType` | `string?` | Return type (for methods, properties, fields, events). |
+| `parameters` | `ApiParameterInfo[]` | Parameters (for methods, constructors, indexers). |
+| `genericParameters` | `GenericParameterInfo[]` | Generic method parameters. |
+| `isStatic` | `bool` | Whether the member is static. |
+| `isVirtual` | `bool` | Whether the member is virtual/overridable. |
+| `isAbstract` | `bool` | Whether the member is abstract. |
+| `hasGetter` | `bool` | Whether a property has a public getter. |
+| `hasSetter` | `bool` | Whether a property has a public setter. |
+| `presence` | `VersionPresence?` | Version availability metadata. |
+
+### Stable ID conventions
+
+Stable IDs are designed to be deterministic and comparable across versions:
+
+- **Types**: `Namespace.TypeName` (e.g. `Acme.Lib.HttpClient`)
+- **Nested types**: `Outer+Inner`
+- **Constructors**: `TypeId..ctor(ParamType1, ParamType2)`
+- **Methods**: `TypeId.MethodName(ParamType1, ParamType2)`
+- **Generic methods**: `TypeId.MethodName\`1(ParamType1)` (backtick + arity)
+- **Properties**: `TypeId.PropertyName`
+- **Indexers**: `TypeId.Item[ParamType1]`
+- **Fields / Events**: `TypeId.MemberName`
+- **Operators**: `TypeId.op_Addition(ParamType1, ParamType2)`
+
+## Parameter info (`ApiParameterInfo`)
+
+| Property | Type | Description |
+|---|---|---|
+| `name` | `string` | Parameter name. |
+| `type` | `string` | Fully qualified parameter type. |
+| `isOptional` | `bool` | Whether the parameter has a default value. |
+| `isParams` | `bool` | Whether the parameter uses `params`. |
+| `isOut` | `bool` | Whether the parameter is `out`. |
+| `isRef` | `bool` | Whether the parameter is `ref` (non-`out`). |
+| `defaultValue` | `string?` | String representation of the default value, if any. |
+
+## Generic parameter info (`GenericParameterInfo`)
+
+| Property | Type | Description |
+|---|---|---|
+| `name` | `string` | Type parameter name (e.g. `T`). |
+| `constraints` | `string[]` | Constraint type names, sorted alphabetically. |
+
+## Version presence metadata (`VersionPresence`)
+
+Present only in manifests produced by `MultiVersionExtractor`. Tracks when
+a type or member was introduced, removed, or changed across versions.
+
+| Property | Type | Description |
+|---|---|---|
+| `introducedIn` | `string?` | Version label when this API element first appeared. |
+| `removedIn` | `string?` | Version label when this API element was removed. |
+| `changedIn` | `string?` | Version label when the signature changed. |
+
+When all three are `null`, the element is present in every extracted
+version.
+
+## Multi-version extraction
+
+The `MultiVersionExtractor` accepts an ordered list of `(VersionLabel,
+AssemblyPath)` pairs and produces:
+
+1. A **merged manifest** -- the union of all types and members across
+   versions, annotated with `VersionPresence` on every node.
+2. A **`VersionDiff`** report containing:
+   - `addedTypes` / `removedTypes`
+   - `addedMembers` / `removedMembers`
+   - `changedMembers` (return type or parameter type changes)
+   - `breakingChanges` (classified as `TypeRemoved`, `MemberRemoved`,
+     `ReturnTypeChanged`, or `ParameterTypesChanged`)
+
+The merged manifest uses the **latest version's** shape as canonical for
+each type/member. The `VersionDiff` is useful for generating migration
+guides or feeding into the compatibility filter.
+
+### Example
+
+```csharp
+var result = MultiVersionExtractor.Extract(new[]
+{
+    new MultiVersionExtractor.VersionInput("1.0.0", @"v1\Vendor.Lib.dll"),
+    new MultiVersionExtractor.VersionInput("2.0.0", @"v2\Vendor.Lib.dll"),
+    new MultiVersionExtractor.VersionInput("3.0.0", @"v3\Vendor.Lib.dll"),
+});
+
+// Types/members only in v2+ will have: presence.introducedIn = "2.0.0"
+// Types/members removed in v3 will have: presence.removedIn = "3.0.0"
+```

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,243 @@
+# Quick Start Guide
+
+This guide walks you through the core WrapGod workflow: extracting an API
+manifest, configuring wrappers, generating code, and migrating existing
+call sites with the built-in analyzers.
+
+## Prerequisites
+
+- .NET 10 SDK (or later, per `global.json` rollForward policy)
+- The third-party assembly you want to wrap (e.g. `Vendor.Lib.dll`)
+
+## 1. Install packages
+
+Add the WrapGod packages to your project. All packages share a version and
+are published from this repository.
+
+```bash
+# Core manifest + extractor
+dotnet add package WrapGod.Manifest
+dotnet add package WrapGod.Extractor
+
+# Source generator (added as an analyzer)
+dotnet add package WrapGod.Generator
+
+# Analyzers + code fixes for migration
+dotnet add package WrapGod.Analyzers
+
+# Optional: fluent configuration DSL
+dotnet add package WrapGod.Fluent
+
+# Optional: attribute-based configuration
+dotnet add package WrapGod.Abstractions
+```
+
+## 2. Extract a manifest from an assembly
+
+Use `AssemblyExtractor` to produce a JSON manifest describing the public
+API surface of a third-party assembly.
+
+```csharp
+using WrapGod.Extractor;
+using WrapGod.Manifest;
+
+// Single-version extraction
+ApiManifest manifest = AssemblyExtractor.Extract(@"path\to\Vendor.Lib.dll");
+
+// Serialize to JSON
+string json = ManifestSerializer.Serialize(manifest);
+File.WriteAllText("vendor-lib.wrapgod.json", json);
+```
+
+The manifest captures every public type, member, parameter, and generic
+constraint. See [MANIFEST.md](MANIFEST.md) for the full schema reference.
+
+### Multi-version extraction
+
+When you need to support multiple versions of the same library, extract
+each version and merge them into a single manifest with version presence
+metadata:
+
+```csharp
+using WrapGod.Extractor;
+
+var result = MultiVersionExtractor.Extract(new[]
+{
+    new MultiVersionExtractor.VersionInput("1.0.0", @"v1\Vendor.Lib.dll"),
+    new MultiVersionExtractor.VersionInput("2.0.0", @"v2\Vendor.Lib.dll"),
+});
+
+ApiManifest merged = result.MergedManifest;
+VersionDiff  diff  = result.Diff;
+```
+
+The merged manifest annotates each type and member with `presence` metadata
+(`introducedIn`, `removedIn`) so the generator knows which API elements
+are version-specific. The `VersionDiff` report lists added, removed, and
+changed members plus classified breaking changes.
+
+## 3. Configure wrappers
+
+WrapGod supports three configuration surfaces that can be used independently
+or combined (see [CONFIGURATION.md](CONFIGURATION.md) for full details):
+
+### JSON configuration
+
+Create a `wrapgod.config.json` alongside your project:
+
+```json
+{
+  "types": [
+    {
+      "sourceType": "Vendor.Lib.HttpClient",
+      "include": true,
+      "targetName": "IHttpClient",
+      "members": [
+        { "sourceMember": "SendAsync", "include": true, "targetName": "SendRequestAsync" },
+        { "sourceMember": "Dispose", "include": false }
+      ]
+    }
+  ]
+}
+```
+
+Load it at build time with:
+
+```csharp
+using WrapGod.Manifest.Config;
+
+WrapGodConfig config = JsonConfigLoader.LoadFromFile("wrapgod.config.json");
+```
+
+### Attribute-based configuration
+
+Annotate your wrapper contracts directly in C#:
+
+```csharp
+using WrapGod.Abstractions.Config;
+
+[WrapType("Vendor.Lib.HttpClient", TargetName = "IHttpClient")]
+public interface IHttpClientWrapper
+{
+    [WrapMember("SendAsync", TargetName = "SendRequestAsync")]
+    Task<Response> SendRequestAsync(Request request);
+}
+```
+
+Read attribute config with:
+
+```csharp
+WrapGodConfig attrConfig = AttributeConfigReader.ReadFromAssembly(typeof(IHttpClientWrapper).Assembly);
+```
+
+### Fluent DSL
+
+Build configuration programmatically:
+
+```csharp
+using WrapGod.Fluent;
+
+var plan = WrapGodConfiguration.Create()
+    .ForAssembly("Vendor.Lib")
+    .WrapType("Vendor.Lib.HttpClient")
+        .As("IHttpClient")
+        .WrapMethod("SendAsync").As("SendRequestAsync")
+        .WrapProperty("Timeout")
+        .ExcludeMember("Dispose")
+    .WrapType("Vendor.Lib.Logger")
+        .As("ILogger")
+        .WrapAllPublicMembers()
+    .MapType("Vendor.Lib.Config", "MyApp.Config")
+    .ExcludeType("Vendor.Lib.Internal*")
+    .Build();
+```
+
+## 4. Generate wrappers
+
+The source generator runs automatically during the build. It reads
+`*.wrapgod.json` manifest files included as **AdditionalFiles** in your
+project.
+
+### Project setup
+
+Add the manifest to your `.csproj`:
+
+```xml
+<ItemGroup>
+  <!-- The extracted manifest -->
+  <AdditionalFiles Include="vendor-lib.wrapgod.json" />
+</ItemGroup>
+
+<ItemGroup>
+  <!-- Reference the generator -->
+  <PackageReference Include="WrapGod.Generator"
+                    OutputItemType="Analyzer"
+                    ReferenceOutputAssembly="false" />
+</ItemGroup>
+```
+
+Build the project:
+
+```bash
+dotnet build
+```
+
+The generator emits two files per wrapped type:
+
+- `IWrapped{TypeName}.g.cs` -- the wrapper interface
+- `{TypeName}Facade.g.cs` -- a facade class that delegates to the original type
+
+Generated code lands in the `WrapGod.Generated` namespace.
+
+## 5. Run analyzers to find direct usage
+
+The WrapGod analyzer package detects call sites that reference the
+original third-party type directly instead of the generated wrapper.
+
+### Mapping file
+
+Create a `*.wrapgod-types.txt` file listing the type mappings. Each line
+uses the format:
+
+```
+Vendor.Lib.HttpClient -> IWrappedHttpClient, HttpClientFacade
+```
+
+Include it as an additional file:
+
+```xml
+<ItemGroup>
+  <AdditionalFiles Include="vendor-lib.wrapgod-types.txt" />
+</ItemGroup>
+```
+
+### Diagnostics
+
+| ID     | Severity | Description |
+|--------|----------|-------------|
+| WG2001 | Warning  | Direct usage of a type that has a generated wrapper interface |
+| WG2002 | Warning  | Direct method call on a type that has a generated facade |
+
+See [ANALYZERS.md](ANALYZERS.md) for the full diagnostics reference.
+
+## 6. Apply code fixes
+
+Both diagnostics ship with automatic code fixes:
+
+- **WG2001** -- replaces the type reference with the wrapper interface name
+- **WG2002** -- replaces the receiver expression with the facade type
+
+You can apply fixes one at a time or use **Fix All** (in your IDE or via
+`dotnet format`) to migrate an entire project in one pass.
+
+```bash
+# Apply all WrapGod code fixes across the solution
+dotnet format analyzers --diagnostics WG2001 WG2002
+```
+
+## Next steps
+
+- [MANIFEST.md](MANIFEST.md) -- manifest format reference
+- [CONFIGURATION.md](CONFIGURATION.md) -- configuration guide (JSON, attributes, fluent, merge rules)
+- [COMPATIBILITY.md](COMPATIBILITY.md) -- compatibility modes (LCD, Targeted, Adaptive)
+- [ANALYZERS.md](ANALYZERS.md) -- analyzer diagnostics reference


### PR DESCRIPTION
## Summary

- Add five new documentation files covering the complete WrapGod developer workflow: quick start guide, manifest format reference, configuration guide (JSON/attributes/fluent DSL/merge precedence), compatibility modes (LCD/Targeted/Adaptive), and analyzer diagnostics reference (WG2001/WG2002 with code fixes)
- Update README.md with a project overview, feature list, solution structure table, and links to all docs
- All implementation issues are complete; this documents the full MVP surface

## Test plan

- [x] `dotnet build` passes with zero warnings and zero errors
- [ ] Review each doc for accuracy against the source code
- [ ] Verify all internal doc links resolve correctly

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)