### PR TITLE
fix(ci): guard docs workflow when docfx config is absent

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,26 +27,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Detect docfx config
+        id: docfx
+        shell: bash
+        run: |
+          if [ -f docs/docfx.json ]; then
+            echo "has_config=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_config=false" >> "$GITHUB_OUTPUT"
+            echo "docs/docfx.json not found; skipping docs publish."
+          fi
+
       - name: Setup .NET
+        if: steps.docfx.outputs.has_config == 'true'
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
 
-      - run: dotnet tool update -g docfx
+      - name: Install docfx
+        if: steps.docfx.outputs.has_config == 'true'
+        run: dotnet tool update -g docfx
 
       - name: Build docfx metadata
+        if: steps.docfx.outputs.has_config == 'true'
         run: docfx metadata docs/docfx.json
-        continue-on-error: true
 
       - name: Build docfx site
+        if: steps.docfx.outputs.has_config == 'true'
         run: docfx build docs/docfx.json
-        continue-on-error: true
 
       - name: Upload artifact
+        if: steps.docfx.outputs.has_config == 'true'
         uses: actions/upload-pages-artifact@v4
         with:
           path: 'docs/_site'
 
       - name: Deploy to GitHub Pages
+        if: steps.docfx.outputs.has_config == 'true'
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- detect whether docs/docfx.json exists before running DocFX
- skip DocFX build/upload/deploy steps when config is missing
- remove continue-on-error from DocFX commands so real build failures surface once config exists

## Root cause
The Publish docs workflow always ran DocFX against docs/docfx.json, but that file is not present in the repository. The DocFX steps failed (exit 255), errors were masked by continue-on-error, and the job later failed while uploading docs/_site because it was never generated.

## Validation
- Confirmed failing run log: https://github.com/JerrettDavis/WrapGod/actions/runs/23670386034/job/68962378190
- This change makes the workflow no-op (and succeed) until a DocFX config is added.