### PR TITLE
feat: convention-first source discovery and deterministic precedence chain (fixes #123)

### DIFF
--- a/WrapGod.Abstractions/Config/WrapGodConfigModels.cs
+++ b/WrapGod.Abstractions/Config/WrapGodConfigModels.cs
@@ -39,8 +39,12 @@ public sealed class MemberConfig
 
 public enum ConfigSource
 {
+    Defaults,
+    RootJson,
+    ProjectJson,
     Json,
     Attributes,
+    Fluent,
 }
 
 public sealed class ConfigMergeResult
@@ -59,4 +63,40 @@ public sealed class ConfigDiagnostic
 public sealed class ConfigMergeOptions
 {
     public ConfigSource HigherPrecedence { get; set; } = ConfigSource.Attributes;
+}
+
+public sealed class ConfigPrecedenceOptions
+{
+    public IReadOnlyList<ConfigSource> SourceOrder { get; set; } =
+    [
+        ConfigSource.Defaults,
+        ConfigSource.RootJson,
+        ConfigSource.ProjectJson,
+        ConfigSource.Attributes,
+        ConfigSource.Fluent,
+    ];
+}
+
+public sealed class ConfigSourceLayers
+{
+    public WrapGodConfig? Defaults { get; set; }
+    public WrapGodConfig? RootJson { get; set; }
+    public WrapGodConfig? ProjectJson { get; set; }
+    public WrapGodConfig? Attributes { get; set; }
+    public WrapGodConfig? Fluent { get; set; }
+}
+
+public sealed class SourceDiscoveryInput
+{
+    public string? WrapGodPackage { get; set; }
+    public IReadOnlyList<string> PackageReferences { get; set; } = Array.Empty<string>();
+    public bool HasSelfSource { get; set; }
+    public string? ExplicitSource { get; set; }
+}
+
+public sealed class SourceDiscoveryResult
+{
+    public string? Source { get; set; }
+    public string Strategy { get; set; } = string.Empty;
+    public List<ConfigDiagnostic> Diagnostics { get; set; } = new();
 }

--- a/WrapGod.Manifest/Config/ConfigPrecedenceEngine.cs
+++ b/WrapGod.Manifest/Config/ConfigPrecedenceEngine.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using WrapGod.Abstractions.Config;
+
+namespace WrapGod.Manifest.Config;
+
+/// <summary>
+/// Resolves a deterministic multi-layer configuration precedence chain.
+/// Default precedence: defaults -> root json -> project json -> attributes -> fluent.
+/// </summary>
+public static class ConfigPrecedenceEngine
+{
+    public static ConfigMergeResult Merge(
+        ConfigSourceLayers layers,
+        ConfigPrecedenceOptions? options = null)
+    {
+        options ??= new ConfigPrecedenceOptions();
+
+        var merged = new WrapGodConfig();
+        var diagnostics = new List<ConfigDiagnostic>();
+        var sawAnySource = false;
+
+        foreach (var source in options.SourceOrder)
+        {
+            var next = GetLayer(layers, source);
+            if (next is null || next.Types.Count == 0)
+                continue;
+
+            sawAnySource = true;
+
+            var step = ConfigMergeEngine.Merge(
+                merged,
+                next,
+                new ConfigMergeOptions { HigherPrecedence = ConfigSource.Attributes });
+
+            merged = step.Config;
+            diagnostics.AddRange(step.Diagnostics);
+        }
+
+        if (!sawAnySource)
+        {
+            diagnostics.Add(new ConfigDiagnostic
+            {
+                Code = "WG6010",
+                Message = "No configuration source was discovered. Add a root/project *.wrapgod.config.json file, annotate wrappers with [WrapType], or provide fluent configuration.",
+                Target = "config.sources"
+            });
+        }
+
+        return new ConfigMergeResult
+        {
+            Config = merged,
+            Diagnostics = diagnostics
+        };
+    }
+
+    private static WrapGodConfig? GetLayer(ConfigSourceLayers layers, ConfigSource source)
+    {
+        return source switch
+        {
+            ConfigSource.Defaults => layers.Defaults,
+            ConfigSource.RootJson => layers.RootJson,
+            ConfigSource.ProjectJson or ConfigSource.Json => layers.ProjectJson,
+            ConfigSource.Attributes => layers.Attributes,
+            ConfigSource.Fluent => layers.Fluent,
+            _ => null,
+        };
+    }
+}

--- a/WrapGod.Manifest/Config/SourceDiscoveryEngine.cs
+++ b/WrapGod.Manifest/Config/SourceDiscoveryEngine.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using WrapGod.Abstractions.Config;
+
+namespace WrapGod.Manifest.Config;
+
+/// <summary>
+/// Convention-first source discovery for zero-config flows.
+/// Discovery order: WrapGodPackage -> package refs -> @self -> explicit.
+/// </summary>
+public static class SourceDiscoveryEngine
+{
+    public static SourceDiscoveryResult Discover(SourceDiscoveryInput input)
+    {
+        if (!string.IsNullOrWhiteSpace(input.WrapGodPackage))
+        {
+            return new SourceDiscoveryResult
+            {
+                Source = input.WrapGodPackage,
+                Strategy = "WrapGodPackage"
+            };
+        }
+
+        var packageRef = input.PackageReferences
+            .FirstOrDefault(static p => !string.IsNullOrWhiteSpace(p));
+
+        if (!string.IsNullOrWhiteSpace(packageRef))
+        {
+            return new SourceDiscoveryResult
+            {
+                Source = packageRef,
+                Strategy = "PackageReference"
+            };
+        }
+
+        if (input.HasSelfSource)
+        {
+            return new SourceDiscoveryResult
+            {
+                Source = "@self",
+                Strategy = "@self"
+            };
+        }
+
+        if (!string.IsNullOrWhiteSpace(input.ExplicitSource))
+        {
+            return new SourceDiscoveryResult
+            {
+                Source = input.ExplicitSource,
+                Strategy = "Explicit"
+            };
+        }
+
+        return new SourceDiscoveryResult
+        {
+            Strategy = "None",
+            Diagnostics = new List<ConfigDiagnostic>
+            {
+                new()
+                {
+                    Code = "WG6011",
+                    Target = "source.discovery",
+                    Message = "No source was discovered. Set WrapGodPackage, add a package reference, annotate a wrapper with [WrapType(\"@self\")], or provide an explicit source."
+                }
+            }
+        };
+    }
+}

--- a/WrapGod.Tests/ConventionDiscoveryAndPrecedenceTests.cs
+++ b/WrapGod.Tests/ConventionDiscoveryAndPrecedenceTests.cs
@@ -1,0 +1,108 @@
+using WrapGod.Abstractions.Config;
+using WrapGod.Manifest.Config;
+using Xunit;
+
+namespace WrapGod.Tests;
+
+public sealed class ConventionDiscoveryAndPrecedenceTests
+{
+    [Fact]
+    public void SourceDiscovery_UsesConfiguredOrder()
+    {
+        var result = SourceDiscoveryEngine.Discover(new SourceDiscoveryInput
+        {
+            WrapGodPackage = "Vendor.Primary",
+            PackageReferences = ["Vendor.Secondary"],
+            HasSelfSource = true,
+            ExplicitSource = "Vendor.Explicit"
+        });
+
+        Assert.Equal("Vendor.Primary", result.Source);
+        Assert.Equal("WrapGodPackage", result.Strategy);
+    }
+
+    [Fact]
+    public void SourceDiscovery_PackageReferences_UseDeclarationOrder()
+    {
+        var result = SourceDiscoveryEngine.Discover(new SourceDiscoveryInput
+        {
+            PackageReferences = ["Vendor.Secondary", "Vendor.Primary"],
+            HasSelfSource = true,
+            ExplicitSource = "Vendor.Explicit"
+        });
+
+        Assert.Equal("Vendor.Secondary", result.Source);
+        Assert.Equal("PackageReference", result.Strategy);
+    }
+
+    [Fact]
+    public void SourceDiscovery_NoSource_EmitsActionableDiagnostic()
+    {
+        var result = SourceDiscoveryEngine.Discover(new SourceDiscoveryInput());
+
+        Assert.Null(result.Source);
+        var diag = Assert.Single(result.Diagnostics);
+        Assert.Equal("WG6011", diag.Code);
+        Assert.Contains("WrapGodPackage", diag.Message);
+        Assert.Contains("@self", diag.Message);
+        Assert.Contains("explicit", diag.Message);
+    }
+
+    [Fact]
+    public void PrecedenceEngine_AppliesDefaultChain_Deterministically()
+    {
+        var layers = new ConfigSourceLayers
+        {
+            Defaults = MakeConfig(include: true, targetName: "DefaultName"),
+            RootJson = MakeConfig(include: true, targetName: "RootName"),
+            ProjectJson = MakeConfig(include: true, targetName: "ProjectName"),
+            Attributes = MakeConfig(include: false, targetName: "AttributeName"),
+            Fluent = MakeConfig(include: true, targetName: "FluentName")
+        };
+
+        var merged = ConfigPrecedenceEngine.Merge(layers);
+        var type = Assert.Single(merged.Config.Types);
+
+        Assert.Equal("Vendor.Client", type.SourceType);
+        Assert.True(type.Include);
+        Assert.Equal("FluentName", type.TargetName);
+    }
+
+    [Fact]
+    public void PrecedenceEngine_NoLayers_EmitsActionableDiagnostic()
+    {
+        var merged = ConfigPrecedenceEngine.Merge(new ConfigSourceLayers());
+
+        Assert.Empty(merged.Config.Types);
+        var diag = Assert.Single(merged.Diagnostics);
+        Assert.Equal("WG6010", diag.Code);
+        Assert.Contains("root/project", diag.Message);
+        Assert.Contains("[WrapType]", diag.Message);
+        Assert.Contains("fluent", diag.Message);
+    }
+
+    private static WrapGodConfig MakeConfig(bool? include, string? targetName)
+    {
+        return new WrapGodConfig
+        {
+            Types =
+            [
+                new TypeConfig
+                {
+                    SourceType = "Vendor.Client",
+                    Include = include,
+                    TargetName = targetName,
+                    Members =
+                    [
+                        new MemberConfig
+                        {
+                            SourceMember = "DoWork",
+                            Include = include,
+                            TargetName = targetName is null ? null : targetName + "Member"
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -86,6 +86,16 @@ public interface IHttpClientWrapper { }
 | `Include` | `bool` | Include this type in generation (default `true`). |
 | `TargetName` | `string?` | Rename the generated wrapper. |
 
+Source resolution for `[WrapType]` follows a deterministic discovery order:
+
+1. Convention match in `WrapGodPackage`
+2. Convention match in referenced packages/assemblies (first declared package reference wins)
+3. `@self` (the attributed type itself)
+4. Explicit metadata name from `sourceType`
+
+If no source can be found, WrapGod emits an actionable diagnostic with
+remediation hints.
+
 Can be applied to classes, interfaces, and structs.
 
 ### `[WrapMember]`
@@ -181,28 +191,41 @@ The `GenerationPlan` contains:
 
 ## Merge precedence
 
-When both JSON and attribute configuration exist for the same type or
-member, the `ConfigMergeEngine` merges them using a configurable
-precedence rule.
+WrapGod supports a deterministic precedence chain:
+
+1. Defaults
+2. Root JSON
+3. Project JSON
+4. Attributes
+5. Fluent
+
+Later layers always win.
 
 ```csharp
-using WrapGod.Abstractions.Config;
 using WrapGod.Manifest.Config;
 
-var result = ConfigMergeEngine.Merge(jsonConfig, attributeConfig, new ConfigMergeOptions
+var result = ConfigPrecedenceEngine.Merge(new ConfigSourceLayers
 {
-    HigherPrecedence = ConfigSource.Attributes  // default
+    Defaults = defaults,
+    RootJson = rootJson,
+    ProjectJson = projectJson,
+    Attributes = attributes,
+    Fluent = fluent
 });
 
 WrapGodConfig merged = result.Config;
 List<ConfigDiagnostic> conflicts = result.Diagnostics;
 ```
 
+For backward compatibility, `ConfigMergeEngine.Merge(json, attributes)`
+remains available for two-source merges.
+
 ### Precedence rules
 
-- **`ConfigSource.Attributes`** (default): attribute-defined values win
-  over JSON values when both are present.
-- **`ConfigSource.Json`**: JSON-defined values win.
+- Multi-source merges are deterministic and ordered.
+- Two-source merges still support:
+  - **`ConfigSource.Attributes`** (default): attribute values win.
+  - **`ConfigSource.Json`**: JSON values win.
 
 When a conflict is detected (both sources define a different value for the
 same setting), a `ConfigDiagnostic` is emitted:


### PR DESCRIPTION
## Summary
- add `SourceDiscoveryEngine` with deterministic order: WrapGodPackage -> package refs -> @self -> explicit
- add `ConfigPrecedenceEngine` with deterministic merge chain: defaults -> root json -> project json -> attributes -> fluent
- extend shared config abstractions with precedence/discovery models
- add focused tests for discovery ordering, actionable no-source diagnostics, precedence behavior, and empty-source diagnostics
- document discovery and precedence behavior in `docs/CONFIGURATION.md`

## Validation
- `dotnet test WrapGod.slnx --filter "FullyQualifiedName~ConventionDiscoveryAndPrecedenceTests"`
- `dotnet test WrapGod.slnx --filter "FullyQualifiedName~ConfigIngestionTests|FullyQualifiedName~ConfigRoundtripTests"`

Fixes #123
