### PR TITLE
feat: CI benchmark workflow + phased gating rollout

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,48 @@
+name: Benchmarks
+
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'BenchmarkDotNet filter pattern'
+        required: false
+        default: '*'
+  schedule:
+    # Weekly on Sundays at 04:00 UTC — informational only
+    - cron: '0 4 * * 0'
+
+jobs:
+  run-benchmarks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore WrapGod.Benchmarks/WrapGod.Benchmarks.csproj
+
+      - name: Build benchmarks
+        run: dotnet build WrapGod.Benchmarks/WrapGod.Benchmarks.csproj --configuration Release --no-restore
+
+      - name: Run benchmarks
+        run: >
+          dotnet run --project WrapGod.Benchmarks/WrapGod.Benchmarks.csproj
+          --configuration Release
+          --no-build
+          --
+          --filter '${{ github.event.inputs.filter || '*' }}'
+          --exporters json
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: benchmark-results
+          path: BenchmarkDotNet.Artifacts/
+          retention-days: 30


### PR DESCRIPTION
## Summary
- Add `.github/workflows/benchmarks.yml` with manual trigger (`workflow_dispatch`) and optional weekly schedule (Sundays 04:00 UTC)
- Builds and runs benchmarks with `--exporters json`, uploads results as artifacts (30-day retention)
- Informational only — does NOT gate PRs (phased rollout: observe first, gate later)

## Test plan
- [x] YAML syntax valid
- [ ] Manual dispatch works from Actions tab
- [ ] Artifacts appear after run

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)