### PR TITLE
Add BasicExample project

### DIFF
--- a/examples/BasicExample/BasicExample.slnx
+++ b/examples/BasicExample/BasicExample.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="VendorLib/VendorLib.csproj" />
+  <Project Path="MyApp/MyApp.csproj" />
+</Solution>

--- a/examples/BasicExample/MyApp/MyApp.csproj
+++ b/examples/BasicExample/MyApp/MyApp.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>MyApp</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VendorLib\VendorLib.csproj" />
+    <ProjectReference Include="..\..\..\WrapGod.Abstractions\WrapGod.Abstractions.csproj" />
+    <ProjectReference Include="..\..\..\WrapGod.Fluent\WrapGod.Fluent.csproj" />
+    <ProjectReference Include="..\..\..\WrapGod.Manifest\WrapGod.Manifest.csproj" />
+    <ProjectReference Include="..\..\..\WrapGod.TypeMap\WrapGod.TypeMap.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/BasicExample/MyApp/Program.cs
+++ b/examples/BasicExample/MyApp/Program.cs
@@ -1,0 +1,121 @@
+using WrapGod.Abstractions.Config;
+using WrapGod.Fluent;
+using WrapGod.Manifest.Config;
+using WrapGod.TypeMap;
+using WrapGod.TypeMap.Generation;
+
+// ────────────────────────────────────────────────────────────────
+// WrapGod Basic Example
+//
+// This example demonstrates the full WrapGod pipeline:
+//   1. Load a JSON config (wrapgod.json) defining which vendor types to wrap
+//   2. Build a TypeMappingPlan via the TypeMappingPlanner
+//   3. Emit generated mapper source code via the TypeMapperEmitter
+//   4. Show the equivalent fluent DSL configuration
+// ────────────────────────────────────────────────────────────────
+
+Console.WriteLine("=== WrapGod Basic Example ===");
+Console.WriteLine();
+
+// ── Step 1: Load the JSON config ────────────────────────────────
+var configPath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "wrapgod.json");
+if (!File.Exists(configPath))
+{
+    // Fallback: try relative to the working directory
+    configPath = Path.Combine(Directory.GetCurrentDirectory(), "wrapgod.json");
+}
+
+WrapGodConfig config;
+if (File.Exists(configPath))
+{
+    config = JsonConfigLoader.LoadFromFile(configPath);
+    Console.WriteLine($"Loaded config from: {configPath}");
+}
+else
+{
+    // Build config in-memory as fallback
+    config = new WrapGodConfig();
+    config.Types.Add(new TypeConfig
+    {
+        SourceType = "VendorLib.HttpClient",
+        Include = true,
+        TargetName = "IHttpClient",
+    });
+    config.Types[0].Members.Add(new MemberConfig { SourceMember = "Get", Include = true, TargetName = "SendGet" });
+    config.Types[0].Members.Add(new MemberConfig { SourceMember = "Post", Include = true, TargetName = "SendPost" });
+    config.Types[0].Members.Add(new MemberConfig { SourceMember = "Timeout", Include = true });
+
+    config.Types.Add(new TypeConfig
+    {
+        SourceType = "VendorLib.Logger",
+        Include = true,
+        TargetName = "ILogger",
+    });
+    config.Types[1].Members.Add(new MemberConfig { SourceMember = "Info", Include = true });
+    config.Types[1].Members.Add(new MemberConfig { SourceMember = "Warn", Include = true });
+    config.Types[1].Members.Add(new MemberConfig { SourceMember = "Error", Include = true });
+
+    Console.WriteLine("Config file not found; using in-memory config.");
+}
+
+Console.WriteLine($"  Types configured: {config.Types.Count}");
+Console.WriteLine();
+
+// ── Step 2: Build a TypeMappingPlan ─────────────────────────────
+var overrides = new List<TypeMappingOverride>
+{
+    new() { SourceType = "VendorLib.LogLevel", Kind = TypeMappingKind.Enum },
+};
+
+var plan = TypeMappingPlanner.BuildPlan(config, overrides);
+Console.WriteLine($"TypeMappingPlan built: {plan.Mappings.Count} mapping(s)");
+foreach (var mapping in plan.Mappings)
+{
+    Console.WriteLine($"  {mapping.SourceType} -> {mapping.DestinationType} ({mapping.Kind})");
+    foreach (var member in mapping.MemberMappings)
+    {
+        Console.WriteLine($"    {member.SourceMember} -> {member.DestinationMember}");
+    }
+}
+
+Console.WriteLine();
+
+// ── Step 3: Emit generated mapper source code ───────────────────
+var generatedCode = TypeMapperEmitter.Emit(plan);
+Console.WriteLine("Generated mapper source code:");
+Console.WriteLine(new string('-', 60));
+Console.WriteLine(generatedCode);
+Console.WriteLine(new string('-', 60));
+Console.WriteLine();
+
+// ── Step 4: Equivalent fluent DSL configuration ─────────────────
+Console.WriteLine("Equivalent fluent DSL configuration:");
+var fluentPlan = WrapGodConfiguration.Create()
+    .ForAssembly("VendorLib")
+    .WrapType("VendorLib.HttpClient")
+        .As("IHttpClient")
+        .WrapMethod("Get").As("SendGet")
+        .WrapMethod("Post").As("SendPost")
+        .WrapProperty("Timeout")
+        .ExcludeMember("Dispose")
+    .WrapType("VendorLib.Logger")
+        .As("ILogger")
+        .WrapAllPublicMembers()
+    .MapType("VendorLib.LogLevel", "AppLogLevel")
+    .Build();
+
+Console.WriteLine($"  Assembly: {fluentPlan.AssemblyName}");
+Console.WriteLine($"  Type directives: {fluentPlan.TypeDirectives.Count}");
+Console.WriteLine($"  Type mappings: {fluentPlan.TypeMappings.Count}");
+
+foreach (var td in fluentPlan.TypeDirectives)
+{
+    Console.WriteLine($"  {td.SourceType} -> {td.TargetName ?? "(same)"}");
+    foreach (var md in td.MemberDirectives)
+    {
+        Console.WriteLine($"    {md.SourceName} -> {md.TargetName ?? "(same)"} ({md.Kind})");
+    }
+}
+
+Console.WriteLine();
+Console.WriteLine("Done.");

--- a/examples/BasicExample/MyApp/wrapgod.json
+++ b/examples/BasicExample/MyApp/wrapgod.json
@@ -1,0 +1,31 @@
+{
+  "types": [
+    {
+      "sourceType": "VendorLib.HttpClient",
+      "include": true,
+      "targetName": "IHttpClient",
+      "members": [
+        { "sourceMember": "Get", "include": true, "targetName": "SendGet" },
+        { "sourceMember": "Post", "include": true, "targetName": "SendPost" },
+        { "sourceMember": "Timeout", "include": true },
+        { "sourceMember": "Dispose", "include": false }
+      ]
+    },
+    {
+      "sourceType": "VendorLib.Logger",
+      "include": true,
+      "targetName": "ILogger",
+      "members": [
+        { "sourceMember": "Info", "include": true },
+        { "sourceMember": "Warn", "include": true },
+        { "sourceMember": "Error", "include": true }
+      ]
+    },
+    {
+      "sourceType": "VendorLib.LogLevel",
+      "include": true,
+      "targetName": "AppLogLevel",
+      "members": []
+    }
+  ]
+}

--- a/examples/BasicExample/README.md
+++ b/examples/BasicExample/README.md
@@ -1,0 +1,43 @@
+# WrapGod Basic Example
+
+This example demonstrates the core WrapGod pipeline: taking a third-party
+library and generating type-safe wrappers around it.
+
+## Project structure
+
+```
+BasicExample/
+  VendorLib/          # Simulated third-party library
+    HttpClient.cs     # HTTP client class to wrap
+    Logger.cs         # Logger class + LogLevel enum to wrap
+  MyApp/              # Consuming application
+    wrapgod.json      # WrapGod manifest — defines which types/members to wrap
+    Program.cs        # Runs the full pipeline end-to-end
+  BasicExample.slnx   # Solution file
+```
+
+## What it shows
+
+1. **JSON config loading** — `wrapgod.json` declares which vendor types to
+   include, which members to expose, and how to rename them.
+2. **TypeMappingPlanner** — Builds a `TypeMappingPlan` from the config,
+   supporting object mappings, enum casts, and member renames.
+3. **TypeMapperEmitter** — Generates C# static mapper classes with `Map()`
+   methods that convert from vendor types to your wrapper types.
+4. **Fluent DSL** — Shows the equivalent configuration built programmatically
+   with the `WrapGodConfiguration` fluent API.
+
+## Running the example
+
+```bash
+# From the repository root
+dotnet run --project examples/BasicExample/MyApp/MyApp.csproj
+
+# Or from this directory
+dotnet run --project MyApp/MyApp.csproj
+```
+
+## Expected output
+
+The program prints the loaded config summary, the generated mapper source code,
+and the equivalent fluent DSL configuration to the console.

--- a/examples/BasicExample/VendorLib/HttpClient.cs
+++ b/examples/BasicExample/VendorLib/HttpClient.cs
@@ -1,0 +1,32 @@
+namespace VendorLib;
+
+/// <summary>
+/// A simulated third-party HTTP client that your application depends on.
+/// In a real scenario this would come from an external NuGet package.
+/// </summary>
+public class HttpClient
+{
+    /// <summary>Timeout in seconds for HTTP requests.</summary>
+    public int Timeout { get; set; } = 30;
+
+    /// <summary>The base URL for requests.</summary>
+    public string BaseUrl { get; set; } = "https://api.example.com";
+
+    /// <summary>Send a GET request and return the response body.</summary>
+    public string Get(string path)
+    {
+        return $"[GET {BaseUrl}/{path} timeout={Timeout}s]";
+    }
+
+    /// <summary>Send a POST request with a body and return the response.</summary>
+    public string Post(string path, string body)
+    {
+        return $"[POST {BaseUrl}/{path} body={body} timeout={Timeout}s]";
+    }
+
+    /// <summary>Dispose underlying resources. Consumers should not need this on the wrapper.</summary>
+    public void Dispose()
+    {
+        // no-op for demo
+    }
+}

--- a/examples/BasicExample/VendorLib/Logger.cs
+++ b/examples/BasicExample/VendorLib/Logger.cs
@@ -1,0 +1,31 @@
+namespace VendorLib;
+
+/// <summary>
+/// A simulated third-party logger. Wrapping it lets you swap
+/// implementations without touching consuming code.
+/// </summary>
+public class Logger
+{
+    /// <summary>The minimum log level.</summary>
+    public LogLevel MinLevel { get; set; } = LogLevel.Info;
+
+    /// <summary>Log an informational message.</summary>
+    public void Info(string message) => Console.WriteLine($"[INFO] {message}");
+
+    /// <summary>Log a warning message.</summary>
+    public void Warn(string message) => Console.WriteLine($"[WARN] {message}");
+
+    /// <summary>Log an error message.</summary>
+    public void Error(string message) => Console.WriteLine($"[ERROR] {message}");
+}
+
+/// <summary>
+/// Log severity levels used by the vendor logger.
+/// </summary>
+public enum LogLevel
+{
+    Debug,
+    Info,
+    Warn,
+    Error,
+}

--- a/examples/BasicExample/VendorLib/VendorLib.csproj
+++ b/examples/BasicExample/VendorLib/VendorLib.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>VendorLib</RootNamespace>
+    <!-- Suppress CA1822 — these are intentionally instance methods to simulate a real vendor API -->
+    <NoWarn>$(NoWarn);CA1822</NoWarn>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Adds `examples/BasicExample/` with a simulated VendorLib (HttpClient, Logger, LogLevel enum) and a consuming MyApp
- MyApp demonstrates the full pipeline: JSON config loading, TypeMappingPlanner, TypeMapperEmitter, and fluent DSL equivalent
- Includes a `wrapgod.json` manifest and a walkthrough README

## Test plan
- [x] `BasicExample.slnx` builds with zero warnings/errors
- [x] Main `WrapGod.slnx` still builds cleanly

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)