### PR TITLE
wip: add end-to-end WrapGod workflow example (issue #43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ covering extraction, configuration, generation, and migration.
 - [Configuration Guide](docs/CONFIGURATION.md) -- JSON, attributes, fluent DSL, merge precedence
 - [Compatibility Modes](docs/COMPATIBILITY.md) -- LCD, Targeted, and Adaptive modes
 - [Analyzer Diagnostics Reference](docs/ANALYZERS.md) -- WG2001, WG2002, code fixes, suppression
+- [Examples](examples/README.md) -- runnable end-to-end workflow sample (extract -> config -> generate -> analyze -> fix)
 
 ## Engineering
 

--- a/examples/Acme.Lib/Acme.Lib.csproj
+++ b/examples/Acme.Lib/Acme.Lib.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/Acme.Lib/BarClient.cs
+++ b/examples/Acme.Lib/BarClient.cs
@@ -1,0 +1,9 @@
+namespace Acme.Lib;
+
+public sealed class BarClient
+{
+    public void Send(string payload)
+    {
+        _ = payload;
+    }
+}

--- a/examples/Acme.Lib/Class1.cs
+++ b/examples/Acme.Lib/Class1.cs
@@ -1,0 +1,1 @@
+// Intentionally removed. See FooService/BarClient.

--- a/examples/Acme.Lib/FooService.cs
+++ b/examples/Acme.Lib/FooService.cs
@@ -1,0 +1,10 @@
+namespace Acme.Lib;
+
+public sealed class FooService
+{
+    public string DoWork(string input) => $"acme:{input}";
+
+    public int GetStatus() => 200;
+
+    public string Name => "Foo";
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,1 +1,52 @@
-# Examples\n\nWork in progress for issue #43.\n\n- [ ] Add runnable extract/config/generate/analyze/fix sample\n- [ ] Add step-by-step docs and validation commands\n
+# WrapGod Examples
+
+This folder contains a runnable, end-to-end workflow demo for issue #43.
+
+## Example projects
+
+- `Acme.Lib` — tiny third-party library we will wrap
+- `WrapGod.WorkflowDemo` — console app that executes the full WrapGod flow
+
+## What the demo does
+
+`WrapGod.WorkflowDemo` performs these steps in one run:
+
+1. **Extract** — builds `Acme.Lib` and extracts `acme.wrapgod.json`
+2. **Config** — writes `acme.wrapgod.config.json` (rename + exclude)
+3. **Generate** — runs `WrapGodIncrementalGenerator` and emits generated sources
+4. **Analyze** — runs `DirectUsageAnalyzer` and reports `WG2001/WG2002`
+5. **Fix** — applies `UseWrapperCodeFixProvider` for `WG2001`
+
+Artifacts are written to `examples/output/`:
+
+- `acme.wrapgod.json`
+- `acme.wrapgod.config.json`
+- `acme.wrapgod-types.txt`
+- `diagnostics.txt`
+- `Consumer.fixed.cs`
+- `generated/*.g.cs`
+
+## Run it
+
+From repository root:
+
+```bash
+dotnet run --project examples/WrapGod.WorkflowDemo/WrapGod.WorkflowDemo.csproj
+```
+
+Expected summary includes:
+
+- `WG2001 present: True`
+- `WG2002 present: True`
+- `Generated BetterFoo interface: True`
+- `Generated BarClient wrapper (expected false): False`
+
+## Validate locally
+
+```bash
+# Build example solution
+dotnet build examples/WrapGod.Examples.slnx -c Release
+
+# Run the workflow demo
+dotnet run --project examples/WrapGod.WorkflowDemo/WrapGod.WorkflowDemo.csproj -c Release
+```

--- a/examples/WrapGod.Examples.slnx
+++ b/examples/WrapGod.Examples.slnx
@@ -1,0 +1,10 @@
+<Solution>
+  <Project Path="../WrapGod.Abstractions/WrapGod.Abstractions.csproj" />
+  <Project Path="../WrapGod.Analyzers/WrapGod.Analyzers.csproj" />
+  <Project Path="../WrapGod.Extractor/WrapGod.Extractor.csproj" />
+  <Project Path="../WrapGod.Generator/WrapGod.Generator.csproj" />
+  <Project Path="../WrapGod.Manifest/WrapGod.Manifest.csproj" />
+  <Project Path="../WrapGod.TypeMap/WrapGod.TypeMap.csproj" />
+  <Project Path="Acme.Lib/Acme.Lib.csproj" />
+  <Project Path="WrapGod.WorkflowDemo/WrapGod.WorkflowDemo.csproj" />
+</Solution>

--- a/examples/WrapGod.WorkflowDemo/Program.cs
+++ b/examples/WrapGod.WorkflowDemo/Program.cs
@@ -1,0 +1,298 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using WrapGod.Analyzers;
+using WrapGod.Extractor;
+using WrapGod.Generator;
+using WrapGod.Manifest;
+
+var root = GetRepoRoot();
+var outputDir = Path.Combine(root, "examples", "output");
+Directory.CreateDirectory(outputDir);
+
+Console.WriteLine("== WrapGod end-to-end workflow example ==");
+
+// 1) EXTRACT
+var acmeAssemblyPath = BuildAcmeLibrary(root);
+ApiManifest manifest = AssemblyExtractor.Extract(acmeAssemblyPath);
+var manifestPath = Path.Combine(outputDir, "acme.wrapgod.json");
+await File.WriteAllTextAsync(manifestPath, ManifestSerializer.Serialize(manifest));
+Console.WriteLine($"[extract] manifest written: {manifestPath}");
+
+// 2) CONFIG
+const string configJson = """
+{
+  "types": [
+    {
+      "sourceType": "Acme.Lib.FooService",
+      "include": true,
+      "targetName": "BetterFoo",
+      "members": [
+        { "sourceMember": "GetStatus", "include": false }
+      ]
+    },
+    {
+      "sourceType": "Acme.Lib.BarClient",
+      "include": false
+    }
+  ]
+}
+""";
+var configPath = Path.Combine(outputDir, "acme.wrapgod.config.json");
+await File.WriteAllTextAsync(configPath, configJson);
+Console.WriteLine($"[config] config written: {configPath}");
+
+// 3) GENERATE
+GeneratorDriverRunResult genResult = RunGenerator(
+    manifestJson: await File.ReadAllTextAsync(manifestPath),
+    configJson: configJson);
+var generatedDir = Path.Combine(outputDir, "generated");
+Directory.CreateDirectory(generatedDir);
+
+foreach (var generated in genResult.Results.SelectMany(r => r.GeneratedSources))
+{
+    var path = Path.Combine(generatedDir, generated.HintName);
+    await File.WriteAllTextAsync(path, generated.SourceText.ToString());
+}
+
+Console.WriteLine($"[generate] files emitted: {genResult.Results.SelectMany(r => r.GeneratedSources).Count()}");
+
+// 4) ANALYZE
+const string mappings = "Acme.Lib.FooService -> IWrappedBetterFoo, BetterFooFacade";
+var mappingPath = Path.Combine(outputDir, "acme.wrapgod-types.txt");
+await File.WriteAllTextAsync(mappingPath, mappings + Environment.NewLine);
+
+const string consumerSource = """
+namespace MyApp;
+
+public sealed class Consumer
+{
+    private Acme.Lib.FooService _svc = new Acme.Lib.FooService();
+
+    public void Run()
+    {
+        _ = _svc.DoWork("hello");
+    }
+}
+""";
+
+ImmutableArray<Diagnostic> diagnostics = RunAnalyzer(consumerSource, mappings);
+var diagnosticsPath = Path.Combine(outputDir, "diagnostics.txt");
+await File.WriteAllLinesAsync(diagnosticsPath, diagnostics.Select(d => d.ToString()));
+Console.WriteLine($"[analyze] diagnostics: {string.Join(", ", diagnostics.Select(d => d.Id).Distinct())}");
+
+// 5) FIX
+var fixedSource = ApplyCodeFix(consumerSource, "WG2001", mappings);
+var fixedPath = Path.Combine(outputDir, "Consumer.fixed.cs");
+await File.WriteAllTextAsync(fixedPath, fixedSource);
+Console.WriteLine($"[fix] code fix output written: {fixedPath}");
+
+Console.WriteLine();
+Console.WriteLine("Summary:");
+Console.WriteLine($"- WG2001 present: {diagnostics.Any(d => d.Id == "WG2001")}");
+Console.WriteLine($"- WG2002 present: {diagnostics.Any(d => d.Id == "WG2002")}");
+Console.WriteLine($"- Generated BetterFoo interface: {File.Exists(Path.Combine(generatedDir, "IWrappedBetterFoo.g.cs"))}");
+Console.WriteLine($"- Generated BarClient wrapper (expected false): {File.Exists(Path.Combine(generatedDir, "IWrappedBarClient.g.cs"))}");
+
+return;
+
+static string GetRepoRoot()
+{
+    var current = new DirectoryInfo(AppContext.BaseDirectory);
+    while (current is not null)
+    {
+        if (File.Exists(Path.Combine(current.FullName, "WrapGod.slnx")))
+            return current.FullName;
+
+        current = current.Parent;
+    }
+
+    throw new InvalidOperationException("Could not locate repo root.");
+}
+
+static string BuildAcmeLibrary(string repoRoot)
+{
+    var projectPath = Path.Combine(repoRoot, "examples", "Acme.Lib", "Acme.Lib.csproj");
+    var psi = new System.Diagnostics.ProcessStartInfo("dotnet", $"build \"{projectPath}\" -c Release")
+    {
+        WorkingDirectory = repoRoot,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+    };
+
+    using var process = System.Diagnostics.Process.Start(psi)
+        ?? throw new InvalidOperationException("Failed to start dotnet build.");
+
+    string output = process.StandardOutput.ReadToEnd();
+    string error = process.StandardError.ReadToEnd();
+    process.WaitForExit();
+
+    if (process.ExitCode != 0)
+    {
+        throw new InvalidOperationException($"Acme.Lib build failed.{Environment.NewLine}{output}{Environment.NewLine}{error}");
+    }
+
+    var dllPath = Path.Combine(repoRoot, "examples", "Acme.Lib", "bin", "Release", "net10.0", "Acme.Lib.dll");
+    if (!File.Exists(dllPath))
+        throw new FileNotFoundException("Expected Acme.Lib.dll was not found.", dllPath);
+
+    return dllPath;
+}
+
+static GeneratorDriverRunResult RunGenerator(string manifestJson, string configJson)
+{
+    var syntaxTree = CSharpSyntaxTree.ParseText("namespace Placeholder; public class Marker { }");
+    var references = new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) };
+
+    var compilation = CSharpCompilation.Create(
+        assemblyName: "ExampleGeneration",
+        syntaxTrees: [syntaxTree],
+        references: references,
+        options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+    var additionalTexts = new List<AdditionalText>
+    {
+        new InMemoryAdditionalText("acme.wrapgod.json", manifestJson),
+        new InMemoryAdditionalText("acme.wrapgod.config.json", configJson),
+    };
+
+    IIncrementalGenerator generator = new WrapGodIncrementalGenerator();
+    GeneratorDriver driver = CSharpGeneratorDriver.Create(
+        generators: [generator.AsSourceGenerator()],
+        additionalTexts: additionalTexts);
+
+    driver = driver.RunGenerators(compilation);
+    return driver.GetRunResult();
+}
+
+static ImmutableArray<Diagnostic> RunAnalyzer(string source, string mappings)
+{
+    var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+    var references = new List<MetadataReference>
+    {
+        MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(Acme.Lib.FooService).Assembly.Location),
+    };
+
+    var netStandardPath = Path.Combine(
+        Path.GetDirectoryName(typeof(object).Assembly.Location)!,
+        "netstandard.dll");
+
+    if (File.Exists(netStandardPath))
+        references.Add(MetadataReference.CreateFromFile(netStandardPath));
+
+    var compilation = CSharpCompilation.Create(
+        "AnalyzerExample",
+        [syntaxTree],
+        references,
+        new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+    var analyzer = new DirectUsageAnalyzer();
+    var additionalTexts = new AdditionalText[]
+    {
+        new InMemoryAdditionalText("acme.wrapgod-types.txt", mappings),
+    };
+
+    var compilationWithAnalyzers = compilation.WithAnalyzers(
+        [analyzer],
+        new AnalyzerOptions(additionalTexts.ToImmutableArray()));
+
+    return compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().GetAwaiter().GetResult();
+}
+
+static string ApplyCodeFix(string source, string diagnosticId, string mappings)
+{
+    var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+    var references = new List<MetadataReference>
+    {
+        MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(Acme.Lib.FooService).Assembly.Location),
+    };
+
+    var netStandardPath = Path.Combine(
+        Path.GetDirectoryName(typeof(object).Assembly.Location)!,
+        "netstandard.dll");
+
+    if (File.Exists(netStandardPath))
+        references.Add(MetadataReference.CreateFromFile(netStandardPath));
+
+    var compilation = CSharpCompilation.Create(
+        "CodeFixExample",
+        [syntaxTree],
+        references,
+        new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+    var analyzer = new DirectUsageAnalyzer();
+    var additionalTexts = new AdditionalText[]
+    {
+        new InMemoryAdditionalText("acme.wrapgod-types.txt", mappings),
+    };
+
+    var diagnostics = compilation.WithAnalyzers(
+            [analyzer],
+            new AnalyzerOptions(additionalTexts.ToImmutableArray()))
+        .GetAnalyzerDiagnosticsAsync().GetAwaiter().GetResult();
+
+    var target = diagnostics.FirstOrDefault(d => d.Id == diagnosticId);
+    if (target is null)
+        return source;
+
+    var fixProvider = new UseWrapperCodeFixProvider();
+
+    var workspace = new AdhocWorkspace();
+    var projectId = ProjectId.CreateNewId();
+    var documentId = DocumentId.CreateNewId(projectId);
+
+    var projectInfo = ProjectInfo.Create(
+        projectId,
+        VersionStamp.Default,
+        name: "ExampleProject",
+        assemblyName: "ExampleProject",
+        language: LanguageNames.CSharp,
+        compilationOptions: compilation.Options,
+        metadataReferences: compilation.References);
+
+    var solution = workspace.CurrentSolution
+        .AddProject(projectInfo)
+        .AddDocument(documentId, "Consumer.cs", SourceText.From(source));
+
+    var document = solution.GetDocument(documentId)
+        ?? throw new InvalidOperationException("Could not create document for code fix.");
+
+    CodeAction? codeAction = null;
+    var context = new CodeFixContext(
+        document,
+        target,
+        registerCodeFix: (action, _) => codeAction = action,
+        cancellationToken: CancellationToken.None);
+
+    fixProvider.RegisterCodeFixesAsync(context).GetAwaiter().GetResult();
+    if (codeAction is null)
+        return source;
+
+    var operations = codeAction.GetOperationsAsync(CancellationToken.None).GetAwaiter().GetResult();
+    var changedSolution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
+    var changedDocument = changedSolution.GetDocument(documentId)
+        ?? throw new InvalidOperationException("Could not fetch changed document.");
+
+    return changedDocument.GetTextAsync().GetAwaiter().GetResult().ToString();
+}
+
+file sealed class InMemoryAdditionalText(string path, string content) : AdditionalText
+{
+    private readonly SourceText _text = SourceText.From(content);
+
+    public override string Path { get; } = path;
+
+    public override SourceText? GetText(CancellationToken cancellationToken = default)
+        => _text;
+}

--- a/examples/WrapGod.WorkflowDemo/WrapGod.WorkflowDemo.csproj
+++ b/examples/WrapGod.WorkflowDemo/WrapGod.WorkflowDemo.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Acme.Lib\Acme.Lib.csproj" />
+    <ProjectReference Include="..\..\WrapGod.Extractor\WrapGod.Extractor.csproj" />
+    <ProjectReference Include="..\..\WrapGod.Manifest\WrapGod.Manifest.csproj" />
+    <ProjectReference Include="..\..\WrapGod.Generator\WrapGod.Generator.csproj" />
+    <ProjectReference Include="..\..\WrapGod.Analyzers\WrapGod.Analyzers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Closes #43\n\n## Summary\n- Added a runnable end-to-end example under xamples/\n- Created xamples/Acme.Lib mock vendor library and xamples/WrapGod.WorkflowDemo orchestrator app\n- Demo executes: extract -> config -> generate -> analyze -> fix\n- Added docs and validation commands in xamples/README.md\n- Linked examples from top-level README.md\n\n## Validation\n- dotnet build examples/WrapGod.Examples.slnx -c Release\n- dotnet run --project examples/WrapGod.WorkflowDemo/WrapGod.WorkflowDemo.csproj -c Release\n  - WG2001 present: True\n  - WG2002 present: True\n  - Generated BetterFoo interface: True\n  - Generated BarClient wrapper (expected false): False\n- dotnet test WrapGod.Tests/WrapGod.Tests.csproj -c Release (94 passed)\n\n## CI\n- GitHub Actions uild-test passed on PR #56\n