### PR TITLE
feat: generic configuration support

### DIFF
--- a/WrapGod.Abstractions/Config/WrapGodConfigModels.cs
+++ b/WrapGod.Abstractions/Config/WrapGodConfigModels.cs
@@ -14,6 +14,20 @@ public sealed class TypeConfig
     public bool? Include { get; set; }
     public string? TargetName { get; set; }
     public List<MemberConfig> Members { get; set; } = new();
+
+    /// <summary>
+    /// When <c>true</c>, <see cref="SourceType"/> is treated as an open generic
+    /// pattern (e.g. <c>"Dictionary&lt;,&gt;"</c> or <c>"IRepository&lt;&gt;"</c>).
+    /// The pattern matches any closed construction of the generic type.
+    /// </summary>
+    public bool IsGenericPattern { get; set; }
+
+    /// <summary>
+    /// The arity (number of type parameters) of the generic pattern.
+    /// Derived automatically from the source type pattern when
+    /// <see cref="IsGenericPattern"/> is <c>true</c>.
+    /// </summary>
+    public int GenericArity { get; set; }
 }
 
 public sealed class MemberConfig

--- a/WrapGod.Fluent/GenerationPlan.cs
+++ b/WrapGod.Fluent/GenerationPlan.cs
@@ -47,6 +47,18 @@ public sealed class TypeDirective
 
     /// <summary>Members to exclude by name.</summary>
     public IReadOnlyList<string> ExcludedMembers { get; init; } = [];
+
+    /// <summary>
+    /// When <c>true</c>, <see cref="SourceType"/> is an open generic pattern
+    /// (e.g. <c>"IRepository&lt;&gt;"</c>) that matches any closed construction.
+    /// </summary>
+    public bool IsGenericPattern { get; init; }
+
+    /// <summary>
+    /// The arity (number of type parameters) of the generic pattern.
+    /// Only meaningful when <see cref="IsGenericPattern"/> is <c>true</c>.
+    /// </summary>
+    public int GenericArity { get; init; }
 }
 
 /// <summary>

--- a/WrapGod.Fluent/TypeDirectiveBuilder.cs
+++ b/WrapGod.Fluent/TypeDirectiveBuilder.cs
@@ -15,11 +15,31 @@ public sealed class TypeDirectiveBuilder
     private bool _wrapAll;
     private readonly List<MemberDirectiveBuilder> _memberBuilders = [];
     private readonly List<string> _excludedMembers = [];
+    private readonly bool _isGenericPattern;
+    private readonly int _genericArity;
 
     internal TypeDirectiveBuilder(WrapGodConfiguration parent, string sourceType)
     {
         _parent = parent;
         _sourceType = sourceType;
+
+        // Auto-detect open generic patterns like "IRepository<>" or "Dictionary<,>".
+        var openAngle = sourceType.IndexOf('<');
+        if (openAngle >= 0)
+        {
+            var closeAngle = sourceType.LastIndexOf('>');
+            if (closeAngle > openAngle)
+            {
+                var inner = sourceType.Substring(openAngle + 1, closeAngle - openAngle - 1).Trim();
+                bool isOpen = inner.Length == 0 ||
+                              inner.Replace(",", "").Replace(" ", "").Length == 0;
+                if (isOpen)
+                {
+                    _isGenericPattern = true;
+                    _genericArity = inner.Length == 0 ? 1 : inner.Split(',').Length;
+                }
+            }
+        }
     }
 
     /// <summary>Set the target interface / wrapper name for this type.</summary>
@@ -90,6 +110,8 @@ public sealed class TypeDirectiveBuilder
             WrapAllPublicMembers = _wrapAll,
             MemberDirectives = members,
             ExcludedMembers = _excludedMembers,
+            IsGenericPattern = _isGenericPattern,
+            GenericArity = _genericArity,
         };
     }
 }

--- a/WrapGod.Manifest/Config/ConfigMergeEngine.cs
+++ b/WrapGod.Manifest/Config/ConfigMergeEngine.cs
@@ -18,14 +18,59 @@ public static class ConfigMergeEngine
 
         foreach (var typeKey in allTypeKeys)
         {
-            var fromJson = jsonConfig.Types.FirstOrDefault(t => string.Equals(t.SourceType, typeKey, StringComparison.Ordinal));
-            var fromAttr = attributeConfig.Types.FirstOrDefault(t => string.Equals(t.SourceType, typeKey, StringComparison.Ordinal));
+            var fromJson = FindMatchingType(jsonConfig.Types, typeKey);
+            var fromAttr = FindMatchingType(attributeConfig.Types, typeKey);
 
             var mergedType = MergeType(typeKey, fromJson, fromAttr, options, result.Diagnostics);
+
+            // Preserve generic pattern metadata from whichever source had it.
+            var sourceWithPattern = fromJson?.IsGenericPattern == true ? fromJson
+                : fromAttr?.IsGenericPattern == true ? fromAttr
+                : null;
+            if (sourceWithPattern != null)
+            {
+                mergedType.IsGenericPattern = true;
+                mergedType.GenericArity = sourceWithPattern.GenericArity;
+            }
+
             result.Config.Types.Add(mergedType);
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Finds a type config matching the given key. First tries an exact match,
+    /// then falls back to matching generic patterns by base name.
+    /// </summary>
+    private static TypeConfig? FindMatchingType(List<TypeConfig> types, string key)
+    {
+        // Exact match first.
+        var exact = types.FirstOrDefault(t => string.Equals(t.SourceType, key, StringComparison.Ordinal));
+        if (exact != null)
+            return exact;
+
+        // Try matching open generic patterns by base name.
+        var baseName = GetGenericBaseName(key);
+        if (baseName != null)
+        {
+            return types.FirstOrDefault(t =>
+                t.IsGenericPattern &&
+                string.Equals(GetGenericBaseName(t.SourceType) ?? t.SourceType, baseName, StringComparison.Ordinal));
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the base type name from a generic type string.
+    /// <c>"Dictionary&lt;,&gt;"</c> becomes <c>"Dictionary"</c>.
+    /// Returns <c>null</c> for non-generic types.
+    /// </summary>
+    internal static string? GetGenericBaseName(string sourceType)
+    {
+        var openAngle = sourceType.IndexOf('<');
+        return openAngle > 0 ? sourceType.Substring(0, openAngle) : null;
     }
 
     private static TypeConfig MergeType(

--- a/WrapGod.Manifest/Config/JsonConfigLoader.cs
+++ b/WrapGod.Manifest/Config/JsonConfigLoader.cs
@@ -28,6 +28,45 @@ public static class JsonConfigLoader
     public static WrapGodConfig LoadFromJson(string json)
     {
         var config = JsonSerializer.Deserialize<WrapGodConfig>(json, Options);
-        return config ?? new WrapGodConfig();
+        if (config is null)
+            return new WrapGodConfig();
+
+        // Post-process: detect open generic patterns in sourceType values.
+        foreach (var type in config.Types)
+        {
+            InferGenericPattern(type);
+        }
+
+        return config;
+    }
+
+    /// <summary>
+    /// Detects open generic patterns like <c>"Dictionary&lt;,&gt;"</c> or
+    /// <c>"IRepository&lt;&gt;"</c> and sets <see cref="TypeConfig.IsGenericPattern"/>
+    /// and <see cref="TypeConfig.GenericArity"/> accordingly.
+    /// </summary>
+    internal static void InferGenericPattern(TypeConfig type)
+    {
+        var source = type.SourceType;
+        var openAngle = source.IndexOf('<');
+        if (openAngle < 0)
+            return;
+
+        var closeAngle = source.LastIndexOf('>');
+        if (closeAngle <= openAngle)
+            return;
+
+        // Extract inner content between < and >.
+        var inner = source.Substring(openAngle + 1, closeAngle - openAngle - 1).Trim();
+
+        // Open generic pattern: inner is empty or contains only commas/whitespace.
+        bool isOpenGeneric = inner.Length == 0 ||
+                             inner.Replace(",", "").Replace(" ", "").Length == 0;
+
+        if (isOpenGeneric)
+        {
+            type.IsGenericPattern = true;
+            type.GenericArity = inner.Length == 0 ? 1 : inner.Split(',').Length;
+        }
     }
 }

--- a/WrapGod.Tests/GenericConfigTests.cs
+++ b/WrapGod.Tests/GenericConfigTests.cs
@@ -1,0 +1,192 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Abstractions.Config;
+using WrapGod.Fluent;
+using WrapGod.Manifest.Config;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("Generic configuration support")]
+public sealed class GenericConfigTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // -- JSON config helpers ------------------------------------------------
+
+    private static readonly string GenericJsonConfig = """
+        {
+          "types": [
+            {
+              "sourceType": "IRepository<>",
+              "include": true,
+              "targetName": "IWrappedRepository"
+            },
+            {
+              "sourceType": "Dictionary<,>",
+              "include": true,
+              "targetName": "IWrappedDictionary"
+            },
+            {
+              "sourceType": "Vendor.ConcreteService",
+              "include": true,
+              "targetName": "IConcreteService"
+            }
+          ]
+        }
+        """;
+
+    private static WrapGodConfig LoadGenericJsonConfig() =>
+        JsonConfigLoader.LoadFromJson(GenericJsonConfig);
+
+    // -- Fluent DSL helpers -------------------------------------------------
+
+    private static GenerationPlan BuildGenericFluentPlan() =>
+        WrapGodConfiguration.Create()
+            .ForAssembly("Vendor.Lib")
+            .WrapType("IRepository<>")
+                .As("IWrappedRepository")
+            .WrapType("Dictionary<,>")
+                .As("IWrappedDictionary")
+            .WrapType("Vendor.ConcreteService")
+                .As("IConcreteService")
+            .Build();
+
+    // -- Merge engine helpers -----------------------------------------------
+
+    private static ConfigMergeResult MergeGenericAndConcreteRules()
+    {
+        var jsonConfig = new WrapGodConfig();
+        jsonConfig.Types.Add(new TypeConfig
+        {
+            SourceType = "IRepository<>",
+            IsGenericPattern = true,
+            GenericArity = 1,
+            Include = true,
+            TargetName = "JsonRepo",
+        });
+        jsonConfig.Types.Add(new TypeConfig
+        {
+            SourceType = "Vendor.ConcreteService",
+            Include = true,
+            TargetName = "JsonConcrete",
+        });
+
+        var attrConfig = new WrapGodConfig();
+        attrConfig.Types.Add(new TypeConfig
+        {
+            SourceType = "Vendor.ConcreteService",
+            Include = false,
+            TargetName = "AttrConcrete",
+        });
+
+        return ConfigMergeEngine.Merge(jsonConfig, attrConfig, new ConfigMergeOptions
+        {
+            HigherPrecedence = ConfigSource.Attributes,
+        });
+    }
+
+    private static ConfigMergeResult MergeGenericPatternConflict()
+    {
+        var jsonConfig = new WrapGodConfig();
+        jsonConfig.Types.Add(new TypeConfig
+        {
+            SourceType = "IRepository<>",
+            IsGenericPattern = true,
+            GenericArity = 1,
+            Include = true,
+            TargetName = "JsonRepo",
+        });
+
+        var attrConfig = new WrapGodConfig();
+        attrConfig.Types.Add(new TypeConfig
+        {
+            SourceType = "IRepository<>",
+            IsGenericPattern = true,
+            GenericArity = 1,
+            Include = false,
+            TargetName = "AttrRepo",
+        });
+
+        return ConfigMergeEngine.Merge(jsonConfig, attrConfig, new ConfigMergeOptions
+        {
+            HigherPrecedence = ConfigSource.Attributes,
+        });
+    }
+
+    // -- Scenarios: JSON config with generic type rules ---------------------
+
+    [Scenario("JSON config with open generic type rules loads correctly")]
+    [Fact]
+    public Task JsonConfig_GenericTypeRules_LoadCorrectly()
+        => Given("a JSON config with generic type patterns", LoadGenericJsonConfig)
+            .Then("three type rules are parsed", config => config.Types.Count == 3)
+            .And("IRepository<> is marked as a generic pattern", config =>
+                config.Types[0].IsGenericPattern)
+            .And("IRepository<> has arity 1", config =>
+                config.Types[0].GenericArity == 1)
+            .And("Dictionary<,> is marked as a generic pattern", config =>
+                config.Types[1].IsGenericPattern)
+            .And("Dictionary<,> has arity 2", config =>
+                config.Types[1].GenericArity == 2)
+            .And("ConcreteService is NOT a generic pattern", config =>
+                !config.Types[2].IsGenericPattern)
+            .And("ConcreteService has arity 0", config =>
+                config.Types[2].GenericArity == 0)
+            .AssertPassed();
+
+    // -- Scenarios: Fluent config with generic patterns ---------------------
+
+    [Scenario("Fluent config with generic patterns builds correct plan")]
+    [Fact]
+    public Task FluentConfig_GenericPatterns_BuildCorrectPlan()
+        => Given("a fluent config with generic type patterns", BuildGenericFluentPlan)
+            .Then("three type directives are created", plan =>
+                plan.TypeDirectives.Count == 3)
+            .And("IRepository<> directive is a generic pattern", plan =>
+                plan.TypeDirectives[0].IsGenericPattern)
+            .And("IRepository<> directive has arity 1", plan =>
+                plan.TypeDirectives[0].GenericArity == 1)
+            .And("IRepository<> directive has correct target name", plan =>
+                plan.TypeDirectives[0].TargetName == "IWrappedRepository")
+            .And("Dictionary<,> directive is a generic pattern", plan =>
+                plan.TypeDirectives[1].IsGenericPattern)
+            .And("Dictionary<,> directive has arity 2", plan =>
+                plan.TypeDirectives[1].GenericArity == 2)
+            .And("ConcreteService directive is NOT a generic pattern", plan =>
+                !plan.TypeDirectives[2].IsGenericPattern)
+            .AssertPassed();
+
+    // -- Scenarios: Merge engine with generic + concrete rules ---------------
+
+    [Scenario("Merge engine handles generic and concrete rules together")]
+    [Fact]
+    public Task MergeEngine_GenericAndConcreteRules_HandledCorrectly()
+        => Given("JSON config with generic + concrete and attribute config with concrete",
+                MergeGenericAndConcreteRules)
+            .Then("merged config has two type rules", result =>
+                result.Config.Types.Count == 2)
+            .And("the generic pattern rule is preserved", result =>
+                result.Config.Types.Any(t => t.IsGenericPattern && t.SourceType == "IRepository<>"))
+            .And("the concrete rule uses attribute precedence for target name", result =>
+                result.Config.Types.First(t => t.SourceType == "Vendor.ConcreteService")
+                    .TargetName == "AttrConcrete")
+            .And("diagnostics are emitted for the concrete conflict", result =>
+                result.Diagnostics.Count > 0)
+            .AssertPassed();
+
+    [Scenario("Merge engine resolves conflicting generic pattern rules by precedence")]
+    [Fact]
+    public Task MergeEngine_GenericPatternConflict_ResolvedByPrecedence()
+        => Given("conflicting JSON and attribute configs for a generic pattern",
+                MergeGenericPatternConflict)
+            .Then("merged config has one type rule", result =>
+                result.Config.Types.Count == 1)
+            .And("attribute config wins for include", result =>
+                result.Config.Types[0].Include == false)
+            .And("attribute config wins for target name", result =>
+                result.Config.Types[0].TargetName == "AttrRepo")
+            .And("the generic pattern metadata is preserved", result =>
+                result.Config.Types[0].IsGenericPattern)
+            .And("diagnostics are emitted for the conflict", result =>
+                result.Diagnostics.Count > 0)
+            .AssertPassed();
+}


### PR DESCRIPTION
## Summary
- Extend `TypeConfig` and `TypeDirective` models with `IsGenericPattern` and `GenericArity` fields to support open generic type patterns (e.g. `IRepository<>`, `Dictionary<,>`)
- JSON config auto-detects open generic patterns on load via `JsonConfigLoader.InferGenericPattern`
- Fluent DSL (`WrapType("IRepository<>")`) auto-detects generic patterns in `TypeDirectiveBuilder`
- Merge engine resolves generic pattern rules alongside concrete ones using base-name matching
- 4 new TinyBDD tests covering JSON loading, fluent building, and merge engine scenarios

## Test plan
- [x] JSON config with generic type rules loads correctly (arity detected)
- [x] Fluent config with generic patterns builds correct plan
- [x] Merge engine handles generic + concrete rules
- [x] Merge engine resolves conflicting generic pattern rules by precedence
- [x] All 109 existing tests still pass

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)