### PR TITLE
feat(extractor): add NuGet package source for extraction

### DIFF
--- a/WrapGod.Cli/ExtractCommand.cs
+++ b/WrapGod.Cli/ExtractCommand.cs
@@ -10,27 +10,64 @@ internal static class ExtractCommand
 
     public static Command Create()
     {
-        var assemblyPathArg = new Argument<FileInfo>(
+        var assemblyPathArg = new Argument<FileInfo?>(
             "assembly-path",
-            "Path to the .NET assembly to extract");
+            () => null,
+            "Path to the .NET assembly to extract (optional when using --nuget)");
 
         var outputOption = new Option<FileInfo>(
             ["--output", "-o"],
             () => new FileInfo("manifest.json"),
             "Output path for the generated manifest");
 
-        var command = new Command("extract", "Extract API manifest from a .NET assembly")
+        var nugetOption = new Option<string[]>(
+            "--nuget",
+            "NuGet package to extract in format <packageId>@<version>. Supports multiple flags for multi-version.")
         {
-            assemblyPathArg,
-            outputOption
+            AllowMultipleArgumentsPerToken = true,
+            Arity = ArgumentArity.ZeroOrMore
         };
 
-        command.SetHandler(HandleAsync, assemblyPathArg, outputOption);
+        var tfmOption = new Option<string?>(
+            "--tfm",
+            "Explicit target framework moniker override (e.g. net8.0, netstandard2.0)");
+
+        var sourceOption = new Option<string?>(
+            "--source",
+            "Private NuGet feed URL (defaults to nuget.org)");
+
+        var command = new Command("extract", "Extract API manifest from a .NET assembly or NuGet package")
+        {
+            assemblyPathArg,
+            outputOption,
+            nugetOption,
+            tfmOption,
+            sourceOption
+        };
+
+        command.SetHandler(HandleAsync, assemblyPathArg, outputOption, nugetOption, tfmOption, sourceOption);
         return command;
     }
 
-    private static async Task HandleAsync(FileInfo assemblyPath, FileInfo output)
+    private static async Task HandleAsync(
+        FileInfo? assemblyPath,
+        FileInfo output,
+        string[] nugetSpecs,
+        string? tfm,
+        string? source)
     {
+        if (nugetSpecs is { Length: > 0 })
+        {
+            await HandleNuGetAsync(nugetSpecs, output, tfm, source);
+            return;
+        }
+
+        if (assemblyPath is null)
+        {
+            Console.Error.WriteLine("Error: Either provide an assembly-path argument or use --nuget <packageId>@<version>.");
+            return;
+        }
+
         if (!assemblyPath.Exists)
         {
             Console.Error.WriteLine($"Assembly not found: {assemblyPath.FullName}");
@@ -47,5 +84,66 @@ internal static class ExtractCommand
         Console.WriteLine($"Manifest written to {output.FullName}");
         Console.WriteLine($"  Types: {manifest.Types.Count}");
         Console.WriteLine($"  Members: {manifest.Types.Sum(t => t.Members.Count)}");
+    }
+
+    private static async Task HandleNuGetAsync(
+        string[] nugetSpecs,
+        FileInfo output,
+        string? tfm,
+        string? source)
+    {
+        var parsed = new List<(string PackageId, string Version)>();
+
+        foreach (var spec in nugetSpecs)
+        {
+            var atIndex = spec.LastIndexOf('@');
+            if (atIndex <= 0 || atIndex >= spec.Length - 1)
+            {
+                Console.Error.WriteLine($"Invalid --nuget format: '{spec}'. Expected <packageId>@<version>.");
+                return;
+            }
+
+            parsed.Add((spec[..atIndex], spec[(atIndex + 1)..]));
+        }
+
+        var extractor = new NuGetExtractor();
+
+        if (parsed.Count == 1)
+        {
+            var (packageId, version) = parsed[0];
+            Console.WriteLine($"Resolving NuGet package {packageId}@{version}...");
+
+            var manifest = await extractor.ExtractFromPackageAsync(packageId, version, tfm, source);
+
+            var json = JsonSerializer.Serialize(manifest, SerializerOptions);
+            await File.WriteAllTextAsync(output.FullName, json);
+
+            Console.WriteLine($"Manifest written to {output.FullName}");
+            Console.WriteLine($"  Types: {manifest.Types.Count}");
+            Console.WriteLine($"  Members: {manifest.Types.Sum(t => t.Members.Count)}");
+        }
+        else
+        {
+            // Multi-version: group by package ID.
+            var groups = parsed.GroupBy(p => p.PackageId, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var group in groups)
+            {
+                var packageId = group.Key;
+                var versions = group.Select(g => g.Version).ToList();
+
+                Console.WriteLine($"Resolving NuGet package {packageId} versions: {string.Join(", ", versions)}...");
+
+                var result = await extractor.ExtractMultiVersionAsync(packageId, versions, tfm, source);
+
+                var json = JsonSerializer.Serialize(result.MergedManifest, SerializerOptions);
+                await File.WriteAllTextAsync(output.FullName, json);
+
+                Console.WriteLine($"Merged manifest written to {output.FullName}");
+                Console.WriteLine($"  Types: {result.MergedManifest.Types.Count}");
+                Console.WriteLine($"  Members: {result.MergedManifest.Types.Sum(t => t.Members.Count)}");
+                Console.WriteLine($"  Breaking changes: {result.Diff.BreakingChanges.Count}");
+            }
+        }
     }
 }

--- a/WrapGod.Extractor/NuGetExtractor.cs
+++ b/WrapGod.Extractor/NuGetExtractor.cs
@@ -1,0 +1,85 @@
+using WrapGod.Manifest;
+
+namespace WrapGod.Extractor;
+
+/// <summary>
+/// High-level extractor that resolves a NuGet package, downloads it if needed,
+/// and delegates to <see cref="AssemblyExtractor"/> to produce an <see cref="ApiManifest"/>.
+/// </summary>
+public sealed class NuGetExtractor
+{
+    private readonly NuGetPackageResolver _resolver;
+
+    /// <summary>
+    /// Creates a new NuGet extractor using the given resolver.
+    /// When <c>null</c>, a default resolver is created.
+    /// </summary>
+    public NuGetExtractor(NuGetPackageResolver? resolver = null)
+    {
+        _resolver = resolver ?? new NuGetPackageResolver();
+    }
+
+    /// <summary>
+    /// Resolves a NuGet package, downloads it, and extracts an <see cref="ApiManifest"/>
+    /// from its primary DLL.
+    /// </summary>
+    /// <param name="packageId">NuGet package identifier.</param>
+    /// <param name="version">Exact package version.</param>
+    /// <param name="targetFramework">Optional explicit TFM override.</param>
+    /// <param name="sourceFeed">Optional private feed URL.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="ApiManifest"/> extracted from the package assembly.</returns>
+    public async Task<ApiManifest> ExtractFromPackageAsync(
+        string packageId,
+        string version,
+        string? targetFramework = null,
+        string? sourceFeed = null,
+        CancellationToken cancellationToken = default)
+    {
+        var dllPath = await _resolver.ResolveAsync(
+            packageId, version, targetFramework, sourceFeed, cancellationToken);
+
+        return AssemblyExtractor.Extract(dllPath);
+    }
+
+    /// <summary>
+    /// Result of a multi-version NuGet extraction.
+    /// </summary>
+    /// <param name="MergedManifest">The merged manifest with version presence metadata.</param>
+    /// <param name="Diff">Compatibility diff report across versions.</param>
+    public sealed record MultiVersionResult(ApiManifest MergedManifest, VersionDiff Diff);
+
+    /// <summary>
+    /// Extracts multiple versions of the same NuGet package and produces a merged manifest
+    /// with version presence metadata and a compatibility diff.
+    /// </summary>
+    /// <param name="packageId">NuGet package identifier.</param>
+    /// <param name="versions">List of version strings to extract and compare.</param>
+    /// <param name="targetFramework">Optional explicit TFM override (applied to all versions).</param>
+    /// <param name="sourceFeed">Optional private feed URL.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Merged manifest and diff report.</returns>
+    public async Task<MultiVersionResult> ExtractMultiVersionAsync(
+        string packageId,
+        IReadOnlyList<string> versions,
+        string? targetFramework = null,
+        string? sourceFeed = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (versions.Count == 0)
+            throw new ArgumentException("At least one version is required.", nameof(versions));
+
+        var versionInputs = new List<MultiVersionExtractor.VersionInput>();
+
+        foreach (var version in versions)
+        {
+            var dllPath = await _resolver.ResolveAsync(
+                packageId, version, targetFramework, sourceFeed, cancellationToken);
+
+            versionInputs.Add(new MultiVersionExtractor.VersionInput(version, dllPath));
+        }
+
+        var result = MultiVersionExtractor.Extract(versionInputs);
+        return new MultiVersionResult(result.MergedManifest, result.Diff);
+    }
+}

--- a/WrapGod.Extractor/NuGetPackageResolver.cs
+++ b/WrapGod.Extractor/NuGetPackageResolver.cs
@@ -1,0 +1,215 @@
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace WrapGod.Extractor;
+
+/// <summary>
+/// Resolves a NuGet package by downloading the .nupkg and extracting the best-match DLL
+/// for a given target framework. Results are cached locally to avoid repeated downloads.
+/// </summary>
+public sealed class NuGetPackageResolver
+{
+    /// <summary>Default NuGet v3 feed URL (nuget.org).</summary>
+    public const string DefaultSourceFeed = "https://api.nuget.org/v3/index.json";
+
+    /// <summary>
+    /// Ordered list of preferred TFMs when auto-selecting the best match.
+    /// First match wins.
+    /// </summary>
+    private static readonly string[] PreferredTfms =
+    [
+        "net8.0",
+        "net7.0",
+        "net6.0",
+        "netstandard2.1",
+        "netstandard2.0",
+        "netstandard1.6",
+        "net472",
+        "net462",
+    ];
+
+    private readonly string _cacheRoot;
+
+    /// <summary>
+    /// Creates a new resolver with the given local cache root.
+    /// Defaults to <c>.wrapgod-cache/packages</c> under the current directory.
+    /// </summary>
+    public NuGetPackageResolver(string? cacheRoot = null)
+    {
+        _cacheRoot = cacheRoot ?? Path.Combine(Directory.GetCurrentDirectory(), ".wrapgod-cache", "packages");
+    }
+
+    /// <summary>
+    /// Resolves a NuGet package to a local DLL path. Downloads and extracts
+    /// the package when not already cached.
+    /// </summary>
+    /// <param name="packageId">NuGet package identifier (e.g. <c>Newtonsoft.Json</c>).</param>
+    /// <param name="version">Exact package version (e.g. <c>13.0.3</c>).</param>
+    /// <param name="targetFramework">
+    /// Explicit TFM to extract (e.g. <c>net8.0</c>). When <c>null</c>, the best
+    /// match is auto-selected using <see cref="PreferredTfms"/>.
+    /// </param>
+    /// <param name="sourceFeed">NuGet v3 feed URL. Defaults to nuget.org.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Absolute path to the extracted DLL inside the local cache.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the package cannot be found, contains no compatible DLLs,
+    /// or the specified TFM does not exist in the package.
+    /// </exception>
+    public async Task<string> ResolveAsync(
+        string packageId,
+        string version,
+        string? targetFramework = null,
+        string? sourceFeed = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        var packageDir = GetPackageDirectory(packageId, version);
+
+        // Check if we already have a cached extraction marker.
+        var markerPath = Path.Combine(packageDir, ".extracted");
+        if (!File.Exists(markerPath))
+        {
+            await DownloadAndExtractAsync(packageId, version, sourceFeed ?? DefaultSourceFeed, packageDir, cancellationToken);
+        }
+
+        return FindDll(packageId, packageDir, targetFramework);
+    }
+
+    /// <summary>
+    /// Returns the local cache directory for a given package id and version.
+    /// </summary>
+    public string GetPackageDirectory(string packageId, string version)
+        => Path.Combine(_cacheRoot, packageId.ToLowerInvariant(), version);
+
+    private static async Task DownloadAndExtractAsync(
+        string packageId,
+        string version,
+        string sourceFeed,
+        string packageDir,
+        CancellationToken cancellationToken)
+    {
+        var cache = new SourceCacheContext();
+        var repository = Repository.Factory.GetCoreV3(sourceFeed);
+        var resource = await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
+
+        var nugetVersion = new NuGetVersion(version);
+
+        // Verify the package exists.
+        var versions = await resource.GetAllVersionsAsync(packageId, cache, NullLogger.Instance, cancellationToken);
+        if (!versions.Contains(nugetVersion))
+        {
+            throw new InvalidOperationException(
+                $"Package '{packageId}' version '{version}' was not found on feed '{sourceFeed}'.");
+        }
+
+        Directory.CreateDirectory(packageDir);
+
+        var nupkgPath = Path.Combine(packageDir, $"{packageId}.{version}.nupkg");
+
+        // Download the .nupkg.
+        using (var fileStream = File.Create(nupkgPath))
+        {
+            var downloaded = await resource.CopyNupkgToStreamAsync(
+                packageId, nugetVersion, fileStream, cache, NullLogger.Instance, cancellationToken);
+
+            if (!downloaded)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to download package '{packageId}' version '{version}'.");
+            }
+        }
+
+        // Extract lib/ DLLs from the nupkg.
+        using var packageReader = new PackageArchiveReader(nupkgPath);
+        var libItems = (await packageReader.GetLibItemsAsync(cancellationToken)).ToList();
+
+        foreach (var group in libItems)
+        {
+            var tfm = group.TargetFramework.GetShortFolderName();
+            var tfmDir = Path.Combine(packageDir, "lib", tfm);
+            Directory.CreateDirectory(tfmDir);
+
+            foreach (var item in group.Items)
+            {
+                var fileName = Path.GetFileName(item);
+                if (!fileName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                using var entryStream = await packageReader.GetStreamAsync(item, cancellationToken);
+                var targetPath = Path.Combine(tfmDir, fileName);
+                using var output = File.Create(targetPath);
+                await entryStream.CopyToAsync(output, cancellationToken);
+            }
+        }
+
+        // Write extraction marker.
+        await File.WriteAllTextAsync(Path.Combine(packageDir, ".extracted"), DateTimeOffset.UtcNow.ToString("O"), cancellationToken);
+    }
+
+    private static string FindDll(string packageId, string packageDir, string? targetFramework)
+    {
+        var libDir = Path.Combine(packageDir, "lib");
+
+        if (!Directory.Exists(libDir))
+        {
+            throw new InvalidOperationException(
+                $"Package '{packageId}' does not contain a lib/ folder with any DLLs.");
+        }
+
+        var availableTfms = Directory.GetDirectories(libDir)
+            .Select(Path.GetFileName)
+            .Where(d => d is not null)
+            .Cast<string>()
+            .ToList();
+
+        if (availableTfms.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Package '{packageId}' lib/ folder contains no TFM subfolders.");
+        }
+
+        string chosenTfm;
+
+        if (targetFramework is not null)
+        {
+            // Exact match required.
+            chosenTfm = availableTfms.FirstOrDefault(
+                t => string.Equals(t, targetFramework, StringComparison.OrdinalIgnoreCase))
+                ?? throw new InvalidOperationException(
+                    $"Package '{packageId}' does not contain TFM '{targetFramework}'. " +
+                    $"Available: {string.Join(", ", availableTfms)}");
+        }
+        else
+        {
+            // Auto-select best match from preference order.
+            chosenTfm = PreferredTfms
+                .FirstOrDefault(pref => availableTfms.Any(
+                    t => string.Equals(t, pref, StringComparison.OrdinalIgnoreCase)))
+                ?? availableTfms[0]; // Fallback to first available.
+        }
+
+        var tfmPath = Path.Combine(libDir, chosenTfm);
+        var dlls = Directory.GetFiles(tfmPath, "*.dll");
+
+        if (dlls.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"No DLLs found in '{tfmPath}' for package '{packageId}'.");
+        }
+
+        // Prefer the DLL matching the package name, otherwise return the first.
+        var primaryDll = dlls.FirstOrDefault(
+            d => Path.GetFileNameWithoutExtension(d)
+                .Equals(packageId, StringComparison.OrdinalIgnoreCase))
+            ?? dlls[0];
+
+        return primaryDll;
+    }
+}

--- a/WrapGod.Extractor/WrapGod.Extractor.csproj
+++ b/WrapGod.Extractor/WrapGod.Extractor.csproj
@@ -2,6 +2,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.4" />
+    <PackageReference Include="NuGet.Protocol" Version="6.13.2" />
+    <PackageReference Include="NuGet.Packaging" Version="6.13.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WrapGod.Tests/NuGetExtractorTests.cs
+++ b/WrapGod.Tests/NuGetExtractorTests.cs
@@ -1,0 +1,122 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Extractor;
+using WrapGod.Manifest;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("NuGet package extraction")]
+public sealed class NuGetExtractorTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private static readonly string TestCacheRoot =
+        Path.Combine(Path.GetTempPath(), "wrapgod-test-cache", Guid.NewGuid().ToString("N"));
+
+    private static readonly byte[] MzHeaderStub = [0x4D, 0x5A];
+    private static readonly string[] MockTfms = ["netstandard2.0", "netstandard2.1", "net8.0"];
+
+    private static NuGetPackageResolver CreateResolver() => new(TestCacheRoot);
+
+    private static Task<string> ResolveNewtonsoftJson()
+    {
+        var resolver = CreateResolver();
+        return resolver.ResolveAsync("Newtonsoft.Json", "13.0.3");
+    }
+
+    private static Task<ApiManifest> ExtractNewtonsoftJson()
+    {
+        var resolver = CreateResolver();
+        var extractor = new NuGetExtractor(resolver);
+        return extractor.ExtractFromPackageAsync("Newtonsoft.Json", "13.0.3");
+    }
+
+    // ── Integration Scenarios (require network) ─────────────────────
+
+    [Scenario("Resolve a known public NuGet package")]
+    [Fact]
+    [Trait("Category", "Integration")]
+    public Task Resolve_KnownPackage_ReturnsDllPath()
+        => Given("a NuGet package resolver for Newtonsoft.Json 13.0.3", ResolveNewtonsoftJson)
+            .Then("the resolved path exists", path => File.Exists(path))
+            .And("the resolved path is a DLL", path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .And("the DLL filename contains the package name", path =>
+                Path.GetFileNameWithoutExtension(path)
+                    .Equals("Newtonsoft.Json", StringComparison.OrdinalIgnoreCase))
+            .AssertPassed();
+
+    [Scenario("Extract a manifest from a NuGet package")]
+    [Fact]
+    [Trait("Category", "Integration")]
+    public Task Extract_KnownPackage_ProducesManifest()
+        => Given("an extracted manifest from Newtonsoft.Json 13.0.3", ExtractNewtonsoftJson)
+            .Then("the manifest is not null", manifest => manifest is not null)
+            .And("the manifest contains types", manifest => manifest.Types.Count > 0)
+            .And("the assembly name is Newtonsoft.Json", manifest =>
+                manifest.Assembly.Name == "Newtonsoft.Json")
+            .AssertPassed();
+
+    [Scenario("Cache hit avoids re-download")]
+    [Fact]
+    [Trait("Category", "Integration")]
+    public Task CacheHit_AvoidsRedownload()
+        => Given("two resolutions of the same package from the same cache", (Func<Task<(string Path1, string Path2)>>)(async () =>
+            {
+                var resolver = CreateResolver();
+                var path1 = await resolver.ResolveAsync("Newtonsoft.Json", "13.0.3");
+                var path2 = await resolver.ResolveAsync("Newtonsoft.Json", "13.0.3");
+                return (Path1: path1, Path2: path2);
+            }))
+            .Then("both paths are identical", result => result.Path1 == result.Path2)
+            .And("the file still exists", result => File.Exists(result.Path1))
+            .AssertPassed();
+
+    // ── Unit Scenarios (no network) ─────────────────────────────────
+
+    [Scenario("TFM selection picks best match from available folders")]
+    [Fact]
+    public Task TfmSelection_PicksBestMatch()
+        => Given("a mock package directory with multiple TFMs", () =>
+            {
+                var resolver = CreateResolver();
+                var pkgDir = resolver.GetPackageDirectory("MockPkg", "1.0.0");
+
+                // Create mock lib structure with multiple TFMs.
+                foreach (var tfm in MockTfms)
+                {
+                    var tfmDir = Path.Combine(pkgDir, "lib", tfm);
+                    Directory.CreateDirectory(tfmDir);
+                    File.WriteAllBytes(Path.Combine(tfmDir, "MockPkg.dll"), MzHeaderStub);
+                }
+
+                // Write extraction marker.
+                File.WriteAllText(Path.Combine(pkgDir, ".extracted"), "done");
+                return resolver;
+            })
+            .Then("ResolveAsync selects net8.0", (Func<NuGetPackageResolver, Task<bool>>)(async resolver =>
+            {
+                var path = await resolver.ResolveAsync("MockPkg", "1.0.0");
+                return path.Contains("net8.0", StringComparison.OrdinalIgnoreCase);
+            }))
+            .AssertPassed();
+
+    [Scenario("Invalid package throws InvalidOperationException")]
+    [Fact]
+    [Trait("Category", "Integration")]
+    public Task InvalidPackage_Throws()
+        => Given("a resolver for a non-existent package", () => CreateResolver())
+            .Then("resolving throws InvalidOperationException", (Func<NuGetPackageResolver, Task<bool>>)(async resolver =>
+            {
+                try
+                {
+                    await resolver.ResolveAsync("NonExistent_Package_ZZZ_12345", "99.99.99");
+                    return false;
+                }
+                catch (InvalidOperationException)
+                {
+                    return true;
+                }
+            }))
+            .AssertPassed();
+}


### PR DESCRIPTION
## Summary
- Add `NuGetPackageResolver` that downloads `.nupkg` from NuGet feeds, extracts DLLs with auto TFM selection (net8.0 > netstandard2.1 > netstandard2.0), and caches in `.wrapgod-cache/packages/`
- Add `NuGetExtractor` for single-package and multi-version extraction that delegates to `AssemblyExtractor`
- Update CLI `extract` command with `--nuget <packageId>@<version>`, `--tfm`, and `--source` options
- Add TinyBDD tests for TFM selection, cache hits, package resolution, and invalid package handling (integration tests marked with `[Trait("Category", "Integration")]`)

Closes #108

## Test plan
- [x] Unit test: TFM selection picks net8.0 over netstandard variants
- [x] Integration test: resolve Newtonsoft.Json 13.0.3 from nuget.org
- [x] Integration test: cache hit returns same path without re-download
- [x] Integration test: invalid package throws InvalidOperationException
- [x] All 188 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)