### PR TITLE
feat: unify analyzer type mapping with manifest/config

### DIFF
--- a/WrapGod.Analyzers/DirectUsageAnalyzer.cs
+++ b/WrapGod.Analyzers/DirectUsageAnalyzer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -15,9 +16,14 @@ namespace WrapGod.Analyzers;
 /// Roslyn analyzer that detects direct usage of third-party types that should
 /// be accessed through WrapGod-generated wrapper interfaces and facades.
 ///
-/// Reads wrapped type mappings from an AdditionalFile named
-/// <c>*.wrapgod-types.txt</c> (one mapping per line):
-///   <c>Acme.Lib.FooService -> IWrappedFooService, FooServiceFacade</c>
+/// <b>Primary source (preferred):</b> derives type mappings from
+/// <c>*.wrapgod.json</c> manifest files and optional <c>*.wrapgod.config.json</c>
+/// config files (the same files the generator reads). Config renames
+/// (<c>TargetName</c>) are applied when deriving wrapper/facade names.
+///
+/// <b>Fallback:</b> reads <c>*.wrapgod-types.txt</c> files (legacy format,
+/// one mapping per line):
+///   <c>Acme.Lib.FooService -&gt; IWrappedFooService, FooServiceFacade</c>
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class DirectUsageAnalyzer : DiagnosticAnalyzer
@@ -34,7 +40,15 @@ public sealed class DirectUsageAnalyzer : DiagnosticAnalyzer
 
         context.RegisterCompilationStartAction(compilationStart =>
         {
-            var mappings = LoadMappings(compilationStart.Options.AdditionalFiles);
+            var additionalFiles = compilationStart.Options.AdditionalFiles;
+
+            // Primary: derive mappings from manifest + config.
+            var mappings = LoadMappingsFromManifests(additionalFiles);
+
+            // Fallback: legacy .wrapgod-types.txt files.
+            if (mappings.Count == 0)
+                mappings = LoadMappingsFromTxtFiles(additionalFiles);
+
             if (mappings.Count == 0)
                 return;
 
@@ -138,13 +152,166 @@ public sealed class DirectUsageAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // ── Mapping file parsing ─────────────────────────────────────────
+    // ── Manifest + config mapping discovery ──────────────────────────
+
+    /// <summary>
+    /// Derives type mappings from <c>*.wrapgod.json</c> manifests, applying
+    /// any rename rules found in <c>*.wrapgod.config.json</c> config files.
+    /// </summary>
+    internal static List<WrappedTypeMapping> LoadMappingsFromManifests(
+        ImmutableArray<AdditionalText> additionalFiles)
+    {
+        // 1. Parse config files to build a rename lookup.
+        var configRenames = new Dictionary<string, string>(StringComparer.Ordinal);
+        var configExcludes = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var file in additionalFiles)
+        {
+            var fileName = Path.GetFileName(file.Path);
+            if (!fileName.EndsWith(".wrapgod.config.json", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var text = file.GetText();
+            if (text is null)
+                continue;
+
+            ParseConfigJson(text.ToString(), configRenames, configExcludes);
+        }
+
+        // 2. Parse manifest files and derive mappings.
+        var results = new List<WrappedTypeMapping>();
+
+        foreach (var file in additionalFiles)
+        {
+            var fileName = Path.GetFileName(file.Path);
+            if (!fileName.EndsWith(".wrapgod.json", StringComparison.OrdinalIgnoreCase))
+                continue;
+            // Skip config files that also end with .wrapgod.json pattern.
+            if (fileName.EndsWith(".wrapgod.config.json", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var text = file.GetText();
+            if (text is null)
+                continue;
+
+            ParseManifestJson(text.ToString(), configRenames, configExcludes, results);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Parses a <c>*.wrapgod.config.json</c> and populates rename and exclude lookups.
+    /// </summary>
+    private static void ParseConfigJson(
+        string json,
+        Dictionary<string, string> renames,
+        HashSet<string> excludes)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("types", out var typesEl) ||
+                typesEl.ValueKind != JsonValueKind.Array)
+                return;
+
+            foreach (var typeEl in typesEl.EnumerateArray())
+            {
+                var sourceType = GetJsonString(typeEl, "sourceType");
+                if (string.IsNullOrEmpty(sourceType))
+                    continue;
+
+                // Check for explicit exclusion.
+                if (typeEl.TryGetProperty("include", out var includeEl) &&
+                    includeEl.ValueKind == JsonValueKind.False)
+                {
+                    excludes.Add(sourceType);
+                    continue;
+                }
+
+                // Check for rename.
+                var targetName = GetJsonString(typeEl, "targetName");
+                if (!string.IsNullOrEmpty(targetName))
+                {
+                    renames[sourceType] = targetName;
+                }
+            }
+        }
+#pragma warning disable CA1031 // analyzer must not crash
+        catch
+#pragma warning restore CA1031
+        {
+            // Silently ignore malformed config.
+        }
+    }
+
+    /// <summary>
+    /// Parses a <c>*.wrapgod.json</c> manifest and appends derived mappings to <paramref name="results"/>.
+    /// Applies config renames and exclusions.
+    /// </summary>
+    private static void ParseManifestJson(
+        string json,
+        Dictionary<string, string> renames,
+        HashSet<string> excludes,
+        List<WrappedTypeMapping> results)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("types", out var typesEl) ||
+                typesEl.ValueKind != JsonValueKind.Array)
+                return;
+
+            foreach (var typeEl in typesEl.EnumerateArray())
+            {
+                var fullName = GetJsonString(typeEl, "fullName");
+                var name = GetJsonString(typeEl, "name");
+
+                if (string.IsNullOrEmpty(fullName) || string.IsNullOrEmpty(name))
+                    continue;
+
+                // Skip excluded types.
+                if (excludes.Contains(fullName))
+                    continue;
+
+                // Apply config rename if present.
+                var effectiveName = renames.TryGetValue(fullName, out var renamed)
+                    ? renamed
+                    : name;
+
+                // Derive wrapper names using same convention as the generator.
+                var wrapperInterface = "IWrapped" + effectiveName;
+                var facadeType = effectiveName + "Facade";
+
+                results.Add(new WrappedTypeMapping(fullName, wrapperInterface, facadeType));
+            }
+        }
+#pragma warning disable CA1031 // analyzer must not crash
+        catch
+#pragma warning restore CA1031
+        {
+            // Silently ignore malformed manifest.
+        }
+    }
+
+    private static string GetJsonString(JsonElement el, string propertyName)
+    {
+        return el.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString() ?? string.Empty
+            : string.Empty;
+    }
+
+    // ── Legacy .wrapgod-types.txt parsing (fallback) ─────────────────
 
     /// <summary>
     /// Parses additional files matching <c>*.wrapgod-types.txt</c>.
     /// Each line: <c>Acme.Lib.FooService -&gt; IWrappedFooService, FooServiceFacade</c>
     /// </summary>
-    private static List<WrappedTypeMapping> LoadMappings(
+    private static List<WrappedTypeMapping> LoadMappingsFromTxtFiles(
         ImmutableArray<AdditionalText> additionalFiles)
     {
         var results = new List<WrappedTypeMapping>();

--- a/WrapGod.Analyzers/UseWrapperCodeFixProvider.cs
+++ b/WrapGod.Analyzers/UseWrapperCodeFixProvider.cs
@@ -21,8 +21,10 @@ namespace WrapGod.Analyzers;
 ///   WG2001 — replaces direct type references with the wrapper interface
 ///   WG2002 — replaces direct method calls with facade calls
 ///
-/// Reads the same <c>*.wrapgod-types.txt</c> additional files used by
-/// <see cref="DirectUsageAnalyzer"/> to determine the deterministic mapping.
+/// Mapping information is embedded in the diagnostic message arguments produced
+/// by <see cref="DirectUsageAnalyzer"/>, which derives mappings from
+/// <c>*.wrapgod.json</c> manifests + <c>*.wrapgod.config.json</c> config files
+/// (with <c>*.wrapgod-types.txt</c> as a legacy fallback).
 /// Supports FixAll via the built-in <see cref="WellKnownFixAllProviders.BatchFixer"/>.
 /// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseWrapperCodeFixProvider))]

--- a/WrapGod.Tests/AnalyzerTests.cs
+++ b/WrapGod.Tests/AnalyzerTests.cs
@@ -21,12 +21,66 @@ public sealed class AnalyzerTests(ITestOutputHelper output) : TinyBddXunitBase(o
         "Acme.Lib.FooService -> IWrappedFooService, FooServiceFacade";
 
     /// <summary>
+    /// Manifest JSON for Acme.Lib.FooService with a DoWork method.
+    /// </summary>
+    private static readonly string DefaultManifest = """
+        {
+          "schemaVersion": "1.0",
+          "generatedAt": "2026-03-27T00:00:00Z",
+          "assembly": { "name": "Acme.Lib", "version": "1.0.0" },
+          "types": [
+            {
+              "stableId": "Acme.Lib.FooService",
+              "fullName": "Acme.Lib.FooService",
+              "name": "FooService",
+              "namespace": "Acme.Lib",
+              "kind": "class",
+              "interfaces": [],
+              "genericParameters": [],
+              "members": [
+                {
+                  "stableId": "Acme.Lib.FooService.DoWork(System.String)",
+                  "name": "DoWork",
+                  "kind": "method",
+                  "returnType": "string",
+                  "parameters": [{ "name": "input", "type": "string" }],
+                  "genericParameters": [],
+                  "isStatic": false,
+                  "isVirtual": false,
+                  "isAbstract": false,
+                  "hasGetter": false,
+                  "hasSetter": false
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    /// <summary>
     /// Compiles the given source with the <see cref="DirectUsageAnalyzer"/>
     /// registered and returns the reported diagnostics.
+    /// Accepts legacy .txt mappings via <paramref name="mappings"/>.
     /// </summary>
     private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
         string source,
         string? mappings = null)
+    {
+        var additionalTexts = new AdditionalText[]
+        {
+            new InMemoryAdditionalText(MappingFileName, mappings ?? DefaultMappings),
+        };
+
+        return await RunAnalyzerAsync(source, additionalTexts);
+    }
+
+    /// <summary>
+    /// Compiles the given source with the <see cref="DirectUsageAnalyzer"/>
+    /// registered and the supplied additional files.
+    /// </summary>
+    private static async Task<ImmutableArray<Diagnostic>> RunAnalyzerAsync(
+        string source,
+        AdditionalText[] additionalTexts)
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(source);
 
@@ -53,10 +107,6 @@ public sealed class AnalyzerTests(ITestOutputHelper output) : TinyBddXunitBase(o
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
         var analyzer = new DirectUsageAnalyzer();
-        var additionalTexts = new AdditionalText[]
-        {
-            new InMemoryAdditionalText(MappingFileName, mappings ?? DefaultMappings),
-        };
 
         var compilationWithAnalyzers = compilation.WithAnalyzers(
             ImmutableArray.Create<DiagnosticAnalyzer>(analyzer),
@@ -67,6 +117,10 @@ public sealed class AnalyzerTests(ITestOutputHelper output) : TinyBddXunitBase(o
 
     private static ImmutableArray<Diagnostic> RunDiagnostics(string source, string? mappings = null)
         => GetDiagnosticsAsync(source, mappings).GetAwaiter().GetResult();
+
+    private static ImmutableArray<Diagnostic> RunDiagnosticsWithFiles(
+        string source, params AdditionalText[] additionalTexts)
+        => RunAnalyzerAsync(source, additionalTexts).GetAwaiter().GetResult();
 
     // ── Source snippets ──────────────────────────────────────────────
 
@@ -132,7 +186,7 @@ public sealed class AnalyzerTests(ITestOutputHelper output) : TinyBddXunitBase(o
         }
         """;
 
-    // ── Scenarios ────────────────────────────────────────────────────
+    // ── Scenarios: legacy .txt files (backward compat) ───────────────
 
     [Scenario("Direct type usage reports WG2001")]
     [Fact]
@@ -163,6 +217,117 @@ public sealed class AnalyzerTests(ITestOutputHelper output) : TinyBddXunitBase(o
     public Task WrapperInterfaceUsage_ReportsNoDiagnostic()
         => Given("source code that uses the wrapper interface",
                 () => RunDiagnostics(WrapperInterfaceUsageSource))
+            .Then("no WG2001 diagnostics are reported", diagnostics =>
+                !diagnostics.Any(d => d.Id == "WG2001"))
+            .And("no WG2002 diagnostics are reported", diagnostics =>
+                !diagnostics.Any(d => d.Id == "WG2002"))
+            .AssertPassed();
+
+    [Scenario("Backward compat: .txt file mappings still work when no manifest is present")]
+    [Fact]
+    public Task TxtFileFallback_StillWorks()
+        => Given("source with only a legacy .wrapgod-types.txt file (no manifest)",
+                () => RunDiagnostics(DirectTypeUsageSource))
+            .Then("WG2001 is reported via .txt fallback", diagnostics =>
+                diagnostics.Any(d => d.Id == "WG2001"))
+            .And("the diagnostic suggests the wrapper from the .txt mapping", diagnostics =>
+                diagnostics.First(d => d.Id == "WG2001")
+                    .GetMessage(System.Globalization.CultureInfo.InvariantCulture)
+                    .Contains("IWrappedFooService", StringComparison.Ordinal))
+            .AssertPassed();
+
+    // ── Scenarios: manifest-based discovery ──────────────────────────
+
+    [Scenario("Analyzer discovers types from manifest (no .txt file)")]
+    [Fact]
+    public Task ManifestDiscovery_ReportsWG2001()
+        => Given("source with a .wrapgod.json manifest and no .txt file",
+                () => RunDiagnosticsWithFiles(
+                    DirectTypeUsageSource,
+                    new InMemoryAdditionalText("acme.wrapgod.json", DefaultManifest)))
+            .Then("at least one WG2001 diagnostic is reported", diagnostics =>
+                diagnostics.Any(d => d.Id == "WG2001"))
+            .And("the diagnostic suggests IWrappedFooService", diagnostics =>
+                diagnostics.First(d => d.Id == "WG2001")
+                    .GetMessage(System.Globalization.CultureInfo.InvariantCulture)
+                    .Contains("IWrappedFooService", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Analyzer discovers method calls from manifest (no .txt file)")]
+    [Fact]
+    public Task ManifestDiscovery_ReportsWG2002()
+        => Given("source with a .wrapgod.json manifest and no .txt file",
+                () => RunDiagnosticsWithFiles(
+                    DirectMethodCallSource,
+                    new InMemoryAdditionalText("acme.wrapgod.json", DefaultManifest)))
+            .Then("at least one WG2002 diagnostic is reported", diagnostics =>
+                diagnostics.Any(d => d.Id == "WG2002"))
+            .And("the diagnostic suggests FooServiceFacade", diagnostics =>
+                diagnostics.First(d => d.Id == "WG2002")
+                    .GetMessage(System.Globalization.CultureInfo.InvariantCulture)
+                    .Contains("FooServiceFacade", StringComparison.Ordinal))
+            .AssertPassed();
+
+    // ── Scenarios: config renames ────────────────────────────────────
+
+    [Scenario("Analyzer applies config rename to wrapper names")]
+    [Fact]
+    public Task ConfigRename_AppliesTargetName()
+        => Given("a manifest with a config that renames FooService to BetterFoo",
+                () => RunDiagnosticsWithFiles(
+                    DirectTypeUsageSource,
+                    new InMemoryAdditionalText("acme.wrapgod.json", DefaultManifest),
+                    new InMemoryAdditionalText("acme.wrapgod.config.json", """
+                        {
+                          "types": [
+                            { "sourceType": "Acme.Lib.FooService", "include": true, "targetName": "BetterFoo" }
+                          ]
+                        }
+                        """)))
+            .Then("WG2001 is reported", diagnostics =>
+                diagnostics.Any(d => d.Id == "WG2001"))
+            .And("the diagnostic suggests IWrappedBetterFoo (renamed)", diagnostics =>
+                diagnostics.First(d => d.Id == "WG2001")
+                    .GetMessage(System.Globalization.CultureInfo.InvariantCulture)
+                    .Contains("IWrappedBetterFoo", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Config rename also applies to facade name in WG2002")]
+    [Fact]
+    public Task ConfigRename_AppliesToFacade()
+        => Given("a manifest with a config that renames FooService to BetterFoo",
+                () => RunDiagnosticsWithFiles(
+                    DirectMethodCallSource,
+                    new InMemoryAdditionalText("acme.wrapgod.json", DefaultManifest),
+                    new InMemoryAdditionalText("acme.wrapgod.config.json", """
+                        {
+                          "types": [
+                            { "sourceType": "Acme.Lib.FooService", "include": true, "targetName": "BetterFoo" }
+                          ]
+                        }
+                        """)))
+            .Then("WG2002 is reported", diagnostics =>
+                diagnostics.Any(d => d.Id == "WG2002"))
+            .And("the diagnostic suggests BetterFooFacade (renamed)", diagnostics =>
+                diagnostics.First(d => d.Id == "WG2002")
+                    .GetMessage(System.Globalization.CultureInfo.InvariantCulture)
+                    .Contains("BetterFooFacade", StringComparison.Ordinal))
+            .AssertPassed();
+
+    [Scenario("Config excludes type -- no diagnostic reported")]
+    [Fact]
+    public Task ConfigExclude_SuppressesDiagnostic()
+        => Given("a manifest with a config that excludes FooService",
+                () => RunDiagnosticsWithFiles(
+                    DirectTypeUsageSource,
+                    new InMemoryAdditionalText("acme.wrapgod.json", DefaultManifest),
+                    new InMemoryAdditionalText("acme.wrapgod.config.json", """
+                        {
+                          "types": [
+                            { "sourceType": "Acme.Lib.FooService", "include": false }
+                          ]
+                        }
+                        """)))
             .Then("no WG2001 diagnostics are reported", diagnostics =>
                 !diagnostics.Any(d => d.Id == "WG2001"))
             .And("no WG2002 diagnostics are reported", diagnostics =>


### PR DESCRIPTION
## Summary
- **DirectUsageAnalyzer** now derives type mappings from `*.wrapgod.json` manifests + `*.wrapgod.config.json` config files (same sources the generator reads), eliminating the need for separate `*.wrapgod-types.txt` mapping files
- Config `TargetName` renames and `include: false` exclusions are respected when building the analyzer's type lookup
- Legacy `*.wrapgod-types.txt` files are kept as a fallback for backward compatibility (used only when no manifests are found)
- Added 6 new test scenarios covering manifest discovery, config renames, config exclusions, and backward compat

Closes #38

## Test plan
- [x] Existing analyzer tests still pass (backward compat with `.txt` files)
- [x] New test: analyzer discovers types from manifest JSON (no `.txt` file)
- [x] New test: analyzer applies config `TargetName` renames to interface names
- [x] New test: analyzer applies config `TargetName` renames to facade names
- [x] New test: config `include: false` suppresses diagnostics
- [x] Full test suite passes (94/94)

🤖 Generated with [Claude Code](https://claude.com/claude-code)