### PR TITLE
feat: implement RFC 0051 incremental extractor cache

### DIFF
--- a/WrapGod.Extractor/AssemblyExtractor.cs
+++ b/WrapGod.Extractor/AssemblyExtractor.cs
@@ -11,6 +11,39 @@ namespace WrapGod.Extractor;
 public static class AssemblyExtractor
 {
     /// <summary>
+    /// Extracts an <see cref="ApiManifest"/> from the assembly at <paramref name="assemblyPath"/>,
+    /// optionally using an <see cref="ExtractorCache"/> to skip re-extraction when the assembly
+    /// has not changed.
+    /// </summary>
+    /// <param name="assemblyPath">Absolute path to the .NET assembly DLL.</param>
+    /// <param name="useCache">When <c>true</c>, checks cache before extracting and stores the result.</param>
+    /// <param name="cache">Cache instance. If null and <paramref name="useCache"/> is true, a default cache is created.</param>
+    /// <returns>A fully-populated, deterministically-sorted manifest.</returns>
+    /// <exception cref="FileNotFoundException">Thrown when the assembly file does not exist.</exception>
+    public static ApiManifest Extract(string assemblyPath, bool useCache, ExtractorCache? cache = null)
+    {
+        if (!File.Exists(assemblyPath))
+        {
+            throw new FileNotFoundException("Assembly file not found.", assemblyPath);
+        }
+
+        if (useCache)
+        {
+            cache ??= new ExtractorCache();
+
+            var cached = cache.TryGetCached(assemblyPath);
+            if (cached is not null)
+                return cached;
+
+            var manifest = Extract(assemblyPath);
+            cache.Store(assemblyPath, manifest);
+            return manifest;
+        }
+
+        return Extract(assemblyPath);
+    }
+
+    /// <summary>
     /// Extracts an <see cref="ApiManifest"/> from the assembly at <paramref name="assemblyPath"/>.
     /// </summary>
     /// <param name="assemblyPath">Absolute path to the .NET assembly DLL.</param>

--- a/WrapGod.Extractor/ExtractorCache.cs
+++ b/WrapGod.Extractor/ExtractorCache.cs
@@ -1,0 +1,140 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using WrapGod.Manifest;
+
+namespace WrapGod.Extractor;
+
+/// <summary>
+/// Incremental cache for <see cref="AssemblyExtractor"/> results.
+/// Cache key: assembly path + file hash + extractor version.
+/// Storage: JSON files in a configurable cache directory.
+/// </summary>
+public sealed class ExtractorCache
+{
+    /// <summary>
+    /// Bump this when extractor logic changes to invalidate all cached entries.
+    /// </summary>
+    internal const string ExtractorVersion = "1";
+
+    private static readonly JsonSerializerOptions CacheJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    private readonly string _cacheDirectory;
+
+    /// <summary>
+    /// Creates a new <see cref="ExtractorCache"/> using the specified directory.
+    /// </summary>
+    /// <param name="cacheDirectory">
+    /// Directory where cache files are stored.
+    /// Defaults to <c>.wrapgod-cache/</c> under the current working directory.
+    /// </param>
+    public ExtractorCache(string? cacheDirectory = null)
+    {
+        _cacheDirectory = cacheDirectory ?? Path.Combine(Directory.GetCurrentDirectory(), ".wrapgod-cache");
+    }
+
+    /// <summary>
+    /// Returns a cached <see cref="ApiManifest"/> if the cache entry is still valid
+    /// (same file hash and extractor version). Returns <c>null</c> on cache miss.
+    /// </summary>
+    public ApiManifest? TryGetCached(string assemblyPath)
+    {
+        var cacheFile = GetCacheFilePath(assemblyPath);
+
+        if (!File.Exists(cacheFile))
+            return null;
+
+        try
+        {
+            var json = File.ReadAllText(cacheFile);
+            var entry = JsonSerializer.Deserialize<CacheEntry>(json, CacheJsonOptions);
+
+            if (entry is null)
+                return null;
+
+            // Validate extractor version
+            if (entry.ExtractorVersion != ExtractorVersion)
+                return null;
+
+            // Validate file hash
+            var currentHash = ComputeFileHash(assemblyPath);
+            if (entry.FileHash != currentHash)
+                return null;
+
+            return entry.Manifest;
+        }
+        catch (JsonException)
+        {
+            // Corrupted cache entry — treat as miss
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Persists the extraction result to the cache.
+    /// </summary>
+    public void Store(string assemblyPath, ApiManifest manifest)
+    {
+        var cacheFile = GetCacheFilePath(assemblyPath);
+        Directory.CreateDirectory(_cacheDirectory);
+
+        var entry = new CacheEntry
+        {
+            AssemblyPath = Path.GetFullPath(assemblyPath),
+            FileHash = ComputeFileHash(assemblyPath),
+            ExtractorVersion = ExtractorVersion,
+            CachedAt = DateTimeOffset.UtcNow,
+            Manifest = manifest,
+        };
+
+        var json = JsonSerializer.Serialize(entry, CacheJsonOptions);
+        File.WriteAllText(cacheFile, json);
+    }
+
+    /// <summary>
+    /// Removes a cached entry for the given assembly path.
+    /// </summary>
+    public void Invalidate(string assemblyPath)
+    {
+        var cacheFile = GetCacheFilePath(assemblyPath);
+
+        if (File.Exists(cacheFile))
+            File.Delete(cacheFile);
+    }
+
+    private string GetCacheFilePath(string assemblyPath)
+    {
+        var fullPath = Path.GetFullPath(assemblyPath);
+        var hash = ComputeStringHash(fullPath);
+        return Path.Combine(_cacheDirectory, $"{hash}.json");
+    }
+
+    private static string ComputeFileHash(string filePath)
+    {
+        using var stream = File.OpenRead(filePath);
+        var hash = SHA256.HashData(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string ComputeStringHash(string value)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(value);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    internal sealed class CacheEntry
+    {
+        public string AssemblyPath { get; set; } = string.Empty;
+        public string FileHash { get; set; } = string.Empty;
+        public string ExtractorVersion { get; set; } = string.Empty;
+        public DateTimeOffset CachedAt { get; set; }
+        public ApiManifest Manifest { get; set; } = new();
+    }
+}

--- a/WrapGod.Tests/ExtractorCacheTests.cs
+++ b/WrapGod.Tests/ExtractorCacheTests.cs
@@ -1,0 +1,157 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Extractor;
+using WrapGod.Manifest;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("Extractor cache")]
+public sealed class ExtractorCacheTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static readonly string CoreLibPath = typeof(object).Assembly.Location;
+
+    private static string CreateTempCacheDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "wrapgod-cache-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    // ── Scenario data ────────────────────────────────────────────────
+
+    internal sealed record CacheMissResult(string CacheDir, ExtractorCache Cache, ApiManifest Manifest);
+
+    private static CacheMissResult PerformCacheMissExtraction()
+    {
+        var cacheDir = CreateTempCacheDir();
+        var cache = new ExtractorCache(cacheDir);
+
+        // First call — cache is empty, should extract and store
+        var manifest = AssemblyExtractor.Extract(CoreLibPath, useCache: true, cache);
+
+        return new CacheMissResult(cacheDir, cache, manifest);
+    }
+
+    internal sealed record CacheHitResult(string CacheDir, ApiManifest FirstManifest, ApiManifest SecondManifest);
+
+    private static CacheHitResult PerformCacheHitExtraction()
+    {
+        var cacheDir = CreateTempCacheDir();
+        var cache = new ExtractorCache(cacheDir);
+
+        // First call — populates cache
+        var first = AssemblyExtractor.Extract(CoreLibPath, useCache: true, cache);
+
+        // Second call — should return from cache
+        var second = AssemblyExtractor.Extract(CoreLibPath, useCache: true, cache);
+
+        return new CacheHitResult(cacheDir, first, second);
+    }
+
+    internal sealed record ModifiedAssemblyResult(bool CacheReturnedNullAfterModification);
+
+    private static ModifiedAssemblyResult SimulateModifiedAssembly()
+    {
+        var cacheDir = CreateTempCacheDir();
+        try
+        {
+            var cache = new ExtractorCache(cacheDir);
+
+            // Store a manifest with the current assembly hash
+            var manifest = AssemblyExtractor.Extract(CoreLibPath);
+            cache.Store(CoreLibPath, manifest);
+
+            // Tamper with the cache file to simulate a different file hash
+            var cacheFiles = Directory.GetFiles(cacheDir, "*.json");
+            foreach (var file in cacheFiles)
+            {
+                var content = File.ReadAllText(file);
+                content = content.Replace(manifest.SourceHash!, "0000000000000000000000000000000000000000000000000000000000000000");
+                File.WriteAllText(file, content);
+            }
+
+            // Now TryGetCached should return null because hash doesn't match
+            var result = cache.TryGetCached(CoreLibPath);
+
+            return new ModifiedAssemblyResult(result is null);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    internal sealed record InvalidateResult(bool EntryExistedBefore, bool EntryGoneAfter);
+
+    private static InvalidateResult PerformInvalidation()
+    {
+        var cacheDir = CreateTempCacheDir();
+        try
+        {
+            var cache = new ExtractorCache(cacheDir);
+            var manifest = AssemblyExtractor.Extract(CoreLibPath);
+            cache.Store(CoreLibPath, manifest);
+
+            var existedBefore = cache.TryGetCached(CoreLibPath) is not null;
+            cache.Invalidate(CoreLibPath);
+            var goneAfter = cache.TryGetCached(CoreLibPath) is null;
+
+            return new InvalidateResult(existedBefore, goneAfter);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+                Directory.Delete(cacheDir, recursive: true);
+        }
+    }
+
+    // ── Scenarios ────────────────────────────────────────────────────
+
+    [Scenario("Cache miss extracts and stores")]
+    [Fact]
+    public Task CacheMiss_ExtractsAndStores()
+        => Given("a fresh cache and an assembly to extract", PerformCacheMissExtraction)
+            .Then("a manifest is returned", result => result.Manifest is not null)
+            .And("the manifest contains types", result => result.Manifest.Types.Count > 0)
+            .And("a cache file was created", result =>
+                Directory.GetFiles(result.CacheDir, "*.json").Length > 0)
+            .And("the cached entry can be retrieved", result =>
+                result.Cache.TryGetCached(CoreLibPath) is not null)
+            .AssertPassed();
+
+    [Scenario("Cache hit returns stored manifest without re-extraction")]
+    [Fact]
+    public Task CacheHit_ReturnsStoredManifest()
+        => Given("two consecutive extractions with cache enabled", PerformCacheHitExtraction)
+            .Then("both manifests are non-null", result =>
+                result.FirstManifest is not null && result.SecondManifest is not null)
+            .And("type counts match", result =>
+                result.FirstManifest.Types.Count == result.SecondManifest.Types.Count)
+            .And("assembly names match", result =>
+                result.FirstManifest.Assembly.Name == result.SecondManifest.Assembly.Name)
+            .And("source hashes match", result =>
+                result.FirstManifest.SourceHash == result.SecondManifest.SourceHash)
+            .AssertPassed();
+
+    [Scenario("Modified assembly invalidates cache (different hash)")]
+    [Fact]
+    public Task ModifiedAssembly_InvalidatesCache()
+        => Given("a cached entry with a tampered file hash", SimulateModifiedAssembly)
+            .Then("the cache returns null for the modified assembly", result =>
+                result.CacheReturnedNullAfterModification)
+            .AssertPassed();
+
+    [Scenario("Invalidate removes cached entry")]
+    [Fact]
+    public Task Invalidate_RemovesCachedEntry()
+        => Given("an invalidation of a cached entry", PerformInvalidation)
+            .Then("the entry existed before invalidation", result =>
+                result.EntryExistedBefore)
+            .And("the entry is gone after invalidation", result =>
+                result.EntryGoneAfter)
+            .AssertPassed();
+}


### PR DESCRIPTION
## Summary
- Add `ExtractorCache` in `WrapGod.Extractor/ExtractorCache.cs` — cache key is assembly path + SHA-256 file hash + extractor version, stored as JSON in configurable directory (defaults to `.wrapgod-cache/`)
- Add `AssemblyExtractor.Extract(assemblyPath, useCache, cache?)` overload that checks cache first, extracts on miss, and stores the result
- `TryGetCached`, `Store`, and `Invalidate` methods for full cache lifecycle
- 4 TinyBDD scenario tests covering cache miss/hit/hash-invalidation/explicit-invalidation

## Test plan
- [x] `dotnet build WrapGod.slnx --nologo -c Release` — 0 errors, 0 warnings
- [x] `dotnet test WrapGod.Tests/WrapGod.Tests.csproj --nologo -v q` — 124 passed, 0 failed

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)