### PR TITLE
feat: implement wg.diagnostic.v1 model + JSON emitter

### DIFF
--- a/WrapGod.Abstractions/Diagnostics/WgDiagnosticEmitter.cs
+++ b/WrapGod.Abstractions/Diagnostics/WgDiagnosticEmitter.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using WrapGod.Abstractions.Config;
+
+namespace WrapGod.Abstractions.Diagnostics;
+
+public static class WgDiagnosticEmitter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = null,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+    };
+
+    public static string EmitJson(IEnumerable<WgDiagnosticV1> diagnostics)
+        => JsonSerializer.Serialize(diagnostics, JsonOptions);
+
+    public static WgDiagnosticV1 FromConfigDiagnostic(ConfigDiagnostic diagnostic, DateTime? timestampUtc = null)
+    {
+        return new WgDiagnosticV1
+        {
+            Schema = WgDiagnosticV1.SchemaId,
+            Code = diagnostic.Code,
+            Severity = WgDiagnosticSeverity.Warning,
+            Stage = WgDiagnosticStage.Config,
+            Category = "config",
+            Message = diagnostic.Message,
+            Source = new WgDiagnosticSource
+            {
+                Tool = "WrapGod",
+                Component = "WrapGod.Manifest.ConfigMergeEngine",
+            },
+            Location = string.IsNullOrWhiteSpace(diagnostic.Target)
+                ? null
+                : new WgDiagnosticLocation { Symbol = diagnostic.Target },
+            TimestampUtc = timestampUtc ?? DateTime.UtcNow,
+        };
+    }
+}

--- a/WrapGod.Abstractions/Diagnostics/WgDiagnosticV1.cs
+++ b/WrapGod.Abstractions/Diagnostics/WgDiagnosticV1.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace WrapGod.Abstractions.Diagnostics;
+
+public sealed class WgDiagnosticV1
+{
+    public const string SchemaId = "wg.diagnostic.v1";
+
+    [JsonPropertyName("schema")]
+    public string Schema { get; set; } = SchemaId;
+
+    [JsonPropertyName("code")]
+    public string Code { get; set; } = string.Empty;
+
+    [JsonPropertyName("severity")]
+    public string Severity { get; set; } = WgDiagnosticSeverity.Warning;
+
+    [JsonPropertyName("stage")]
+    public string Stage { get; set; } = WgDiagnosticStage.Analyze;
+
+    [JsonPropertyName("category")]
+    public string? Category { get; set; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    [JsonPropertyName("source")]
+    public WgDiagnosticSource Source { get; set; } = new();
+
+    [JsonPropertyName("location")]
+    public WgDiagnosticLocation? Location { get; set; }
+
+    [JsonPropertyName("relatedLocations")]
+    public List<WgDiagnosticLocation>? RelatedLocations { get; set; }
+
+    [JsonPropertyName("helpUri")]
+    public string? HelpUri { get; set; }
+
+    [JsonPropertyName("tags")]
+    public List<string>? Tags { get; set; }
+
+    [JsonPropertyName("fingerprint")]
+    public string? Fingerprint { get; set; }
+
+    [JsonPropertyName("properties")]
+    public Dictionary<string, object?>? Properties { get; set; }
+
+    [JsonPropertyName("suppression")]
+    public WgDiagnosticSuppression? Suppression { get; set; }
+
+    [JsonPropertyName("timestampUtc")]
+    public DateTime TimestampUtc { get; set; } = DateTime.UtcNow;
+}
+
+public static class WgDiagnosticSeverity
+{
+    public const string Error = "error";
+    public const string Warning = "warning";
+    public const string Note = "note";
+    public const string None = "none";
+}
+
+public static class WgDiagnosticStage
+{
+    public const string Extract = "extract";
+    public const string Plan = "plan";
+    public const string Generate = "generate";
+    public const string Analyze = "analyze";
+    public const string Fix = "fix";
+    public const string Cli = "cli";
+    public const string Config = "config";
+}
+
+public sealed class WgDiagnosticSource
+{
+    [JsonPropertyName("tool")]
+    public string Tool { get; set; } = "WrapGod";
+
+    [JsonPropertyName("component")]
+    public string? Component { get; set; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+}
+
+public sealed class WgDiagnosticLocation
+{
+    [JsonPropertyName("uri")]
+    public string? Uri { get; set; }
+
+    [JsonPropertyName("line")]
+    public int? Line { get; set; }
+
+    [JsonPropertyName("column")]
+    public int? Column { get; set; }
+
+    [JsonPropertyName("endLine")]
+    public int? EndLine { get; set; }
+
+    [JsonPropertyName("endColumn")]
+    public int? EndColumn { get; set; }
+
+    [JsonPropertyName("symbol")]
+    public string? Symbol { get; set; }
+}
+
+public sealed class WgDiagnosticSuppression
+{
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; }
+
+    [JsonPropertyName("justification")]
+    public string? Justification { get; set; }
+
+    [JsonPropertyName("source")]
+    public string? Source { get; set; }
+}

--- a/WrapGod.Abstractions/WrapGod.Abstractions.csproj
+++ b/WrapGod.Abstractions/WrapGod.Abstractions.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
 </Project>

--- a/WrapGod.Analyzers/RoslynDiagnosticAdapter.cs
+++ b/WrapGod.Analyzers/RoslynDiagnosticAdapter.cs
@@ -1,0 +1,51 @@
+using Microsoft.CodeAnalysis;
+using WrapGod.Abstractions.Diagnostics;
+
+namespace WrapGod.Analyzers;
+
+public static class RoslynDiagnosticAdapter
+{
+    public static WgDiagnosticV1 ToWgDiagnosticV1(Diagnostic diagnostic, DateTime? timestampUtc = null)
+    {
+        var span = diagnostic.Location.GetLineSpan();
+        var hasFile = span.Path is not null;
+        var hasPosition = span.StartLinePosition.Line >= 0 && span.StartLinePosition.Character >= 0;
+
+        return new WgDiagnosticV1
+        {
+            Schema = WgDiagnosticV1.SchemaId,
+            Code = diagnostic.Id,
+            Severity = MapSeverity(diagnostic.Severity),
+            Stage = WgDiagnosticStage.Analyze,
+            Category = "migration",
+            Message = diagnostic.GetMessage(System.Globalization.CultureInfo.InvariantCulture),
+            Source = new WgDiagnosticSource
+            {
+                Tool = "WrapGod",
+                Component = "WrapGod.Analyzers",
+            },
+            Location = hasFile
+                ? new WgDiagnosticLocation
+                {
+                    Uri = span.Path,
+                    Line = hasPosition ? span.StartLinePosition.Line + 1 : null,
+                    Column = hasPosition ? span.StartLinePosition.Character + 1 : null,
+                    EndLine = hasPosition ? span.EndLinePosition.Line + 1 : null,
+                    EndColumn = hasPosition ? span.EndLinePosition.Character + 1 : null,
+                }
+                : null,
+            HelpUri = diagnostic.Descriptor.HelpLinkUri,
+            TimestampUtc = timestampUtc ?? DateTime.UtcNow,
+        };
+    }
+
+    private static string MapSeverity(DiagnosticSeverity severity)
+        => severity switch
+        {
+            DiagnosticSeverity.Error => WgDiagnosticSeverity.Error,
+            DiagnosticSeverity.Warning => WgDiagnosticSeverity.Warning,
+            DiagnosticSeverity.Info => WgDiagnosticSeverity.Note,
+            DiagnosticSeverity.Hidden => WgDiagnosticSeverity.None,
+            _ => WgDiagnosticSeverity.Note,
+        };
+}

--- a/WrapGod.Tests/DiagnosticsContractTests.cs
+++ b/WrapGod.Tests/DiagnosticsContractTests.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using Json.Schema;
+using Microsoft.CodeAnalysis;
+using WrapGod.Abstractions.Config;
+using WrapGod.Abstractions.Diagnostics;
+using WrapGod.Analyzers;
+
+namespace WrapGod.Tests;
+
+public sealed class DiagnosticsContractTests
+{
+    private static readonly DateTime FixedUtc =
+        new(2026, 03, 27, 22, 0, 0, DateTimeKind.Utc);
+
+    private static readonly string RepoRoot =
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
+
+    private static JsonDocument EmitSampleJson()
+    {
+        var analyzerDescriptor = new DiagnosticDescriptor(
+            "WG2001",
+            "Direct type usage",
+            "Type 'Vendor.Client' has a generated wrapper interface; use 'IClient' instead",
+            "Usage",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: "https://wrapgod.dev/docs/analyzers/WG2001");
+
+        var analyzerDiagnostic = Diagnostic.Create(analyzerDescriptor, Location.None);
+        var wg2001 = RoslynDiagnosticAdapter.ToWgDiagnosticV1(analyzerDiagnostic, FixedUtc);
+
+        var configDiagnostic = new ConfigDiagnostic
+        {
+            Code = "WG6001",
+            Message = "Type include conflict between JSON and attributes.",
+            Target = "Vendor.Client",
+        };
+
+        var wg6001 = WgDiagnosticEmitter.FromConfigDiagnostic(configDiagnostic, FixedUtc);
+
+        var json = WgDiagnosticEmitter.EmitJson(new[] { wg2001, wg6001 });
+        return JsonDocument.Parse(json);
+    }
+
+    [Fact]
+    public void JsonOutput_ValidatesAgainstRfc0054Shape()
+    {
+        using var doc = EmitSampleJson();
+        var schemaText = File.ReadAllText(Path.Combine(RepoRoot, "schemas", "wg.diagnostic.v1.schema.json"));
+        var schema = JsonSchema.FromText(schemaText);
+
+        var diagnostics = doc.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(2, diagnostics.Length);
+
+        foreach (var diagnostic in diagnostics)
+        {
+            var result = schema.Evaluate(diagnostic, new EvaluationOptions { OutputFormat = OutputFormat.Flag });
+            Assert.True(result.IsValid);
+        }
+    }
+
+    [Fact]
+    public void ExistingProducers_NormalizeIntoCanonicalModel()
+    {
+        using var doc = EmitSampleJson();
+        var diagnostics = doc.RootElement.EnumerateArray().ToArray();
+
+        var wg2001 = diagnostics.Single(d => d.GetProperty("code").GetString() == "WG2001");
+        var wg6001 = diagnostics.Single(d => d.GetProperty("code").GetString() == "WG6001");
+
+        Assert.Equal("wg.diagnostic.v1", wg2001.GetProperty("schema").GetString());
+        Assert.Equal("analyze", wg2001.GetProperty("stage").GetString());
+        Assert.Equal("warning", wg2001.GetProperty("severity").GetString());
+
+        Assert.Equal("wg.diagnostic.v1", wg6001.GetProperty("schema").GetString());
+        Assert.Equal("config", wg6001.GetProperty("stage").GetString());
+        Assert.Equal("warning", wg6001.GetProperty("severity").GetString());
+    }
+
+    [Fact]
+    public void SeveritySerialization_UsesLowercaseContractValues()
+    {
+        var payload = new[]
+        {
+            new WgDiagnosticV1
+            {
+                Code = "WG6002",
+                Severity = WgDiagnosticSeverity.Error,
+                Stage = WgDiagnosticStage.Config,
+                Message = "Type targetName conflict.",
+                Source = new WgDiagnosticSource { Tool = "WrapGod", Component = "tests" },
+                TimestampUtc = FixedUtc,
+            },
+            new WgDiagnosticV1
+            {
+                Code = "WG2002",
+                Severity = WgDiagnosticSeverity.Note,
+                Stage = WgDiagnosticStage.Analyze,
+                Message = "Method call can be migrated through facade.",
+                Source = new WgDiagnosticSource { Tool = "WrapGod", Component = "tests" },
+                TimestampUtc = FixedUtc,
+            },
+        };
+
+        var json = WgDiagnosticEmitter.EmitJson(payload);
+        Assert.Contains("\"severity\": \"error\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"severity\": \"note\"", json, StringComparison.Ordinal);
+    }
+}

--- a/schemas/wg.diagnostic.v1.schema.json
+++ b/schemas/wg.diagnostic.v1.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wrapgod.dev/schemas/wg.diagnostic.v1.json",
+  "title": "WrapGod Diagnostic v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "code",
+    "severity",
+    "stage",
+    "message",
+    "source",
+    "timestampUtc"
+  ],
+  "properties": {
+    "schema": { "const": "wg.diagnostic.v1" },
+    "code": { "type": "string", "pattern": "^WG[0-9]{4}$" },
+    "severity": { "enum": ["error", "warning", "note", "none"] },
+    "stage": {
+      "enum": ["extract", "plan", "generate", "analyze", "fix", "cli", "config"]
+    },
+    "category": { "type": "string" },
+    "message": { "type": "string", "minLength": 1 },
+    "source": {
+      "type": "object",
+      "required": ["tool"],
+      "properties": {
+        "tool": { "type": "string", "minLength": 1 },
+        "component": { "type": "string" },
+        "version": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "location": {
+      "type": ["object", "null"],
+      "properties": {
+        "uri": { "type": "string" },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "endLine": { "type": "integer", "minimum": 1 },
+        "endColumn": { "type": "integer", "minimum": 1 },
+        "symbol": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "relatedLocations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/location" }
+    },
+    "helpUri": { "type": ["string", "null"], "format": "uri" },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "fingerprint": { "type": "string" },
+    "properties": { "type": "object", "additionalProperties": true },
+    "suppression": {
+      "type": ["object", "null"],
+      "properties": {
+        "kind": { "enum": ["editorconfig", "pragma", "global", "cli", "baseline"] },
+        "justification": { "type": "string" },
+        "source": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "timestampUtc": { "type": "string", "format": "date-time" }
+  },
+  "$defs": {
+    "location": {
+      "type": "object",
+      "properties": {
+        "uri": { "type": "string" },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "endLine": { "type": "integer", "minimum": 1 },
+        "endColumn": { "type": "integer", "minimum": 1 },
+        "symbol": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary\n- add canonical wg.diagnostic.v1 model in WrapGod.Abstractions.Diagnostics\n- add JSON emitter for canonical diagnostics\n- add normalization adapters for analyzer diagnostics (WG2001/WG2002) and config merge diagnostics (WG6001-WG6004)\n- add schemas/wg.diagnostic.v1.schema.json\n- add unit tests for schema shape validation, producer normalization, and severity serialization\n\n## Testing\n- dotnet test WrapGod.Tests/WrapGod.Tests.csproj\n\nCloses #81