### PR TITLE
fix: unblock main CI by resolving test analyzer errors

### DIFF
--- a/WrapGod.Tests/GeneratorCoverageTests.cs
+++ b/WrapGod.Tests/GeneratorCoverageTests.cs
@@ -50,7 +50,7 @@ public sealed class GeneratorCoverageTests(ITestOutputHelper output) : TinyBddXu
         return driver.GetRunResult();
     }
 
-    private static IReadOnlyList<string> AllGeneratedHintNames(GeneratorDriverRunResult result)
+    private static List<string> AllGeneratedHintNames(GeneratorDriverRunResult result)
         => result.Results.SelectMany(r => r.GeneratedSources).Select(s => s.HintName).ToList();
 
     private static string GetSource(GeneratorDriverRunResult result, string hintName)
@@ -142,71 +142,6 @@ public sealed class GeneratorCoverageTests(ITestOutputHelper output) : TinyBddXu
                   "isStatic": true,
                   "hasGetter": false,
                   "hasSetter": false
-                }
-              ]
-            }
-          ]
-        }
-        """;
-
-    private static readonly string ManifestAdaptiveVersion = """
-        {
-          "schemaVersion": "1.0",
-          "assembly": { "name": "Acme.Lib", "version": "1.0.0" },
-          "types": [
-            {
-              "fullName": "Acme.Lib.Service",
-              "name": "Service",
-              "namespace": "Acme.Lib",
-              "kind": "class",
-              "members": [
-                {
-                  "name": "DoWork",
-                  "kind": "method",
-                  "returnType": "string",
-                  "parameters": [{ "name": "input", "type": "string" }],
-                  "genericParameters": [],
-                  "isStatic": false,
-                  "hasGetter": false,
-                  "hasSetter": false,
-                  "introducedIn": "2.0",
-                  "removedIn": null
-                },
-                {
-                  "name": "DoVoidWork",
-                  "kind": "method",
-                  "returnType": "void",
-                  "parameters": [],
-                  "genericParameters": [],
-                  "isStatic": false,
-                  "hasGetter": false,
-                  "hasSetter": false,
-                  "introducedIn": "2.0",
-                  "removedIn": "4.0"
-                },
-                {
-                  "name": "Enabled",
-                  "kind": "property",
-                  "returnType": "bool",
-                  "parameters": [],
-                  "genericParameters": [],
-                  "isStatic": false,
-                  "hasGetter": true,
-                  "hasSetter": true,
-                  "introducedIn": "3.0",
-                  "removedIn": null
-                },
-                {
-                  "name": "ReadOnlyFlag",
-                  "kind": "property",
-                  "returnType": "bool",
-                  "parameters": [],
-                  "genericParameters": [],
-                  "isStatic": false,
-                  "hasGetter": true,
-                  "hasSetter": false,
-                  "introducedIn": "3.0",
-                  "removedIn": "5.0"
                 }
               ]
             }
@@ -354,9 +289,9 @@ public sealed class GeneratorCoverageTests(ITestOutputHelper output) : TinyBddXu
             .And("a facade is emitted", result =>
                 AllGeneratedHintNames(result).Contains("MarkerFacade.g.cs"))
             .And("the interface body has no method signatures", result =>
-                !GetSource(result, "IWrappedMarker.g.cs").Contains("(", StringComparison.Ordinal)
-                || GetSource(result, "IWrappedMarker.g.cs").Split('\n')
-                    .Count(l => l.TrimStart().StartsWith("    ") && l.Contains("(")) == 0)
+                !GetSource(result, "IWrappedMarker.g.cs").Contains('(')
+                || !GetSource(result, "IWrappedMarker.g.cs").Split('\n')
+                    .Any(l => l.TrimStart().StartsWith("    ", StringComparison.Ordinal) && l.Contains('(')))
             .AssertPassed();
 
     // ── Scenario: Property-only type ─────────────────────────────────

--- a/WrapGod.Tests/TypeMapCoverageTests.cs
+++ b/WrapGod.Tests/TypeMapCoverageTests.cs
@@ -378,7 +378,7 @@ public sealed class TypeMapCoverageTests(ITestOutputHelper output) : TinyBddXuni
             .And("line1again has 4 spaces after outdent", output =>
                 output.Contains("    line1again"))
             .And("line0again has no indentation after double outdent", output =>
-                output.Contains("\nline0again") || output.StartsWith("line0again"))
+                output.Contains("\nline0again", StringComparison.Ordinal) || output.StartsWith("line0again", StringComparison.Ordinal))
             .AssertPassed();
 
     [Scenario("MapperSourceBuilder OpenBrace and CloseBrace manage indent")]
@@ -395,13 +395,13 @@ public sealed class TypeMapCoverageTests(ITestOutputHelper output) : TinyBddXuni
                     return sb.ToString();
                 })
             .Then("the opening brace is at base indentation", output =>
-                output.Contains("{"))
+                output.Contains('{'))
             .And("the member is indented inside the brace", output =>
                 output.Contains("    int x;"))
             .And("the closing brace is at base indentation", output =>
-                output.Contains("}"))
+                output.Contains('}'))
             .And("the indent level returns to zero", output =>
-                output.TrimEnd().EndsWith("}"))
+                output.TrimEnd().EndsWith('}'))
             .AssertPassed();
 
     [Scenario("MapperSourceBuilder BlankLine inserts empty line")]


### PR DESCRIPTION
## Summary
Fixes analyzer violations in recently added coverage tests that are treated as errors in CI.

### Changes
- Replace locale-sensitive StartsWith/EndsWith/Contains single-char usages in failing test assertions
- Replace Count(... ) == 0 with !Any(...)
- Remove unused ManifestAdaptiveVersion test fixture constant
- Return List<string> from helper to satisfy CA1859 performance analyzer

## Validation
- CI=true dotnet build WrapGod.slnx --configuration Release passes locally
