### PR TITLE
Add Moq to NSubstitute migration example

### DIFF
--- a/examples/MoqToNSubstitute/README.md
+++ b/examples/MoqToNSubstitute/README.md
@@ -1,0 +1,104 @@
+# Moq to NSubstitute Migration Example
+
+This example demonstrates how WrapGod can orchestrate a migration from
+[Moq](https://github.com/devlooped/moq) to
+[NSubstitute](https://nsubstitute.github.io/) in a .NET test project.
+
+## Directory layout
+
+```
+MoqToNSubstitute/
+  SampleTests.Before/     -- test project using Moq
+  SampleTests.After/      -- same tests rewritten with NSubstitute
+  migration.wrapgod.json  -- manifest describing the Moq API surface
+  migration.wrapgod.config.json -- mapping rules from Moq to NSubstitute
+```
+
+## Semantic differences
+
+Moq and NSubstitute differ in fundamental design philosophy, which impacts
+migration beyond simple find-and-replace:
+
+| Aspect | Moq | NSubstitute |
+|--------|-----|-------------|
+| Creation | `new Mock<T>()` wraps T | `Substitute.For<T>()` returns T directly |
+| Access | `mock.Object` to get instance | Substitute *is* the instance |
+| Setup | `mock.Setup(x => x.Foo()).Returns(bar)` | `sub.Foo().Returns(bar)` |
+| Verify | `mock.Verify(x => x.Foo(), Times.Once)` | `sub.Received(1).Foo()` |
+| Never called | `Times.Never` | `sub.DidNotReceive().Foo()` |
+| Any arg | `It.IsAny<T>()` | `Arg.Any<T>()` |
+| Predicate | `It.Is<T>(pred)` | `Arg.Is<T>(pred)` |
+
+## What WrapGod does at each step
+
+### 1. Extract the Moq API surface
+
+The `migration.wrapgod.json` manifest captures `Mock<T>`, `It`, `Times`, and
+setup/verify infrastructure. In production this comes from the extractor.
+
+### 2. Define the mapping configuration
+
+`migration.wrapgod.config.json` maps each Moq pattern to NSubstitute with
+safety ratings:
+
+- **safe** -- Direct structural mapping (e.g., `It.IsAny<T>()` to `Arg.Any<T>()`)
+- **guided** -- Requires restructuring (e.g., `Callback`, `MockBehavior.Strict`)
+- **manual** -- No equivalent exists (e.g., `VerifyAll`, `VerifyNoOtherCalls`)
+
+### 3. Key migration patterns
+
+**Mock creation and access:**
+```csharp
+// Moq
+var mock = new Mock<IService>();
+var sut = new MyClass(mock.Object);
+
+// NSubstitute
+var service = Substitute.For<IService>();
+var sut = new MyClass(service);
+```
+
+**Setup and returns:**
+```csharp
+// Moq
+mock.Setup(x => x.GetById(1)).Returns(expected);
+
+// NSubstitute
+service.GetById(1).Returns(expected);
+```
+
+**Verification:**
+```csharp
+// Moq
+mock.Verify(x => x.Save(It.IsAny<User>()), Times.Once);
+mock.Verify(x => x.Delete(It.IsAny<int>()), Times.Never);
+
+// NSubstitute
+service.Received(1).Save(Arg.Any<User>());
+service.DidNotReceive().Delete(Arg.Any<int>());
+```
+
+### 4. Risky or unsupported patterns
+
+| Moq pattern | NSubstitute | Risk |
+|-------------|-------------|------|
+| `MockBehavior.Strict` | No equivalent | Tests may pass when they should fail |
+| `VerifyAll()` | Manual per-call Received | Must list each expectation |
+| `VerifyNoOtherCalls()` | No equivalent | Cannot detect unexpected calls |
+| `Callback(action)` | Returns lambda | Structural rewrite |
+
+### 5. Validate
+
+Compare `SampleTests.Before/` and `SampleTests.After/` side by side. Both
+projects compile and exercise the same service logic with equivalent
+verification semantics.
+
+## Running the examples
+
+```bash
+# Build and run the "before" tests
+dotnet test examples/MoqToNSubstitute/SampleTests.Before/
+
+# Build and run the "after" tests
+dotnet test examples/MoqToNSubstitute/SampleTests.After/
+```

--- a/examples/MoqToNSubstitute/SampleTests.After/Interfaces.cs
+++ b/examples/MoqToNSubstitute/SampleTests.After/Interfaces.cs
@@ -1,0 +1,59 @@
+namespace SampleTests.After;
+
+public interface IEmailService
+{
+    bool SendEmail(string to, string subject, string body);
+    Task<bool> SendEmailAsync(string to, string subject, string body);
+}
+
+public interface IUserRepository
+{
+    User? GetById(int id);
+    IReadOnlyList<User> GetAll();
+    void Save(User user);
+}
+
+public interface ILogger
+{
+    void Log(string message);
+    void LogError(string message, Exception exception);
+}
+
+public class User
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+}
+
+public class UserService(IUserRepository repository, IEmailService emailService, ILogger logger)
+{
+    public User? GetUser(int id)
+    {
+        logger.Log($"Getting user {id}");
+        return repository.GetById(id);
+    }
+
+    public bool NotifyUser(int userId, string message)
+    {
+        var user = repository.GetById(userId);
+        if (user is null)
+        {
+            logger.LogError("User not found", new InvalidOperationException($"User {userId} not found"));
+            return false;
+        }
+
+        return emailService.SendEmail(user.Email, "Notification", message);
+    }
+
+    public void DeactivateUser(int userId)
+    {
+        var user = repository.GetById(userId);
+        if (user is null) return;
+
+        user.IsActive = false;
+        repository.Save(user);
+        logger.Log($"Deactivated user {userId}");
+    }
+}

--- a/examples/MoqToNSubstitute/SampleTests.After/SampleTests.After.csproj
+++ b/examples/MoqToNSubstitute/SampleTests.After/SampleTests.After.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/MoqToNSubstitute/SampleTests.After/UserServiceTests.cs
+++ b/examples/MoqToNSubstitute/SampleTests.After/UserServiceTests.cs
@@ -1,0 +1,87 @@
+using NSubstitute;
+using Xunit;
+
+namespace SampleTests.After;
+
+public class UserServiceTests
+{
+    private readonly IUserRepository _repository = Substitute.For<IUserRepository>();
+    private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+    private readonly ILogger _logger = Substitute.For<ILogger>();
+    private readonly UserService _sut;
+
+    public UserServiceTests()
+    {
+        _sut = new UserService(_repository, _emailService, _logger);
+    }
+
+    [Fact]
+    public void GetUser_ShouldReturnUser_WhenFound()
+    {
+        var expected = new User { Id = 1, Name = "Alice" };
+        _repository.GetById(1).Returns(expected);
+
+        var result = _sut.GetUser(1);
+
+        Assert.Equal(expected, result);
+        _logger.Received(1).Log(Arg.Any<string>());
+    }
+
+    [Fact]
+    public void GetUser_ShouldReturnNull_WhenNotFound()
+    {
+        _repository.GetById(Arg.Any<int>()).Returns((User?)null);
+
+        var result = _sut.GetUser(99);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void NotifyUser_ShouldSendEmail_WhenUserExists()
+    {
+        var user = new User { Id = 1, Email = "alice@example.com" };
+        _repository.GetById(1).Returns(user);
+        _emailService.SendEmail(user.Email, "Notification", "Hello").Returns(true);
+
+        var result = _sut.NotifyUser(1, "Hello");
+
+        Assert.True(result);
+        _emailService.Received(1).SendEmail("alice@example.com", "Notification", "Hello");
+    }
+
+    [Fact]
+    public void NotifyUser_ShouldReturnFalse_WhenUserNotFound()
+    {
+        _repository.GetById(Arg.Any<int>()).Returns((User?)null);
+
+        var result = _sut.NotifyUser(99, "Hello");
+
+        Assert.False(result);
+        _logger.Received(1).LogError(Arg.Any<string>(), Arg.Any<Exception>());
+        _emailService.DidNotReceive().SendEmail(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public void DeactivateUser_ShouldSaveAndLog()
+    {
+        var user = new User { Id = 1, IsActive = true };
+        _repository.GetById(1).Returns(user);
+
+        _sut.DeactivateUser(1);
+
+        Assert.False(user.IsActive);
+        _repository.Received(1).Save(Arg.Is<User>(u => !u.IsActive));
+        _logger.Received(1).Log(Arg.Is<string>(s => s.Contains("Deactivated")));
+    }
+
+    [Fact]
+    public void DeactivateUser_ShouldDoNothing_WhenUserNotFound()
+    {
+        _repository.GetById(Arg.Any<int>()).Returns((User?)null);
+
+        _sut.DeactivateUser(99);
+
+        _repository.DidNotReceive().Save(Arg.Any<User>());
+    }
+}

--- a/examples/MoqToNSubstitute/SampleTests.Before/Interfaces.cs
+++ b/examples/MoqToNSubstitute/SampleTests.Before/Interfaces.cs
@@ -1,0 +1,59 @@
+namespace SampleTests.Before;
+
+public interface IEmailService
+{
+    bool SendEmail(string to, string subject, string body);
+    Task<bool> SendEmailAsync(string to, string subject, string body);
+}
+
+public interface IUserRepository
+{
+    User? GetById(int id);
+    IReadOnlyList<User> GetAll();
+    void Save(User user);
+}
+
+public interface ILogger
+{
+    void Log(string message);
+    void LogError(string message, Exception exception);
+}
+
+public class User
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+}
+
+public class UserService(IUserRepository repository, IEmailService emailService, ILogger logger)
+{
+    public User? GetUser(int id)
+    {
+        logger.Log($"Getting user {id}");
+        return repository.GetById(id);
+    }
+
+    public bool NotifyUser(int userId, string message)
+    {
+        var user = repository.GetById(userId);
+        if (user is null)
+        {
+            logger.LogError("User not found", new InvalidOperationException($"User {userId} not found"));
+            return false;
+        }
+
+        return emailService.SendEmail(user.Email, "Notification", message);
+    }
+
+    public void DeactivateUser(int userId)
+    {
+        var user = repository.GetById(userId);
+        if (user is null) return;
+
+        user.IsActive = false;
+        repository.Save(user);
+        logger.Log($"Deactivated user {userId}");
+    }
+}

--- a/examples/MoqToNSubstitute/SampleTests.Before/SampleTests.Before.csproj
+++ b/examples/MoqToNSubstitute/SampleTests.Before/SampleTests.Before.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+
+</Project>

--- a/examples/MoqToNSubstitute/SampleTests.Before/UserServiceTests.cs
+++ b/examples/MoqToNSubstitute/SampleTests.Before/UserServiceTests.cs
@@ -1,0 +1,106 @@
+using Moq;
+using Xunit;
+
+namespace SampleTests.Before;
+
+public class UserServiceTests
+{
+    private readonly Mock<IUserRepository> _repositoryMock = new();
+    private readonly Mock<IEmailService> _emailServiceMock = new();
+    private readonly Mock<ILogger> _loggerMock = new();
+    private readonly UserService _sut;
+
+    public UserServiceTests()
+    {
+        _sut = new UserService(
+            _repositoryMock.Object,
+            _emailServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public void GetUser_ShouldReturnUser_WhenFound()
+    {
+        var expected = new User { Id = 1, Name = "Alice" };
+        _repositoryMock
+            .Setup(r => r.GetById(1))
+            .Returns(expected);
+
+        var result = _sut.GetUser(1);
+
+        Assert.Equal(expected, result);
+        _loggerMock.Verify(l => l.Log(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void GetUser_ShouldReturnNull_WhenNotFound()
+    {
+        _repositoryMock
+            .Setup(r => r.GetById(It.IsAny<int>()))
+            .Returns((User?)null);
+
+        var result = _sut.GetUser(99);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void NotifyUser_ShouldSendEmail_WhenUserExists()
+    {
+        var user = new User { Id = 1, Email = "alice@example.com" };
+        _repositoryMock.Setup(r => r.GetById(1)).Returns(user);
+        _emailServiceMock
+            .Setup(e => e.SendEmail(user.Email, "Notification", "Hello"))
+            .Returns(true);
+
+        var result = _sut.NotifyUser(1, "Hello");
+
+        Assert.True(result);
+        _emailServiceMock.Verify(
+            e => e.SendEmail("alice@example.com", "Notification", "Hello"),
+            Times.Once);
+    }
+
+    [Fact]
+    public void NotifyUser_ShouldReturnFalse_WhenUserNotFound()
+    {
+        _repositoryMock
+            .Setup(r => r.GetById(It.IsAny<int>()))
+            .Returns((User?)null);
+
+        var result = _sut.NotifyUser(99, "Hello");
+
+        Assert.False(result);
+        _loggerMock.Verify(
+            l => l.LogError(It.IsAny<string>(), It.IsAny<Exception>()),
+            Times.Once);
+        _emailServiceMock.Verify(
+            e => e.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void DeactivateUser_ShouldSaveAndLog()
+    {
+        var user = new User { Id = 1, IsActive = true };
+        _repositoryMock.Setup(r => r.GetById(1)).Returns(user);
+
+        _sut.DeactivateUser(1);
+
+        Assert.False(user.IsActive);
+        _repositoryMock.Verify(r => r.Save(It.Is<User>(u => !u.IsActive)), Times.Once);
+        _loggerMock.Verify(l => l.Log(It.Is<string>(s => s.Contains("Deactivated"))), Times.Once);
+    }
+
+    [Fact]
+    public void DeactivateUser_ShouldDoNothing_WhenUserNotFound()
+    {
+        _repositoryMock
+            .Setup(r => r.GetById(It.IsAny<int>()))
+            .Returns((User?)null);
+
+        _sut.DeactivateUser(99);
+
+        _repositoryMock.Verify(r => r.Save(It.IsAny<User>()), Times.Never);
+    }
+}

--- a/examples/MoqToNSubstitute/migration.wrapgod.config.json
+++ b/examples/MoqToNSubstitute/migration.wrapgod.config.json
@@ -1,0 +1,104 @@
+{
+  "migrationName": "Moq-to-NSubstitute",
+  "sourceLibrary": "Moq",
+  "targetLibrary": "NSubstitute",
+  "sourcePackage": "Moq",
+  "targetPackage": "NSubstitute",
+  "usingReplacements": {
+    "Moq": "NSubstitute"
+  },
+  "mappings": [
+    {
+      "description": "Mock creation",
+      "source": "new Mock<{T}>()",
+      "target": "Substitute.For<{T}>()",
+      "safety": "safe",
+      "notes": "Moq wraps in Mock<T>; NSubstitute returns the interface directly."
+    },
+    {
+      "description": "Accessing mock object",
+      "source": "{mock}.Object",
+      "target": "{mock}",
+      "safety": "safe",
+      "notes": "NSubstitute substitutes are the object directly -- no .Object accessor needed."
+    },
+    {
+      "description": "Setup with returns",
+      "source": "{mock}.Setup(x => x.{Method}({args})).Returns({value})",
+      "target": "{mock}.{Method}({args}).Returns({value})",
+      "safety": "safe",
+      "notes": "NSubstitute chains Returns directly on the method call."
+    },
+    {
+      "description": "Setup with throws",
+      "source": "{mock}.Setup(x => x.{Method}({args})).Throws({exception})",
+      "target": "{mock}.{Method}({args}).Throws({exception})",
+      "safety": "safe"
+    },
+    {
+      "description": "Verify called once",
+      "source": "{mock}.Verify(x => x.{Method}({args}), Times.Once)",
+      "target": "{mock}.Received(1).{Method}({args})",
+      "safety": "safe"
+    },
+    {
+      "description": "Verify never called",
+      "source": "{mock}.Verify(x => x.{Method}({args}), Times.Never)",
+      "target": "{mock}.DidNotReceive().{Method}({args})",
+      "safety": "safe"
+    },
+    {
+      "description": "Verify called exactly N times",
+      "source": "{mock}.Verify(x => x.{Method}({args}), Times.Exactly({n}))",
+      "target": "{mock}.Received({n}).{Method}({args})",
+      "safety": "safe"
+    },
+    {
+      "description": "Verify called at least once",
+      "source": "{mock}.Verify(x => x.{Method}({args}), Times.AtLeastOnce)",
+      "target": "{mock}.Received().{Method}({args})",
+      "safety": "safe",
+      "notes": "Received() with no count means at-least-once in NSubstitute."
+    },
+    {
+      "description": "Argument matcher: any",
+      "source": "It.IsAny<{T}>()",
+      "target": "Arg.Any<{T}>()",
+      "safety": "safe"
+    },
+    {
+      "description": "Argument matcher: predicate",
+      "source": "It.Is<{T}>({predicate})",
+      "target": "Arg.Is<{T}>({predicate})",
+      "safety": "safe"
+    },
+    {
+      "description": "Callback on setup",
+      "source": "{mock}.Setup(x => x.{Method}({args})).Callback({action})",
+      "target": "{mock}.{Method}({args}).Returns(x => { {action}; return default; })",
+      "safety": "guided",
+      "notes": "NSubstitute callbacks are expressed via Returns lambda. Structural rewrite required."
+    },
+    {
+      "description": "MockBehavior.Strict",
+      "source": "new Mock<{T}>(MockBehavior.Strict)",
+      "target": "Substitute.For<{T}>()",
+      "safety": "guided",
+      "notes": "NSubstitute has no strict mode. Unmatched calls return defaults instead of throwing. Review test expectations."
+    },
+    {
+      "description": "VerifyAll",
+      "source": "{mock}.VerifyAll()",
+      "target": "// NSubstitute: verify each call individually with Received()",
+      "safety": "manual",
+      "notes": "No direct NSubstitute equivalent. Each expected call must be verified explicitly."
+    },
+    {
+      "description": "VerifyNoOtherCalls",
+      "source": "{mock}.VerifyNoOtherCalls()",
+      "target": "// NSubstitute: no direct equivalent -- review call expectations",
+      "safety": "manual",
+      "notes": "NSubstitute does not track unexpected calls the same way. Consider restructuring verification."
+    }
+  ]
+}

--- a/examples/MoqToNSubstitute/migration.wrapgod.json
+++ b/examples/MoqToNSubstitute/migration.wrapgod.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "../../schemas/wrapgod.manifest.v1.schema.json",
+  "name": "Moq",
+  "version": "4.20.72",
+  "description": "Manifest defining the Moq public API surface targeted for migration to NSubstitute.",
+  "types": [
+    {
+      "name": "Moq.Mock`1",
+      "namespace": "Moq",
+      "kind": "Class",
+      "genericParameters": ["T"],
+      "members": [
+        { "name": ".ctor", "kind": "Constructor", "parameters": [] },
+        { "name": "Object", "kind": "Property", "returnType": "T" },
+        { "name": "Setup", "kind": "Method", "returnType": "ISetup<T>", "parameters": [{ "name": "expression", "type": "Expression<Func<T, TResult>>" }] },
+        { "name": "Verify", "kind": "Method", "returnType": "void", "parameters": [{ "name": "expression", "type": "Expression<Action<T>>" }] },
+        { "name": "Verify", "kind": "Method", "returnType": "void", "parameters": [{ "name": "expression", "type": "Expression<Action<T>>" }, { "name": "times", "type": "Times" }] }
+      ]
+    },
+    {
+      "name": "Moq.Language.Flow.ISetup`1",
+      "namespace": "Moq.Language.Flow",
+      "kind": "Interface",
+      "members": [
+        { "name": "Returns", "kind": "Method", "returnType": "IReturnsResult<T>", "parameters": [{ "name": "value", "type": "TResult" }] },
+        { "name": "Throws", "kind": "Method", "returnType": "IThrowsResult", "parameters": [{ "name": "exception", "type": "Exception" }] },
+        { "name": "Callback", "kind": "Method", "returnType": "ICallbackResult", "parameters": [{ "name": "action", "type": "Action" }] }
+      ]
+    },
+    {
+      "name": "Moq.Times",
+      "namespace": "Moq",
+      "kind": "Struct",
+      "members": [
+        { "name": "Once", "kind": "Method", "returnType": "Times", "parameters": [], "isStatic": true },
+        { "name": "Never", "kind": "Method", "returnType": "Times", "parameters": [], "isStatic": true },
+        { "name": "Exactly", "kind": "Method", "returnType": "Times", "parameters": [{ "name": "callCount", "type": "int" }], "isStatic": true },
+        { "name": "AtLeastOnce", "kind": "Method", "returnType": "Times", "parameters": [], "isStatic": true }
+      ]
+    },
+    {
+      "name": "Moq.It",
+      "namespace": "Moq",
+      "kind": "Static",
+      "members": [
+        { "name": "IsAny", "kind": "Method", "returnType": "TValue", "parameters": [] },
+        { "name": "Is", "kind": "Method", "returnType": "TValue", "parameters": [{ "name": "match", "type": "Expression<Func<TValue, bool>>" }] }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Before/After test projects showing Moq -> NSubstitute migration patterns
- Manifest and config files with 14 mapping rules including safety ratings
- README documenting semantic differences (Mock<T> vs Substitute.For<T>, Verify vs Received) and risky patterns (VerifyAll, Strict mode)

Closes #62

## Test plan
- [ ] Verify both SampleTests.Before and SampleTests.After compile
- [ ] Review config for completeness of Moq API coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)