### PR TITLE
Add WrapGod CLI tool (wrap-god)

### DIFF
--- a/WrapGod.Cli/AnalyzeCommand.cs
+++ b/WrapGod.Cli/AnalyzeCommand.cs
@@ -1,0 +1,84 @@
+using System.CommandLine;
+using System.Text.Json;
+using WrapGod.Manifest;
+
+namespace WrapGod.Cli;
+
+internal static class AnalyzeCommand
+{
+    public static Command Create()
+    {
+        var manifestPathArg = new Argument<FileInfo>(
+            "manifest-path",
+            "Path to the WrapGod manifest JSON file");
+
+        var configOption = new Option<FileInfo?>(
+            ["--config", "-c"],
+            "Path to the WrapGod config JSON file");
+
+        var command = new Command("analyze", "Analyze a manifest and report diagnostic information")
+        {
+            manifestPathArg,
+            configOption
+        };
+
+        command.SetHandler(HandleAsync, manifestPathArg, configOption);
+        return command;
+    }
+
+    private static async Task HandleAsync(FileInfo manifestPath, FileInfo? config)
+    {
+        if (!manifestPath.Exists)
+        {
+            Console.Error.WriteLine($"Manifest not found: {manifestPath.FullName}");
+            return;
+        }
+
+        Console.WriteLine("WrapGod Analyzer");
+        Console.WriteLine(new string('-', 40));
+        Console.WriteLine();
+
+        var json = await File.ReadAllTextAsync(manifestPath.FullName);
+        var manifest = JsonSerializer.Deserialize<ApiManifest>(json);
+
+        if (manifest is null)
+        {
+            Console.Error.WriteLine("Failed to deserialize manifest.");
+            return;
+        }
+
+        Console.WriteLine($"Assembly:    {manifest.Assembly.Name}");
+        Console.WriteLine($"Version:     {manifest.Assembly.Version}");
+        Console.WriteLine($"Types:       {manifest.Types.Count}");
+
+        var totalMembers = manifest.Types.Sum(t => t.Members.Count);
+        Console.WriteLine($"Members:     {totalMembers}");
+        Console.WriteLine();
+
+        Console.WriteLine("Type breakdown:");
+        foreach (var type in manifest.Types)
+        {
+            Console.WriteLine($"  {type.FullName}");
+            Console.WriteLine($"    Kind: {type.Kind}, Members: {type.Members.Count}");
+            foreach (var member in type.Members)
+            {
+                Console.WriteLine($"      - {member.Name} ({member.Kind})");
+            }
+        }
+
+        if (config is not null)
+        {
+            Console.WriteLine();
+            if (config.Exists)
+                Console.WriteLine($"Config loaded: {config.FullName}");
+            else
+                Console.Error.WriteLine($"Config not found: {config.FullName}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("For full analysis with Roslyn diagnostics (WG2001, WG2002), add");
+        Console.WriteLine("WrapGod.Analyzers to your project and build:");
+        Console.WriteLine("  dotnet add package WrapGod.Analyzers");
+        Console.WriteLine("  dotnet build");
+    }
+}

--- a/WrapGod.Cli/ExtractCommand.cs
+++ b/WrapGod.Cli/ExtractCommand.cs
@@ -1,0 +1,51 @@
+using System.CommandLine;
+using System.Text.Json;
+using WrapGod.Extractor;
+
+namespace WrapGod.Cli;
+
+internal static class ExtractCommand
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
+
+    public static Command Create()
+    {
+        var assemblyPathArg = new Argument<FileInfo>(
+            "assembly-path",
+            "Path to the .NET assembly to extract");
+
+        var outputOption = new Option<FileInfo>(
+            ["--output", "-o"],
+            () => new FileInfo("manifest.json"),
+            "Output path for the generated manifest");
+
+        var command = new Command("extract", "Extract API manifest from a .NET assembly")
+        {
+            assemblyPathArg,
+            outputOption
+        };
+
+        command.SetHandler(HandleAsync, assemblyPathArg, outputOption);
+        return command;
+    }
+
+    private static async Task HandleAsync(FileInfo assemblyPath, FileInfo output)
+    {
+        if (!assemblyPath.Exists)
+        {
+            Console.Error.WriteLine($"Assembly not found: {assemblyPath.FullName}");
+            return;
+        }
+
+        Console.WriteLine($"Extracting manifest from {assemblyPath.Name}...");
+
+        var manifest = AssemblyExtractor.Extract(assemblyPath.FullName);
+
+        var json = JsonSerializer.Serialize(manifest, SerializerOptions);
+
+        await File.WriteAllTextAsync(output.FullName, json);
+        Console.WriteLine($"Manifest written to {output.FullName}");
+        Console.WriteLine($"  Types: {manifest.Types.Count}");
+        Console.WriteLine($"  Members: {manifest.Types.Sum(t => t.Members.Count)}");
+    }
+}

--- a/WrapGod.Cli/GenerateCommand.cs
+++ b/WrapGod.Cli/GenerateCommand.cs
@@ -1,0 +1,64 @@
+using System.CommandLine;
+
+namespace WrapGod.Cli;
+
+internal static class GenerateCommand
+{
+    public static Command Create()
+    {
+        var manifestPathArg = new Argument<FileInfo>(
+            "manifest-path",
+            "Path to the WrapGod manifest JSON file");
+
+        var configOption = new Option<FileInfo?>(
+            ["--config", "-c"],
+            "Path to the WrapGod config JSON file");
+
+        var outputDirOption = new Option<DirectoryInfo>(
+            ["--output-dir", "-o"],
+            () => new DirectoryInfo("./generated"),
+            "Output directory for generated source files");
+
+        var command = new Command("generate", "Generate wrapper source from a manifest (compile-time)")
+        {
+            manifestPathArg,
+            configOption,
+            outputDirOption
+        };
+
+        command.SetHandler(Handle, manifestPathArg, configOption, outputDirOption);
+        return command;
+    }
+
+    private static void Handle(FileInfo manifestPath, FileInfo? config, DirectoryInfo outputDir)
+    {
+        if (!manifestPath.Exists)
+        {
+            Console.Error.WriteLine($"Manifest not found: {manifestPath.FullName}");
+            return;
+        }
+
+        Console.WriteLine("WrapGod Generator");
+        Console.WriteLine(new string('-', 40));
+        Console.WriteLine();
+        Console.WriteLine("The WrapGod generator is a Roslyn incremental source generator that runs");
+        Console.WriteLine("at compile time. It reads *.wrapgod.json manifests from your project and");
+        Console.WriteLine("emits IWrapped{Type} interfaces and {Type}Facade classes automatically.");
+        Console.WriteLine();
+        Console.WriteLine("To use generation:");
+        Console.WriteLine();
+        Console.WriteLine("  1. Add the WrapGod.Generator package to your project:");
+        Console.WriteLine("     dotnet add package WrapGod.Generator");
+        Console.WriteLine();
+        Console.WriteLine("  2. Place your manifest as an AdditionalFile in the project:");
+        Console.WriteLine("     <AdditionalFiles Include=\"manifest.wrapgod.json\" />");
+        Console.WriteLine();
+        Console.WriteLine("  3. Build your project -- wrappers are generated automatically:");
+        Console.WriteLine("     dotnet build");
+        Console.WriteLine();
+        Console.WriteLine($"Manifest:   {manifestPath.FullName}");
+        if (config is not null)
+            Console.WriteLine($"Config:     {config.FullName}");
+        Console.WriteLine($"Output dir: {outputDir.FullName} (not used -- generation is compile-time)");
+    }
+}

--- a/WrapGod.Cli/Program.cs
+++ b/WrapGod.Cli/Program.cs
@@ -1,0 +1,11 @@
+using System.CommandLine;
+using WrapGod.Cli;
+
+var rootCommand = new RootCommand("WrapGod CLI -- extract manifests, generate wrappers, and analyze migrations")
+{
+    ExtractCommand.Create(),
+    GenerateCommand.Create(),
+    AnalyzeCommand.Create()
+};
+
+return await rootCommand.InvokeAsync(args);

--- a/WrapGod.Cli/WrapGod.Cli.csproj
+++ b/WrapGod.Cli/WrapGod.Cli.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>wrap-god</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <RootNamespace>WrapGod.Cli</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WrapGod.Extractor\WrapGod.Extractor.csproj" />
+    <ProjectReference Include="..\WrapGod.Manifest\WrapGod.Manifest.csproj" />
+    <ProjectReference Include="..\WrapGod.Generator\WrapGod.Generator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WrapGod.slnx
+++ b/WrapGod.slnx
@@ -8,4 +8,5 @@
   <Project Path="WrapGod.Runtime/WrapGod.Runtime.csproj" />
   <Project Path="WrapGod.Tests/WrapGod.Tests.csproj" />
   <Project Path="WrapGod.TypeMap/WrapGod.TypeMap.csproj" />
+  <Project Path="WrapGod.Cli/WrapGod.Cli.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary
- New `WrapGod.Cli` project targeting net10.0, packable as a dotnet tool (`wrap-god`)
- `extract` command runs AssemblyExtractor and writes manifest JSON
- `generate` command explains compile-time generation workflow
- `analyze` command deserializes manifest and reports type/member diagnostics
- Added to `WrapGod.slnx`; builds cleanly with zero warnings

Closes #44

## Test plan
- [ ] `dotnet build WrapGod.slnx` succeeds
- [ ] `dotnet run --project WrapGod.Cli -- --help` shows command tree
- [ ] `extract` with a valid assembly produces manifest JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)