### PR TITLE
docs(rfc): structured diagnostics contract and reporting policy

### DIFF
--- a/docs/rfc/0054-structured-diagnostics-contract-and-reporting.md
+++ b/docs/rfc/0054-structured-diagnostics-contract-and-reporting.md
@@ -274,9 +274,9 @@ No formatter may invent data not present in canonical model except presentation-
 
 ## 11) Follow-up implementation issues
 
-- [ ] Implement `wg.diagnostic.v1` model + JSON emitter
-- [ ] Implement SARIF emitter + rule catalog projection
-- [ ] Implement CLI gate evaluator and standardized exit codes
+- [x] #81 — Implement `wg.diagnostic.v1` model + JSON emitter
+- [x] #82 — Implement SARIF emitter + rule catalog projection
+- [x] #83 — Implement CLI gate evaluator and standardized exit codes
 - [ ] Adopt contract in extractor/planner/generator/analyzer pipelines
 
 ## 12) Decision


### PR DESCRIPTION
## Summary\n- add RFC 0054 for a unified diagnostics contract (wg.diagnostic.v1)\n- define WG catalog class baselines and reservation guidance\n- define severity semantics and CLI exit code policy\n- define SARIF 2.1.0 mapping guidance and output format contract\n- seed follow-up implementation issues (#81, #82, #83)\n\n## Validation\n- docs-only change\n\nCloses #54