### PR TITLE
feat: implement benchmark harness (BenchmarkDotNet)

### DIFF
--- a/WrapGod.Benchmarks/ExtractorBenchmarks.cs
+++ b/WrapGod.Benchmarks/ExtractorBenchmarks.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Attributes;
+using WrapGod.Extractor;
+using WrapGod.Manifest;
+
+namespace WrapGod.Benchmarks;
+
+/// <summary>
+/// Benchmarks for <see cref="AssemblyExtractor.Extract"/> across assemblies of varying size.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 2, iterationCount: 5)]
+public class ExtractorBenchmarks
+{
+    private string _smallAssemblyPath = null!;
+    private string _mediumAssemblyPath = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Small: System.Private.CoreLib (typeof(object)) — lean but always available
+        _smallAssemblyPath = typeof(object).Assembly.Location;
+
+        // Medium: System.Text.Json — broader API surface
+        _mediumAssemblyPath = typeof(System.Text.Json.JsonSerializer).Assembly.Location;
+    }
+
+    [Benchmark(Description = "Extract small assembly (CoreLib)")]
+    public ApiManifest ExtractSmallAssembly() =>
+        AssemblyExtractor.Extract(_smallAssemblyPath);
+
+    [Benchmark(Description = "Extract medium assembly (System.Text.Json)")]
+    public ApiManifest ExtractMediumAssembly() =>
+        AssemblyExtractor.Extract(_mediumAssemblyPath);
+}

--- a/WrapGod.Benchmarks/GeneratorBenchmarks.cs
+++ b/WrapGod.Benchmarks/GeneratorBenchmarks.cs
@@ -1,0 +1,89 @@
+using BenchmarkDotNet.Attributes;
+using WrapGod.Manifest;
+
+namespace WrapGod.Benchmarks;
+
+/// <summary>
+/// Benchmarks for manifest parsing and source emission using synthetic manifest data.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 2, iterationCount: 5)]
+public class GeneratorBenchmarks
+{
+    private string _smallManifestJson = null!;
+    private string _mediumManifestJson = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _smallManifestJson = ManifestSerializer.Serialize(BuildSyntheticManifest(typeCount: 10, membersPerType: 5));
+        _mediumManifestJson = ManifestSerializer.Serialize(BuildSyntheticManifest(typeCount: 50, membersPerType: 10));
+    }
+
+    [Benchmark(Description = "Parse small manifest (10 types)")]
+    public ApiManifest? ParseSmallManifest() =>
+        ManifestSerializer.Deserialize(_smallManifestJson);
+
+    [Benchmark(Description = "Parse medium manifest (50 types)")]
+    public ApiManifest? ParseMediumManifest() =>
+        ManifestSerializer.Deserialize(_mediumManifestJson);
+
+    [Benchmark(Description = "Serialize small manifest (10 types)")]
+    public string SerializeSmallManifest() =>
+        ManifestSerializer.Serialize(ManifestSerializer.Deserialize(_smallManifestJson)!);
+
+    [Benchmark(Description = "Serialize medium manifest (50 types)")]
+    public string SerializeMediumManifest() =>
+        ManifestSerializer.Serialize(ManifestSerializer.Deserialize(_mediumManifestJson)!);
+
+    private static ApiManifest BuildSyntheticManifest(int typeCount, int membersPerType)
+    {
+        var types = new List<ApiTypeNode>();
+
+        for (var t = 0; t < typeCount; t++)
+        {
+            var members = new List<ApiMemberNode>();
+            for (var m = 0; m < membersPerType; m++)
+            {
+                members.Add(new ApiMemberNode
+                {
+                    StableId = $"Synthetic.Type{t}.Method{m}()",
+                    Name = $"Method{m}",
+                    Kind = ApiMemberKind.Method,
+                    ReturnType = "System.Void",
+                    Parameters =
+                    [
+                        new ApiParameterInfo
+                        {
+                            Name = "arg0",
+                            Type = "System.String",
+                        },
+                    ],
+                });
+            }
+
+            types.Add(new ApiTypeNode
+            {
+                StableId = $"Synthetic.Type{t}",
+                FullName = $"Synthetic.Type{t}",
+                Name = $"Type{t}",
+                Namespace = "Synthetic",
+                Kind = ApiTypeKind.Class,
+                Members = members,
+            });
+        }
+
+        return new ApiManifest
+        {
+            SchemaVersion = "1.0",
+            GeneratedAt = DateTimeOffset.UtcNow,
+            SourceHash = "benchmark-synthetic",
+            Assembly = new AssemblyIdentity
+            {
+                Name = "Synthetic.Assembly",
+                Version = "1.0.0.0",
+            },
+            Types = types,
+        };
+    }
+}

--- a/WrapGod.Benchmarks/Program.cs
+++ b/WrapGod.Benchmarks/Program.cs
@@ -1,0 +1,11 @@
+using BenchmarkDotNet.Running;
+
+namespace WrapGod.Benchmarks;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/WrapGod.Benchmarks/WrapGod.Benchmarks.csproj
+++ b/WrapGod.Benchmarks/WrapGod.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- Benchmarks are not subject to style enforcement -->
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WrapGod.Extractor\WrapGod.Extractor.csproj" />
+    <ProjectReference Include="..\WrapGod.Manifest\WrapGod.Manifest.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WrapGod.slnx
+++ b/WrapGod.slnx
@@ -9,4 +9,5 @@
   <Project Path="WrapGod.Tests/WrapGod.Tests.csproj" />
   <Project Path="WrapGod.TypeMap/WrapGod.TypeMap.csproj" />
   <Project Path="WrapGod.Cli/WrapGod.Cli.csproj" />
+  <Project Path="WrapGod.Benchmarks/WrapGod.Benchmarks.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary
- Add `WrapGod.Benchmarks` project targeting net10.0 with BenchmarkDotNet
- `ExtractorBenchmarks` benchmarks `AssemblyExtractor.Extract` on CoreLib (small) and System.Text.Json (medium)
- `GeneratorBenchmarks` benchmarks manifest serialization/deserialization with synthetic data (10 and 50 types)
- Project added to `WrapGod.slnx`, builds cleanly in Release

## Test plan
- [x] Solution builds with `dotnet build WrapGod.slnx --nologo -c Release` (0 errors, 0 warnings)
- [ ] Benchmarks can be run locally with `dotnet run -c Release --project WrapGod.Benchmarks`

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)