### PR TITLE
Add NSubstitute to Moq reverse migration example

### DIFF
--- a/examples/NSubstituteToMoq/README.md
+++ b/examples/NSubstituteToMoq/README.md
@@ -1,0 +1,61 @@
+# NSubstitute to Moq Reverse Migration Example
+
+This example demonstrates the **reverse** direction of the
+[Moq to NSubstitute](../MoqToNSubstitute/) migration -- moving from
+NSubstitute back to Moq using WrapGod.
+
+## Why reverse migrations matter
+
+Migrations are not always symmetric. Moving from NSubstitute to Moq introduces
+complexity that the forward direction avoids:
+
+- **Wrapper indirection**: NSubstitute returns the interface directly;
+  Moq wraps it in `Mock<T>`, requiring `.Object` access at every injection
+  point.
+- **Lambda setup expressions**: NSubstitute calls methods directly;
+  Moq requires `Setup(x => x.Method(...))` lambda wrappers.
+- **One-way patterns**: `Arg.Do<T>()` and `ReceivedWithAnyArgs()` have no
+  clean Moq equivalent.
+
+## Directory layout
+
+```
+NSubstituteToMoq/
+  SampleTests.Before/     -- test project using NSubstitute
+  SampleTests.After/      -- same tests rewritten with Moq
+  migration.wrapgod.json  -- manifest describing the NSubstitute API surface
+  migration.wrapgod.config.json -- mapping config with asymmetry notes
+```
+
+## Key asymmetries vs forward migration
+
+| Aspect | Forward (Moq -> NSub) | Reverse (NSub -> Moq) |
+|--------|----------------------|----------------------|
+| Creation | Remove wrapper: `Mock<T>` -> direct T | Add wrapper: direct T -> `Mock<T>` + `.Object` |
+| Setup | Unwrap lambda: `Setup(x => ...)` -> direct call | Wrap in lambda: direct call -> `Setup(x => ...)` |
+| Verify | Simplify: `Verify(..., Times.Once)` -> `Received(1)` | Add ceremony: `Received(1)` -> `Verify(..., Times.Once)` |
+| Arg capture | Safe: `Callback` -> `Arg.Do` (simpler) | Risky: `Arg.Do` -> `Callback` (structural) |
+
+## Risky rewrites
+
+The config includes an `asymmetries` section documenting patterns where the
+reverse migration requires manual intervention:
+
+1. **Substitute-is-T** (high risk) -- Every variable holding a substitute must
+   become `Mock<T>` with `.Object` used at injection points.
+2. **Arg.Do inline capture** (medium risk) -- Must be restructured as
+   `Setup().Callback()`.
+3. **When().Do()** (medium risk) -- Void method callbacks require different
+   syntax in Moq.
+4. **ReceivedWithAnyArgs** (low risk) -- Must enumerate each parameter with
+   `It.IsAny<T>()`.
+
+## Running the examples
+
+```bash
+# Build and run the "before" tests (NSubstitute)
+dotnet test examples/NSubstituteToMoq/SampleTests.Before/
+
+# Build and run the "after" tests (Moq)
+dotnet test examples/NSubstituteToMoq/SampleTests.After/
+```

--- a/examples/NSubstituteToMoq/SampleTests.After/Interfaces.cs
+++ b/examples/NSubstituteToMoq/SampleTests.After/Interfaces.cs
@@ -1,0 +1,72 @@
+namespace SampleTests.After;
+
+public interface IPaymentGateway
+{
+    bool Charge(string customerId, decimal amount);
+    Task<bool> ChargeAsync(string customerId, decimal amount);
+    void Refund(string transactionId);
+}
+
+public interface IInventoryService
+{
+    int GetStock(string sku);
+    void ReserveStock(string sku, int quantity);
+    void ReleaseStock(string sku, int quantity);
+}
+
+public interface IAuditLog
+{
+    void Record(string action, string details);
+}
+
+public class OrderItem
+{
+    public string Sku { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+}
+
+public class OrderService(IPaymentGateway gateway, IInventoryService inventory, IAuditLog audit)
+{
+    public bool PlaceOrder(string customerId, List<OrderItem> items)
+    {
+        foreach (var item in items)
+        {
+            var stock = inventory.GetStock(item.Sku);
+            if (stock < item.Quantity)
+            {
+                audit.Record("OrderFailed", $"Insufficient stock for {item.Sku}");
+                return false;
+            }
+        }
+
+        var total = items.Sum(i => i.Quantity * i.UnitPrice);
+        var charged = gateway.Charge(customerId, total);
+
+        if (!charged)
+        {
+            audit.Record("OrderFailed", "Payment declined");
+            return false;
+        }
+
+        foreach (var item in items)
+        {
+            inventory.ReserveStock(item.Sku, item.Quantity);
+        }
+
+        audit.Record("OrderPlaced", $"Customer {customerId}, total {total:C}");
+        return true;
+    }
+
+    public void CancelOrder(string transactionId, List<OrderItem> items)
+    {
+        gateway.Refund(transactionId);
+
+        foreach (var item in items)
+        {
+            inventory.ReleaseStock(item.Sku, item.Quantity);
+        }
+
+        audit.Record("OrderCancelled", $"Transaction {transactionId}");
+    }
+}

--- a/examples/NSubstituteToMoq/SampleTests.After/OrderServiceTests.cs
+++ b/examples/NSubstituteToMoq/SampleTests.After/OrderServiceTests.cs
@@ -1,0 +1,96 @@
+using Moq;
+using Xunit;
+
+namespace SampleTests.After;
+
+public class OrderServiceTests
+{
+    private readonly Mock<IPaymentGateway> _gatewayMock = new();
+    private readonly Mock<IInventoryService> _inventoryMock = new();
+    private readonly Mock<IAuditLog> _auditMock = new();
+    private readonly OrderService _sut;
+
+    public OrderServiceTests()
+    {
+        _sut = new OrderService(
+            _gatewayMock.Object,
+            _inventoryMock.Object,
+            _auditMock.Object);
+    }
+
+    [Fact]
+    public void PlaceOrder_ShouldSucceed_WhenStockAndPaymentOk()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { Sku = "SKU-1", Quantity = 2, UnitPrice = 10m }
+        };
+        _inventoryMock.Setup(i => i.GetStock("SKU-1")).Returns(5);
+        _gatewayMock.Setup(g => g.Charge("cust-1", 20m)).Returns(true);
+
+        var result = _sut.PlaceOrder("cust-1", items);
+
+        Assert.True(result);
+        _inventoryMock.Verify(i => i.ReserveStock("SKU-1", 2), Times.Once);
+        _auditMock.Verify(
+            a => a.Record("OrderPlaced", It.Is<string>(s => s.Contains("cust-1"))),
+            Times.Once);
+    }
+
+    [Fact]
+    public void PlaceOrder_ShouldFail_WhenInsufficientStock()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { Sku = "SKU-1", Quantity = 10, UnitPrice = 5m }
+        };
+        _inventoryMock.Setup(i => i.GetStock("SKU-1")).Returns(3);
+
+        var result = _sut.PlaceOrder("cust-1", items);
+
+        Assert.False(result);
+        _gatewayMock.Verify(
+            g => g.Charge(It.IsAny<string>(), It.IsAny<decimal>()),
+            Times.Never);
+        _auditMock.Verify(
+            a => a.Record("OrderFailed", It.Is<string>(s => s.Contains("Insufficient"))),
+            Times.Once);
+    }
+
+    [Fact]
+    public void PlaceOrder_ShouldFail_WhenPaymentDeclined()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { Sku = "SKU-1", Quantity = 1, UnitPrice = 50m }
+        };
+        _inventoryMock.Setup(i => i.GetStock("SKU-1")).Returns(10);
+        _gatewayMock.Setup(g => g.Charge("cust-1", 50m)).Returns(false);
+
+        var result = _sut.PlaceOrder("cust-1", items);
+
+        Assert.False(result);
+        _inventoryMock.Verify(
+            i => i.ReserveStock(It.IsAny<string>(), It.IsAny<int>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void CancelOrder_ShouldRefundAndReleaseStock()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { Sku = "SKU-1", Quantity = 2, UnitPrice = 10m },
+            new() { Sku = "SKU-2", Quantity = 1, UnitPrice = 25m }
+        };
+
+        _sut.CancelOrder("txn-123", items);
+
+        _gatewayMock.Verify(g => g.Refund("txn-123"), Times.Once);
+        _inventoryMock.Verify(i => i.ReleaseStock("SKU-1", 2), Times.Once);
+        _inventoryMock.Verify(i => i.ReleaseStock("SKU-2", 1), Times.Once);
+        _auditMock.Verify(
+            a => a.Record("OrderCancelled", It.Is<string>(s => s.Contains("txn-123"))),
+            Times.Once);
+    }
+}

--- a/examples/NSubstituteToMoq/SampleTests.After/SampleTests.After.csproj
+++ b/examples/NSubstituteToMoq/SampleTests.After/SampleTests.After.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+
+</Project>

--- a/examples/NSubstituteToMoq/SampleTests.Before/Interfaces.cs
+++ b/examples/NSubstituteToMoq/SampleTests.Before/Interfaces.cs
@@ -1,0 +1,72 @@
+namespace SampleTests.Before;
+
+public interface IPaymentGateway
+{
+    bool Charge(string customerId, decimal amount);
+    Task<bool> ChargeAsync(string customerId, decimal amount);
+    void Refund(string transactionId);
+}
+
+public interface IInventoryService
+{
+    int GetStock(string sku);
+    void ReserveStock(string sku, int quantity);
+    void ReleaseStock(string sku, int quantity);
+}
+
+public interface IAuditLog
+{
+    void Record(string action, string details);
+}
+
+public class OrderItem
+{
+    public string Sku { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+}
+
+public class OrderService(IPaymentGateway gateway, IInventoryService inventory, IAuditLog audit)
+{
+    public bool PlaceOrder(string customerId, List<OrderItem> items)
+    {
+        foreach (var item in items)
+        {
+            var stock = inventory.GetStock(item.Sku);
+            if (stock < item.Quantity)
+            {
+                audit.Record("OrderFailed", $"Insufficient stock for {item.Sku}");
+                return false;
+            }
+        }
+
+        var total = items.Sum(i => i.Quantity * i.UnitPrice);
+        var charged = gateway.Charge(customerId, total);
+
+        if (!charged)
+        {
+            audit.Record("OrderFailed", "Payment declined");
+            return false;
+        }
+
+        foreach (var item in items)
+        {
+            inventory.ReserveStock(item.Sku, item.Quantity);
+        }
+
+        audit.Record("OrderPlaced", $"Customer {customerId}, total {total:C}");
+        return true;
+    }
+
+    public void CancelOrder(string transactionId, List<OrderItem> items)
+    {
+        gateway.Refund(transactionId);
+
+        foreach (var item in items)
+        {
+            inventory.ReleaseStock(item.Sku, item.Quantity);
+        }
+
+        audit.Record("OrderCancelled", $"Transaction {transactionId}");
+    }
+}

--- a/examples/NSubstituteToMoq/SampleTests.Before/OrderServiceTests.cs
+++ b/examples/NSubstituteToMoq/SampleTests.Before/OrderServiceTests.cs
@@ -1,0 +1,83 @@
+using NSubstitute;
+using Xunit;
+
+namespace SampleTests.Before;
+
+public class OrderServiceTests
+{
+    private readonly IPaymentGateway _gateway = Substitute.For<IPaymentGateway>();
+    private readonly IInventoryService _inventory = Substitute.For<IInventoryService>();
+    private readonly IAuditLog _audit = Substitute.For<IAuditLog>();
+    private readonly OrderService _sut;
+
+    public OrderServiceTests()
+    {
+        _sut = new OrderService(_gateway, _inventory, _audit);
+    }
+
+    [Fact]
+    public void PlaceOrder_ShouldSucceed_WhenStockAndPaymentOk()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { Sku = "SKU-1", Quantity = 2, UnitPrice = 10m }
+        };
+        _inventory.GetStock("SKU-1").Returns(5);
+        _gateway.Charge("cust-1", 20m).Returns(true);
+
+        var result = _sut.PlaceOrder("cust-1", items);
+
+        Assert.True(result);
+        _inventory.Received(1).ReserveStock("SKU-1", 2);
+        _audit.Received(1).Record("OrderPlaced", Arg.Is<string>(s => s.Contains("cust-1")));
+    }
+
+    [Fact]
+    public void PlaceOrder_ShouldFail_WhenInsufficientStock()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { Sku = "SKU-1", Quantity = 10, UnitPrice = 5m }
+        };
+        _inventory.GetStock("SKU-1").Returns(3);
+
+        var result = _sut.PlaceOrder("cust-1", items);
+
+        Assert.False(result);
+        _gateway.DidNotReceive().Charge(Arg.Any<string>(), Arg.Any<decimal>());
+        _audit.Received(1).Record("OrderFailed", Arg.Is<string>(s => s.Contains("Insufficient")));
+    }
+
+    [Fact]
+    public void PlaceOrder_ShouldFail_WhenPaymentDeclined()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { Sku = "SKU-1", Quantity = 1, UnitPrice = 50m }
+        };
+        _inventory.GetStock("SKU-1").Returns(10);
+        _gateway.Charge("cust-1", 50m).Returns(false);
+
+        var result = _sut.PlaceOrder("cust-1", items);
+
+        Assert.False(result);
+        _inventory.DidNotReceive().ReserveStock(Arg.Any<string>(), Arg.Any<int>());
+    }
+
+    [Fact]
+    public void CancelOrder_ShouldRefundAndReleaseStock()
+    {
+        var items = new List<OrderItem>
+        {
+            new() { Sku = "SKU-1", Quantity = 2, UnitPrice = 10m },
+            new() { Sku = "SKU-2", Quantity = 1, UnitPrice = 25m }
+        };
+
+        _sut.CancelOrder("txn-123", items);
+
+        _gateway.Received(1).Refund("txn-123");
+        _inventory.Received(1).ReleaseStock("SKU-1", 2);
+        _inventory.Received(1).ReleaseStock("SKU-2", 1);
+        _audit.Received(1).Record("OrderCancelled", Arg.Is<string>(s => s.Contains("txn-123")));
+    }
+}

--- a/examples/NSubstituteToMoq/SampleTests.Before/SampleTests.Before.csproj
+++ b/examples/NSubstituteToMoq/SampleTests.Before/SampleTests.Before.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/NSubstituteToMoq/migration.wrapgod.config.json
+++ b/examples/NSubstituteToMoq/migration.wrapgod.config.json
@@ -1,0 +1,106 @@
+{
+  "migrationName": "NSubstitute-to-Moq",
+  "sourceLibrary": "NSubstitute",
+  "targetLibrary": "Moq",
+  "sourcePackage": "NSubstitute",
+  "targetPackage": "Moq",
+  "usingReplacements": {
+    "NSubstitute": "Moq"
+  },
+  "notes": "Reverse migration from NSubstitute to Moq. This direction introduces indirection (Mock<T> wrapper, .Object accessor) that does not exist in NSubstitute. Several NSubstitute patterns have no clean Moq equivalent.",
+  "mappings": [
+    {
+      "description": "Substitute creation",
+      "source": "Substitute.For<{T}>()",
+      "target": "new Mock<{T}>()",
+      "safety": "guided",
+      "notes": "Moq returns Mock<T> wrapper, not T directly. All usages of the variable must be updated: pass mock.Object where T is expected, and use mock.Setup/Verify for configuration."
+    },
+    {
+      "description": "Returns setup",
+      "source": "{sub}.{Method}({args}).Returns({value})",
+      "target": "{mock}.Setup(x => x.{Method}({args})).Returns({value})",
+      "safety": "guided",
+      "notes": "Moq requires wrapping in Setup lambda expression. Argument matchers must also be translated."
+    },
+    {
+      "description": "Throws setup",
+      "source": "{sub}.{Method}({args}).Throws({exception})",
+      "target": "{mock}.Setup(x => x.{Method}({args})).Throws({exception})",
+      "safety": "guided"
+    },
+    {
+      "description": "Received with count",
+      "source": "{sub}.Received({n}).{Method}({args})",
+      "target": "{mock}.Verify(x => x.{Method}({args}), Times.Exactly({n}))",
+      "safety": "safe"
+    },
+    {
+      "description": "Received once (no count)",
+      "source": "{sub}.Received().{Method}({args})",
+      "target": "{mock}.Verify(x => x.{Method}({args}), Times.AtLeastOnce)",
+      "safety": "safe"
+    },
+    {
+      "description": "Did not receive",
+      "source": "{sub}.DidNotReceive().{Method}({args})",
+      "target": "{mock}.Verify(x => x.{Method}({args}), Times.Never)",
+      "safety": "safe"
+    },
+    {
+      "description": "Argument matcher: any",
+      "source": "Arg.Any<{T}>()",
+      "target": "It.IsAny<{T}>()",
+      "safety": "safe"
+    },
+    {
+      "description": "Argument matcher: predicate",
+      "source": "Arg.Is<{T}>({predicate})",
+      "target": "It.Is<{T}>({predicate})",
+      "safety": "safe"
+    },
+    {
+      "description": "Argument callback (Arg.Do)",
+      "source": "Arg.Do<{T}>({action})",
+      "target": "// Moq: use Callback() on Setup -- structural rewrite required",
+      "safety": "manual",
+      "notes": "NSubstitute's Arg.Do captures argument inline; Moq requires .Callback() chained on Setup. No direct translation."
+    },
+    {
+      "description": "ReceivedWithAnyArgs",
+      "source": "{sub}.ReceivedWithAnyArgs().{Method}({args})",
+      "target": "{mock}.Verify(x => x.{Method}(It.IsAny<...>(), ...), Times.AtLeastOnce)",
+      "safety": "guided",
+      "notes": "Must replace each parameter with It.IsAny<T>(). No single Moq equivalent to ReceivedWithAnyArgs."
+    },
+    {
+      "description": "Returns from function",
+      "source": "{sub}.{Method}({args}).Returns(callInfo => {expression})",
+      "target": "{mock}.Setup(x => x.{Method}({args})).Returns({expression})",
+      "safety": "guided",
+      "notes": "Moq Returns also accepts Func<TResult> but the CallInfo parameter must be restructured or dropped."
+    }
+  ],
+  "asymmetries": [
+    {
+      "pattern": "Substitute is T directly",
+      "issue": "NSubstitute's substitute IS the interface. Moq wraps it in Mock<T> requiring .Object access everywhere the interface is passed. This is a pervasive structural change.",
+      "risk": "high"
+    },
+    {
+      "pattern": "Arg.Do inline capture",
+      "issue": "No Moq equivalent for inline argument capture. Must restructure to Setup().Callback().",
+      "risk": "medium"
+    },
+    {
+      "pattern": "ReceivedWithAnyArgs",
+      "issue": "Moq has no single-call equivalent. Must enumerate all parameters with It.IsAny<T>().",
+      "risk": "low"
+    },
+    {
+      "pattern": "When().Do() for void methods",
+      "issue": "NSubstitute's When().Do() pattern maps to Moq's Setup().Callback(), but the syntax is significantly different.",
+      "risk": "medium"
+    }
+  ]
+}

--- a/examples/NSubstituteToMoq/migration.wrapgod.json
+++ b/examples/NSubstituteToMoq/migration.wrapgod.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "../../schemas/wrapgod.manifest.v1.schema.json",
+  "name": "NSubstitute",
+  "version": "5.3.0",
+  "description": "Manifest defining the NSubstitute public API surface targeted for reverse migration to Moq.",
+  "types": [
+    {
+      "name": "NSubstitute.Substitute",
+      "namespace": "NSubstitute",
+      "kind": "Static",
+      "members": [
+        { "name": "For", "kind": "Method", "returnType": "T", "parameters": [] }
+      ]
+    },
+    {
+      "name": "NSubstitute.SubstituteExtensions",
+      "namespace": "NSubstitute",
+      "kind": "Static",
+      "members": [
+        { "name": "Returns", "kind": "Method", "returnType": "ConfiguredCall", "parameters": [{ "name": "value", "type": "T" }] },
+        { "name": "Throws", "kind": "Method", "returnType": "ConfiguredCall", "parameters": [{ "name": "exception", "type": "Exception" }] },
+        { "name": "Received", "kind": "Method", "returnType": "T", "parameters": [] },
+        { "name": "Received", "kind": "Method", "returnType": "T", "parameters": [{ "name": "requiredQuantity", "type": "int" }] },
+        { "name": "DidNotReceive", "kind": "Method", "returnType": "T", "parameters": [] },
+        { "name": "ReceivedWithAnyArgs", "kind": "Method", "returnType": "T", "parameters": [] }
+      ]
+    },
+    {
+      "name": "NSubstitute.Arg",
+      "namespace": "NSubstitute",
+      "kind": "Static",
+      "members": [
+        { "name": "Any", "kind": "Method", "returnType": "T", "parameters": [] },
+        { "name": "Is", "kind": "Method", "returnType": "T", "parameters": [{ "name": "predicate", "type": "Expression<Predicate<T>>" }] },
+        { "name": "Do", "kind": "Method", "returnType": "T", "parameters": [{ "name": "action", "type": "Action<T>" }] }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Before/After test projects showing NSubstitute -> Moq reverse migration
- Config with 11 mapping rules and 4 documented asymmetries vs the forward direction
- README explaining one-way mappings, risky rewrites (Arg.Do, ReceivedWithAnyArgs), and the structural cost of adding Mock<T> wrapper indirection

Closes #63

## Test plan
- [ ] Verify both SampleTests.Before and SampleTests.After compile
- [ ] Review asymmetry documentation for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)