### PR TITLE
feat: workflow + template standardization from PatternKit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,125 @@
+name: Bug Report
+description: File a bug report to help us improve WrapGod
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees:
+  - jerrettdavis
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what happened!
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Create a mapping with '...'
+        2. Call method '....'
+        3. Pass parameters '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened instead.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which component is affected?
+      options:
+        - Abstractions
+        - Analyzers
+        - CLI
+        - Extractor
+        - Fluent API
+        - Generator
+        - Manifest
+        - Runtime
+        - TypeMap
+        - Documentation
+        - Examples
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of WrapGod are you using?
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: dotnet-version
+    attributes:
+      label: .NET Version
+      description: What version of .NET are you using?
+      options:
+        - ".NET 10.0"
+        - ".NET 9.0"
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you using?
+      placeholder: "Windows 11, Ubuntu 22.04, macOS 14"
+    validations:
+      required: true
+
+  - type: textarea
+    id: code-sample
+    attributes:
+      label: Code Sample
+      description: Please provide a minimal code sample that reproduces the issue.
+      render: csharp
+      placeholder: |
+        var map = WrapMap.Create<IOldService, INewService>()
+            .ForMember(...)
+            .Build();
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Stack Trace
+      description: Please copy and paste any relevant log output or stack traces.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,107 @@
+name: Feature Request
+description: Suggest an idea for WrapGod
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+assignees:
+  - jerrettdavis
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+      placeholder: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe alternatives you've considered.
+      placeholder: A clear and concise description of any alternative solutions or features you've considered.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which component would this feature affect?
+      options:
+        - Abstractions
+        - Analyzers
+        - CLI
+        - Extractor
+        - Fluent API
+        - Generator
+        - Manifest
+        - Runtime
+        - TypeMap
+        - Documentation
+        - Examples
+        - Build/CI
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to you?
+      options:
+        - Low (Nice to have)
+        - Medium (Would improve workflow)
+        - High (Blocking current work)
+        - Critical (Blocking production use)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Are you willing to contribute this feature?
+      options:
+        - label: I am willing to submit a PR to implement this feature
+        - label: I can help test this feature when implemented
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe a specific use case for this feature.
+      placeholder: |
+        As a [developer type], I want to [action] so that [benefit].
+
+  - type: textarea
+    id: code-example
+    attributes:
+      label: Example Usage (Optional)
+      description: If applicable, show how you envision using this feature.
+      render: csharp
+      placeholder: |
+        // Example of how the feature would be used
+        var map = WrapMap.Create<IOldService, INewService>()
+            .Configure(...)
+            .Build();
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, or examples about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,48 @@
+# Description
+
+Please include a summary of the changes and which issue is fixed. Include relevant motivation and context.
+
+Fixes # (issue)
+
+## Type of Change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Performance improvement
+- [ ] Code refactoring
+- [ ] Build/CI changes
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
+
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] Manual testing
+
+**Test Configuration**:
+- .NET version:
+- OS:
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Screenshots (if applicable)
+
+Add screenshots to help explain your changes.
+
+## Additional Context
+
+Add any other context about the pull request here.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,85 @@
+# Auto-labeling configuration for pull requests
+
+'area: abstractions':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.Abstractions/**/*'
+
+'area: analyzers':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.Analyzers/**/*'
+
+'area: cli':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.Cli/**/*'
+
+'area: extractor':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.Extractor/**/*'
+
+'area: fluent':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.Fluent/**/*'
+
+'area: generator':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.Generator/**/*'
+
+'area: manifest':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.Manifest/**/*'
+
+'area: runtime':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.Runtime/**/*'
+
+'area: typemap':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.TypeMap/**/*'
+
+'area: examples':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'examples/**/*'
+
+'area: documentation':
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.md'
+      - 'docs/**/*'
+
+'area: tests':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.Tests/**/*'
+
+'area: benchmarks':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'WrapGod.Benchmarks/**/*'
+
+'area: ci/cd':
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**/*'
+
+'area: schemas':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'schemas/**/*'
+
+'dependencies':
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/packages.lock.json'
+      - '**/*.csproj'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,40 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 12 * * 0'
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: csharp
+
+      - name: Restore
+        run: dotnet restore WrapGod.slnx
+
+      - name: Build
+        run: dotnet build WrapGod.slnx --configuration Release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
+          comment-summary-in-pr: always

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Publish docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  actions: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  publish-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - run: dotnet tool update -g docfx
+
+      - name: Build docfx metadata
+        run: docfx metadata docs/docfx.json
+        continue-on-error: true
+
+      - name: Build docfx site
+        run: docfx build docs/docfx.json
+        continue-on-error: true
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: 'docs/_site'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,46 @@
+name: Auto Label
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  label-pr:
+    name: Label Pull Request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Label based on files
+        uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  label-size:
+    name: Label PR Size
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Label by size
+        uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_max_size: '10'
+          s_max_size: '100'
+          m_max_size: '500'
+          l_max_size: '1000'
+          fail_if_xl: 'false'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,79 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.vscode/**'
+      - '.editorconfig'
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  validate-pr:
+    name: Validate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore dependencies
+        run: dotnet restore WrapGod.slnx
+
+      - name: Build solution
+        run: |
+          dotnet build WrapGod.slnx \
+            --configuration Release \
+            --no-restore \
+            /p:ContinuousIntegrationBuild=true \
+            /p:Deterministic=true
+
+      - name: Run tests
+        run: |
+          dotnet test WrapGod.slnx \
+            --configuration Release \
+            --no-build \
+            --verbosity normal \
+            --logger "trx;LogFileName=test-results.trx" \
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./TestResults \
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            TestResults/**/*.trx
+          check_name: Test Results
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        if: always()
+        with:
+          files: ./TestResults/**/coverage.opencover.xml
+          flags: unittests
+          name: pr-${{ github.event.pull_request.number }}
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,56 @@
+name: Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Daily at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Close Stale Issues and PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Stale Issues and PRs
+        uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Stale issue configuration
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 7 days if no further activity occurs.
+
+            If this issue is still relevant, please add a comment to keep it open.
+            Thank you for your contributions!
+          close-issue-message: |
+            This issue was automatically closed due to inactivity.
+
+            If you believe this issue is still relevant, please feel free to reopen it or create a new issue with updated information.
+          days-before-stale: 60
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'pinned,security,bug,enhancement'
+
+          # Stale PR configuration
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 14 days if no further activity occurs.
+
+            Please rebase and update if you'd like to continue working on this PR.
+          close-pr-message: |
+            This pull request was automatically closed due to inactivity.
+
+            If you'd like to continue working on this, please feel free to reopen and update it.
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'pinned,security,work-in-progress'
+
+          # Operations per run
+          operations-per-run: 30

--- a/docs/ops/workflow-parity-matrix.md
+++ b/docs/ops/workflow-parity-matrix.md
@@ -1,0 +1,47 @@
+# Workflow Parity Matrix
+
+This document maps each adopted workflow and template file to its PatternKit source
+and documents any intentional deviations for WrapGod.
+
+## Workflows
+
+| WrapGod File | PatternKit Source | Status | Deviations |
+|---|---|---|---|
+| `.github/workflows/ci.yml` | Pre-existing | Kept as-is | WrapGod original; not ported from PatternKit |
+| `.github/workflows/benchmarks.yml` | Pre-existing | Kept as-is | WrapGod original; no PatternKit equivalent |
+| `.github/workflows/examples.yml` | Pre-existing | Kept as-is | WrapGod original; no PatternKit equivalent |
+| `.github/workflows/codeql-analysis.yml` | [PatternKit codeql-analysis.yml](https://github.com/JerrettDavis/PatternKit/blob/main/.github/workflows/codeql-analysis.yml) | Ported | Uses `global-json-file` instead of explicit dotnet versions; references `WrapGod.slnx` instead of `PatternKit.slnx`; uses `actions/checkout@v4` and `actions/setup-dotnet@v4` to match existing WrapGod conventions |
+| `.github/workflows/dependency-review.yml` | [PatternKit dependency-review.yml](https://github.com/JerrettDavis/PatternKit/blob/main/.github/workflows/dependency-review.yml) | Ported | Direct port, no deviations |
+| `.github/workflows/stale.yml` | [PatternKit stale.yml](https://github.com/JerrettDavis/PatternKit/blob/main/.github/workflows/stale.yml) | Ported | Direct port, no deviations |
+| `.github/workflows/labeler.yml` | [PatternKit labeler.yml](https://github.com/JerrettDavis/PatternKit/blob/main/.github/workflows/labeler.yml) | Ported | Direct port, no deviations |
+| `.github/workflows/pr-validation.yml` | [PatternKit pr-validation.yml](https://github.com/JerrettDavis/PatternKit/blob/main/.github/workflows/pr-validation.yml) | Ported | Removed GitVersion/versioning steps; removed docfx build step; removed NuGet dry-run packaging; removed PR comment step; uses `global-json-file` for .NET setup; references `WrapGod.slnx` |
+| `.github/workflows/docs.yml` | [PatternKit docs.yml](https://github.com/JerrettDavis/PatternKit/blob/main/.github/workflows/docs.yml) | Ported | Added `paths` filter for docs changes only; uses `global-json-file`; added `continue-on-error` on docfx steps (no `docfx.json` yet); removed explicit project build steps |
+
+## Label Configuration
+
+| WrapGod File | PatternKit Source | Status | Deviations |
+|---|---|---|---|
+| `.github/labeler.yml` | [PatternKit labeler.yml](https://github.com/JerrettDavis/PatternKit/blob/main/.github/labeler.yml) | Ported | Labels adapted to WrapGod project structure (Abstractions, Analyzers, CLI, Extractor, Fluent, Generator, Manifest, Runtime, TypeMap, Benchmarks, Schemas) instead of PatternKit components |
+
+## Templates
+
+| WrapGod File | PatternKit Source | Status | Deviations |
+|---|---|---|---|
+| `.github/PULL_REQUEST_TEMPLATE.md` | [PatternKit PULL_REQUEST_TEMPLATE.md](https://github.com/JerrettDavis/PatternKit/blob/main/.github/PULL_REQUEST_TEMPLATE.md) | Ported | Direct port, no deviations |
+| `.github/ISSUE_TEMPLATE/bug_report.yml` | [PatternKit bug_report.yml](https://github.com/JerrettDavis/PatternKit/blob/main/.github/ISSUE_TEMPLATE/bug_report.yml) | Ported | Component dropdown updated to WrapGod components; code sample placeholder updated to WrapGod API examples |
+| `.github/ISSUE_TEMPLATE/feature_request.yml` | [PatternKit feature_request.yml](https://github.com/JerrettDavis/PatternKit/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml) | Ported | Component dropdown updated to WrapGod components; code example placeholder updated to WrapGod API examples |
+
+## Validation Checklist
+
+- [ ] `ci.yml` -- existing, no changes needed
+- [ ] `benchmarks.yml` -- existing, no changes needed
+- [ ] `examples.yml` -- existing, no changes needed
+- [ ] `codeql-analysis.yml` -- runs on push/PR to main + weekly schedule
+- [ ] `dependency-review.yml` -- runs on PRs to main
+- [ ] `stale.yml` -- runs daily + manual dispatch
+- [ ] `labeler.yml` -- runs on PR/issue open/sync/reopen
+- [ ] `pr-validation.yml` -- runs on PRs to main (non-docs paths)
+- [ ] `docs.yml` -- runs on push to main when docs change
+- [ ] PR template renders correctly
+- [ ] Bug report template renders correctly
+- [ ] Feature request template renders correctly


### PR DESCRIPTION
## Summary

- Ports 6 workflow files, 3 templates, and 1 label config from [PatternKit](https://github.com/JerrettDavis/PatternKit) into WrapGod, adapted to WrapGod's project structure
- Adds `docs/ops/workflow-parity-matrix.md` documenting each file's PatternKit source and any intentional deviations
- Existing workflows (`ci.yml`, `benchmarks.yml`, `examples.yml`) are untouched

## New files

**Workflows:** `codeql-analysis.yml`, `dependency-review.yml`, `stale.yml`, `labeler.yml`, `pr-validation.yml`, `docs.yml`

**Templates:** `PULL_REQUEST_TEMPLATE.md`, `ISSUE_TEMPLATE/bug_report.yml`, `ISSUE_TEMPLATE/feature_request.yml`

**Config:** `.github/labeler.yml` (label rules for WrapGod components)

**Docs:** `docs/ops/workflow-parity-matrix.md` (parity matrix with deviation notes)

## Test plan

- [ ] Verify `codeql-analysis.yml` triggers on this PR
- [ ] Verify `dependency-review.yml` triggers on this PR
- [ ] Verify `labeler.yml` auto-labels this PR
- [ ] Verify `pr-validation.yml` triggers on this PR
- [ ] Confirm existing `ci.yml` still runs without conflict
- [ ] Confirm PR template renders when opening new PRs
- [ ] Confirm issue templates appear in new issue form

Closes #87

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>