### PR TITLE
feat: SARIF diagnostics emitter + WG rule catalog projection

### DIFF
--- a/WrapGod.Abstractions/Diagnostics/WgDiagnosticEmitter.cs
+++ b/WrapGod.Abstractions/Diagnostics/WgDiagnosticEmitter.cs
@@ -124,7 +124,7 @@ public static class WgDiagnosticEmitter
             relatedLocations = BuildRelatedLocations(diagnostic.RelatedLocations),
             fingerprints = string.IsNullOrWhiteSpace(diagnostic.Fingerprint)
                 ? null
-                : new Dictionary<string, string> { ["wrapgodFingerprint"] = diagnostic.Fingerprint },
+                : new Dictionary<string, string> { ["wrapgodFingerprint"] = diagnostic.Fingerprint! },
             suppressions = BuildSuppressions(diagnostic.Suppression),
             properties = BuildResultProperties(diagnostic),
         };
@@ -140,7 +140,7 @@ public static class WgDiagnosticEmitter
         return new[] { BuildSarifLocation(location) };
     }
 
-    private static object[]? BuildRelatedLocations(IReadOnlyCollection<WgDiagnosticLocation>? locations)
+    private static object[]? BuildRelatedLocations(List<WgDiagnosticLocation>? locations)
     {
         if (locations is null || locations.Count == 0)
         {
@@ -198,7 +198,7 @@ public static class WgDiagnosticEmitter
         };
     }
 
-    private static object? BuildResultProperties(WgDiagnosticV1 diagnostic)
+    private static Dictionary<string, object?> BuildResultProperties(WgDiagnosticV1 diagnostic)
     {
         var baseProperties = new Dictionary<string, object?>
         {


### PR DESCRIPTION
## Summary
- add `WgDiagnosticEmitter.EmitSarif(...)` for SARIF 2.1.0 output from `wg.diagnostic.v1`
- project a stable, unique WG rule catalog into `runs[0].tool.driver.rules[]`
- map severity, locations, related locations, fingerprints, suppressions, `helpUri`, and metadata
- extend contract tests to verify SARIF shape and mapping behavior
- document JSON/SARIF diagnostics emitter responsibilities in architecture docs

## Testing
- `dotnet test WrapGod/WrapGod.Tests/WrapGod.Tests.csproj --filter "FullyQualifiedName~DiagnosticsContractTests" -p:BuildProjectReferences=false`

Fixes #82
