### PR TITLE
feat: issue #124 wrapgod.lock.json reproducibility lockfile

### DIFF
--- a/WrapGod.Cli/ExtractCommand.cs
+++ b/WrapGod.Cli/ExtractCommand.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.Text.Json;
 using WrapGod.Extractor;
+using WrapGod.Manifest;
 
 namespace WrapGod.Cli;
 
@@ -10,61 +11,44 @@ internal static class ExtractCommand
 
     public static Command Create()
     {
-        var assemblyPathArg = new Argument<FileInfo?>(
-            "assembly-path",
-            () => null,
-            "Path to the .NET assembly to extract (optional when using --nuget)");
-
-        var outputOption = new Option<FileInfo>(
-            ["--output", "-o"],
-            () => new FileInfo("manifest.json"),
-            "Output path for the generated manifest");
-
-        var nugetOption = new Option<string[]>(
-            "--nuget",
-            "NuGet package to extract in format <packageId>@<version>. Supports multiple flags for multi-version.")
+        var assemblyPathArg = new Argument<FileInfo?>("assembly-path", () => null, "Path to the .NET assembly to extract (optional when using --nuget or --locked)");
+        var outputOption = new Option<FileInfo>(["--output", "-o"], () => new FileInfo("manifest.json"), "Output path for the generated manifest");
+        var nugetOption = new Option<string[]>("--nuget", "NuGet package to extract in format <packageId>@<version>. Supports multiple flags for multi-version.")
         {
             AllowMultipleArgumentsPerToken = true,
             Arity = ArgumentArity.ZeroOrMore
         };
-
-        var tfmOption = new Option<string?>(
-            "--tfm",
-            "Explicit target framework moniker override (e.g. net8.0, netstandard2.0)");
-
-        var sourceOption = new Option<string?>(
-            "--source",
-            "Private NuGet feed URL (defaults to nuget.org)");
+        var tfmOption = new Option<string?>("--tfm", "Explicit target framework moniker override (e.g. net8.0, netstandard2.0)");
+        var sourceOption = new Option<string?>("--source", "Private NuGet feed URL (defaults to nuget.org)");
+        var lockFileOption = new Option<FileInfo>("--lockfile", () => new FileInfo("wrapgod.lock.json"), "Path to WrapGod lockfile for write/read deterministic resolution data");
+        var lockedOption = new Option<bool>("--locked", "Require lockfile-only resolution. Fails when lockfile is missing or drift is detected.");
 
         var command = new Command("extract", "Extract API manifest from a .NET assembly or NuGet package")
         {
-            assemblyPathArg,
-            outputOption,
-            nugetOption,
-            tfmOption,
-            sourceOption
+            assemblyPathArg, outputOption, nugetOption, tfmOption, sourceOption, lockFileOption, lockedOption
         };
 
-        command.SetHandler(HandleAsync, assemblyPathArg, outputOption, nugetOption, tfmOption, sourceOption);
+        command.SetHandler(HandleAsync, assemblyPathArg, outputOption, nugetOption, tfmOption, sourceOption, lockFileOption, lockedOption);
         return command;
     }
 
-    private static async Task HandleAsync(
-        FileInfo? assemblyPath,
-        FileInfo output,
-        string[] nugetSpecs,
-        string? tfm,
-        string? source)
+    private static async Task HandleAsync(FileInfo? assemblyPath, FileInfo output, string[] nugetSpecs, string? tfm, string? source, FileInfo lockFile, bool locked)
     {
+        if (locked)
+        {
+            await HandleLockedAsync(lockFile, output);
+            return;
+        }
+
         if (nugetSpecs is { Length: > 0 })
         {
-            await HandleNuGetAsync(nugetSpecs, output, tfm, source);
+            await HandleNuGetAsync(nugetSpecs, output, tfm, source, lockFile);
             return;
         }
 
         if (assemblyPath is null)
         {
-            Console.Error.WriteLine("Error: Either provide an assembly-path argument or use --nuget <packageId>@<version>.");
+            Console.Error.WriteLine("Error: Either provide assembly-path, use --nuget, or run --locked with --lockfile.");
             return;
         }
 
@@ -74,26 +58,14 @@ internal static class ExtractCommand
             return;
         }
 
-        Console.WriteLine($"Extracting manifest from {assemblyPath.Name}...");
-
         var manifest = AssemblyExtractor.Extract(assemblyPath.FullName);
-
-        var json = JsonSerializer.Serialize(manifest, SerializerOptions);
-
-        await File.WriteAllTextAsync(output.FullName, json);
+        await File.WriteAllTextAsync(output.FullName, JsonSerializer.Serialize(manifest, SerializerOptions));
         Console.WriteLine($"Manifest written to {output.FullName}");
-        Console.WriteLine($"  Types: {manifest.Types.Count}");
-        Console.WriteLine($"  Members: {manifest.Types.Sum(t => t.Members.Count)}");
     }
 
-    private static async Task HandleNuGetAsync(
-        string[] nugetSpecs,
-        FileInfo output,
-        string? tfm,
-        string? source)
+    private static async Task HandleNuGetAsync(string[] nugetSpecs, FileInfo output, string? tfm, string? source, FileInfo lockFile)
     {
         var parsed = new List<(string PackageId, string Version)>();
-
         foreach (var spec in nugetSpecs)
         {
             var atIndex = spec.LastIndexOf('@');
@@ -107,43 +79,78 @@ internal static class ExtractCommand
         }
 
         var extractor = new NuGetExtractor();
-
         if (parsed.Count == 1)
         {
             var (packageId, version) = parsed[0];
-            Console.WriteLine($"Resolving NuGet package {packageId}@{version}...");
+            var result = await extractor.ExtractFromPackageWithLockAsync(packageId, version, tfm, source);
 
-            var manifest = await extractor.ExtractFromPackageAsync(packageId, version, tfm, source);
-
-            var json = JsonSerializer.Serialize(manifest, SerializerOptions);
-            await File.WriteAllTextAsync(output.FullName, json);
+            await File.WriteAllTextAsync(output.FullName, JsonSerializer.Serialize(result.Manifest, SerializerOptions));
+            await File.WriteAllTextAsync(lockFile.FullName, LockFileSerializer.Serialize(new WrapGodLockFile
+            {
+                Toolchain = new LockToolchain
+                {
+                    Version = typeof(ExtractCommand).Assembly.GetName().Version?.ToString(),
+                    Runtime = Environment.Version.ToString()
+                },
+                Sources =
+                [
+                    new LockSourceEntry
+                    {
+                        PackageId = result.Resolution.PackageId,
+                        Version = result.Resolution.Version,
+                        SourceFeed = result.Resolution.SourceFeed,
+                        PackageSha256 = result.Resolution.PackageSha256,
+                        TargetFramework = result.Resolution.TargetFramework,
+                        DllRelativePath = result.Resolution.DllRelativePath,
+                        DllSha256 = result.Resolution.DllSha256
+                    }
+                ]
+            }));
 
             Console.WriteLine($"Manifest written to {output.FullName}");
-            Console.WriteLine($"  Types: {manifest.Types.Count}");
-            Console.WriteLine($"  Members: {manifest.Types.Sum(t => t.Members.Count)}");
+            Console.WriteLine($"Lockfile written to {lockFile.FullName}");
+            return;
         }
-        else
+
+        var groups = parsed.GroupBy(p => p.PackageId, StringComparer.OrdinalIgnoreCase);
+        foreach (var group in groups)
         {
-            // Multi-version: group by package ID.
-            var groups = parsed.GroupBy(p => p.PackageId, StringComparer.OrdinalIgnoreCase);
+            var result = await extractor.ExtractMultiVersionAsync(group.Key, group.Select(g => g.Version).ToList(), tfm, source);
+            await File.WriteAllTextAsync(output.FullName, JsonSerializer.Serialize(result.MergedManifest, SerializerOptions));
+        }
+    }
 
-            foreach (var group in groups)
-            {
-                var packageId = group.Key;
-                var versions = group.Select(g => g.Version).ToList();
+    private static async Task HandleLockedAsync(FileInfo lockFilePath, FileInfo output)
+    {
+        if (!lockFilePath.Exists)
+        {
+            Console.Error.WriteLine($"Lockfile not found: {lockFilePath.FullName}");
+            return;
+        }
 
-                Console.WriteLine($"Resolving NuGet package {packageId} versions: {string.Join(", ", versions)}...");
+        var lockFile = LockFileSerializer.Deserialize(await File.ReadAllTextAsync(lockFilePath.FullName));
+        if (lockFile is null || lockFile.Sources.Count == 0)
+        {
+            Console.Error.WriteLine("Invalid lockfile: no sources found.");
+            return;
+        }
 
-                var result = await extractor.ExtractMultiVersionAsync(packageId, versions, tfm, source);
+        if (lockFile.Sources.Count > 1)
+        {
+            Console.Error.WriteLine("Locked extraction currently supports one source entry per run.");
+            return;
+        }
 
-                var json = JsonSerializer.Serialize(result.MergedManifest, SerializerOptions);
-                await File.WriteAllTextAsync(output.FullName, json);
-
-                Console.WriteLine($"Merged manifest written to {output.FullName}");
-                Console.WriteLine($"  Types: {result.MergedManifest.Types.Count}");
-                Console.WriteLine($"  Members: {result.MergedManifest.Types.Sum(t => t.Members.Count)}");
-                Console.WriteLine($"  Breaking changes: {result.Diff.BreakingChanges.Count}");
-            }
+        try
+        {
+            var manifest = await new NuGetExtractor().ExtractFromLockAsync(lockFile.Sources[0]);
+            await File.WriteAllTextAsync(output.FullName, JsonSerializer.Serialize(manifest, SerializerOptions));
+            Console.WriteLine($"Manifest written to {output.FullName}");
+            Console.WriteLine("Lockfile verification passed (no drift detected).");
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
         }
     }
 }

--- a/WrapGod.Extractor/NuGetExtractor.cs
+++ b/WrapGod.Extractor/NuGetExtractor.cs
@@ -2,80 +2,56 @@ using WrapGod.Manifest;
 
 namespace WrapGod.Extractor;
 
-/// <summary>
-/// High-level extractor that resolves a NuGet package, downloads it if needed,
-/// and delegates to <see cref="AssemblyExtractor"/> to produce an <see cref="ApiManifest"/>.
-/// </summary>
 public sealed class NuGetExtractor
 {
     private readonly NuGetPackageResolver _resolver;
 
-    /// <summary>
-    /// Creates a new NuGet extractor using the given resolver.
-    /// When <c>null</c>, a default resolver is created.
-    /// </summary>
     public NuGetExtractor(NuGetPackageResolver? resolver = null)
     {
         _resolver = resolver ?? new NuGetPackageResolver();
     }
 
-    /// <summary>
-    /// Resolves a NuGet package, downloads it, and extracts an <see cref="ApiManifest"/>
-    /// from its primary DLL.
-    /// </summary>
-    /// <param name="packageId">NuGet package identifier.</param>
-    /// <param name="version">Exact package version.</param>
-    /// <param name="targetFramework">Optional explicit TFM override.</param>
-    /// <param name="sourceFeed">Optional private feed URL.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>An <see cref="ApiManifest"/> extracted from the package assembly.</returns>
-    public async Task<ApiManifest> ExtractFromPackageAsync(
-        string packageId,
-        string version,
-        string? targetFramework = null,
-        string? sourceFeed = null,
-        CancellationToken cancellationToken = default)
+    public sealed record LockedExtractionResult(ApiManifest Manifest, NuGetPackageResolver.ResolutionResult Resolution);
+
+    public async Task<ApiManifest> ExtractFromPackageAsync(string packageId, string version, string? targetFramework = null, string? sourceFeed = null, CancellationToken cancellationToken = default)
     {
-        var dllPath = await _resolver.ResolveAsync(
-            packageId, version, targetFramework, sourceFeed, cancellationToken);
+        var dllPath = await _resolver.ResolveAsync(packageId, version, targetFramework, sourceFeed, cancellationToken);
+        return AssemblyExtractor.Extract(dllPath);
+    }
+
+    public async Task<LockedExtractionResult> ExtractFromPackageWithLockAsync(string packageId, string version, string? targetFramework = null, string? sourceFeed = null, CancellationToken cancellationToken = default)
+    {
+        var resolution = await _resolver.ResolveWithMetadataAsync(packageId, version, targetFramework, sourceFeed, cancellationToken);
+        var manifest = AssemblyExtractor.Extract(resolution.DllPath);
+        return new LockedExtractionResult(manifest, resolution);
+    }
+
+    public async Task<ApiManifest> ExtractFromLockAsync(LockSourceEntry lockEntry, CancellationToken cancellationToken = default)
+    {
+        var dllPath = await _resolver.ResolveFromLockAsync(
+            lockEntry.PackageId,
+            lockEntry.Version,
+            lockEntry.SourceFeed,
+            lockEntry.PackageSha256,
+            lockEntry.TargetFramework,
+            lockEntry.DllRelativePath,
+            lockEntry.DllSha256,
+            cancellationToken);
 
         return AssemblyExtractor.Extract(dllPath);
     }
 
-    /// <summary>
-    /// Result of a multi-version NuGet extraction.
-    /// </summary>
-    /// <param name="MergedManifest">The merged manifest with version presence metadata.</param>
-    /// <param name="Diff">Compatibility diff report across versions.</param>
     public sealed record MultiVersionResult(ApiManifest MergedManifest, VersionDiff Diff);
 
-    /// <summary>
-    /// Extracts multiple versions of the same NuGet package and produces a merged manifest
-    /// with version presence metadata and a compatibility diff.
-    /// </summary>
-    /// <param name="packageId">NuGet package identifier.</param>
-    /// <param name="versions">List of version strings to extract and compare.</param>
-    /// <param name="targetFramework">Optional explicit TFM override (applied to all versions).</param>
-    /// <param name="sourceFeed">Optional private feed URL.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Merged manifest and diff report.</returns>
-    public async Task<MultiVersionResult> ExtractMultiVersionAsync(
-        string packageId,
-        IReadOnlyList<string> versions,
-        string? targetFramework = null,
-        string? sourceFeed = null,
-        CancellationToken cancellationToken = default)
+    public async Task<MultiVersionResult> ExtractMultiVersionAsync(string packageId, IReadOnlyList<string> versions, string? targetFramework = null, string? sourceFeed = null, CancellationToken cancellationToken = default)
     {
         if (versions.Count == 0)
             throw new ArgumentException("At least one version is required.", nameof(versions));
 
         var versionInputs = new List<MultiVersionExtractor.VersionInput>();
-
         foreach (var version in versions)
         {
-            var dllPath = await _resolver.ResolveAsync(
-                packageId, version, targetFramework, sourceFeed, cancellationToken);
-
+            var dllPath = await _resolver.ResolveAsync(packageId, version, targetFramework, sourceFeed, cancellationToken);
             versionInputs.Add(new MultiVersionExtractor.VersionInput(version, dllPath));
         }
 

--- a/WrapGod.Extractor/NuGetPackageResolver.cs
+++ b/WrapGod.Extractor/NuGetPackageResolver.cs
@@ -1,5 +1,5 @@
+using System.Security.Cryptography;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -7,126 +7,113 @@ using NuGet.Versioning;
 
 namespace WrapGod.Extractor;
 
-/// <summary>
-/// Resolves a NuGet package by downloading the .nupkg and extracting the best-match DLL
-/// for a given target framework. Results are cached locally to avoid repeated downloads.
-/// </summary>
 public sealed class NuGetPackageResolver
 {
-    /// <summary>Default NuGet v3 feed URL (nuget.org).</summary>
+    public sealed record ResolutionResult(
+        string DllPath,
+        string PackageId,
+        string Version,
+        string SourceFeed,
+        string PackageSha256,
+        string TargetFramework,
+        string DllRelativePath,
+        string DllSha256);
+
     public const string DefaultSourceFeed = "https://api.nuget.org/v3/index.json";
 
-    /// <summary>
-    /// Ordered list of preferred TFMs when auto-selecting the best match.
-    /// First match wins.
-    /// </summary>
     private static readonly string[] PreferredTfms =
     [
-        "net8.0",
-        "net7.0",
-        "net6.0",
-        "netstandard2.1",
-        "netstandard2.0",
-        "netstandard1.6",
-        "net472",
-        "net462",
+        "net8.0", "net7.0", "net6.0", "netstandard2.1", "netstandard2.0", "netstandard1.6", "net472", "net462"
     ];
 
     private readonly string _cacheRoot;
 
-    /// <summary>
-    /// Creates a new resolver with the given local cache root.
-    /// Defaults to <c>.wrapgod-cache/packages</c> under the current directory.
-    /// </summary>
     public NuGetPackageResolver(string? cacheRoot = null)
     {
         _cacheRoot = cacheRoot ?? Path.Combine(Directory.GetCurrentDirectory(), ".wrapgod-cache", "packages");
     }
 
-    /// <summary>
-    /// Resolves a NuGet package to a local DLL path. Downloads and extracts
-    /// the package when not already cached.
-    /// </summary>
-    /// <param name="packageId">NuGet package identifier (e.g. <c>Newtonsoft.Json</c>).</param>
-    /// <param name="version">Exact package version (e.g. <c>13.0.3</c>).</param>
-    /// <param name="targetFramework">
-    /// Explicit TFM to extract (e.g. <c>net8.0</c>). When <c>null</c>, the best
-    /// match is auto-selected using <see cref="PreferredTfms"/>.
-    /// </param>
-    /// <param name="sourceFeed">NuGet v3 feed URL. Defaults to nuget.org.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Absolute path to the extracted DLL inside the local cache.</returns>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when the package cannot be found, contains no compatible DLLs,
-    /// or the specified TFM does not exist in the package.
-    /// </exception>
-    public async Task<string> ResolveAsync(
-        string packageId,
-        string version,
-        string? targetFramework = null,
-        string? sourceFeed = null,
-        CancellationToken cancellationToken = default)
+    public async Task<string> ResolveAsync(string packageId, string version, string? targetFramework = null, string? sourceFeed = null, CancellationToken cancellationToken = default)
+        => (await ResolveWithMetadataAsync(packageId, version, targetFramework, sourceFeed, cancellationToken)).DllPath;
+
+    public async Task<ResolutionResult> ResolveWithMetadataAsync(string packageId, string version, string? targetFramework = null, string? sourceFeed = null, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
         ArgumentException.ThrowIfNullOrWhiteSpace(version);
 
+        var feed = sourceFeed ?? DefaultSourceFeed;
         var packageDir = GetPackageDirectory(packageId, version);
-
-        // Check if we already have a cached extraction marker.
         var markerPath = Path.Combine(packageDir, ".extracted");
         if (!File.Exists(markerPath))
         {
-            await DownloadAndExtractAsync(packageId, version, sourceFeed ?? DefaultSourceFeed, packageDir, cancellationToken);
+            await DownloadAndExtractAsync(packageId, version, feed, packageDir, cancellationToken);
         }
 
-        return FindDll(packageId, packageDir, targetFramework);
+        var selection = FindDllSelection(packageId, packageDir, targetFramework);
+        var nupkgPath = Path.Combine(packageDir, $"{packageId}.{version}.nupkg");
+
+        return new ResolutionResult(
+            selection.DllPath,
+            packageId,
+            version,
+            feed,
+            ComputeSha256Hex(nupkgPath),
+            selection.ChosenTfm,
+            selection.DllRelativePath,
+            ComputeSha256Hex(selection.DllPath));
     }
 
-    /// <summary>
-    /// Returns the local cache directory for a given package id and version.
-    /// </summary>
-    public string GetPackageDirectory(string packageId, string version)
-        => Path.Combine(_cacheRoot, packageId.ToLowerInvariant(), version);
-
-    private static async Task DownloadAndExtractAsync(
+    public async Task<string> ResolveFromLockAsync(
         string packageId,
         string version,
         string sourceFeed,
-        string packageDir,
-        CancellationToken cancellationToken)
+        string packageSha256,
+        string targetFramework,
+        string dllRelativePath,
+        string dllSha256,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await ResolveWithMetadataAsync(packageId, version, targetFramework, sourceFeed, cancellationToken);
+
+        if (!string.Equals(result.PackageSha256, packageSha256, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Lock drift detected for {packageId}@{version}: package hash mismatch. Expected {packageSha256}, actual {result.PackageSha256}.");
+
+        if (!string.Equals(result.TargetFramework, targetFramework, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Lock drift detected for {packageId}@{version}: TFM mismatch. Expected {targetFramework}, actual {result.TargetFramework}.");
+
+        if (!string.Equals(result.DllRelativePath, dllRelativePath, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Lock drift detected for {packageId}@{version}: selected DLL mismatch. Expected {dllRelativePath}, actual {result.DllRelativePath}.");
+
+        if (!string.Equals(result.DllSha256, dllSha256, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Lock drift detected for {packageId}@{version}: assembly hash mismatch. Expected {dllSha256}, actual {result.DllSha256}.");
+
+        return result.DllPath;
+    }
+
+    public string GetPackageDirectory(string packageId, string version)
+        => Path.Combine(_cacheRoot, packageId.ToLowerInvariant(), version);
+
+    private static async Task DownloadAndExtractAsync(string packageId, string version, string sourceFeed, string packageDir, CancellationToken cancellationToken)
     {
         var cache = new SourceCacheContext();
         var repository = Repository.Factory.GetCoreV3(sourceFeed);
         var resource = await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
-
         var nugetVersion = new NuGetVersion(version);
 
-        // Verify the package exists.
         var versions = await resource.GetAllVersionsAsync(packageId, cache, NullLogger.Instance, cancellationToken);
         if (!versions.Contains(nugetVersion))
-        {
-            throw new InvalidOperationException(
-                $"Package '{packageId}' version '{version}' was not found on feed '{sourceFeed}'.");
-        }
+            throw new InvalidOperationException($"Package '{packageId}' version '{version}' was not found on feed '{sourceFeed}'.");
 
         Directory.CreateDirectory(packageDir);
-
         var nupkgPath = Path.Combine(packageDir, $"{packageId}.{version}.nupkg");
 
-        // Download the .nupkg.
         using (var fileStream = File.Create(nupkgPath))
         {
-            var downloaded = await resource.CopyNupkgToStreamAsync(
-                packageId, nugetVersion, fileStream, cache, NullLogger.Instance, cancellationToken);
-
+            var downloaded = await resource.CopyNupkgToStreamAsync(packageId, nugetVersion, fileStream, cache, NullLogger.Instance, cancellationToken);
             if (!downloaded)
-            {
-                throw new InvalidOperationException(
-                    $"Failed to download package '{packageId}' version '{version}'.");
-            }
+                throw new InvalidOperationException($"Failed to download package '{packageId}' version '{version}'.");
         }
 
-        // Extract lib/ DLLs from the nupkg.
         using var packageReader = new PackageArchiveReader(nupkgPath);
         var libItems = (await packageReader.GetLibItemsAsync(cancellationToken)).ToList();
 
@@ -149,67 +136,44 @@ public sealed class NuGetPackageResolver
             }
         }
 
-        // Write extraction marker.
         await File.WriteAllTextAsync(Path.Combine(packageDir, ".extracted"), DateTimeOffset.UtcNow.ToString("O"), cancellationToken);
     }
 
-    private static string FindDll(string packageId, string packageDir, string? targetFramework)
+    private static (string DllPath, string ChosenTfm, string DllRelativePath) FindDllSelection(string packageId, string packageDir, string? targetFramework)
     {
         var libDir = Path.Combine(packageDir, "lib");
-
         if (!Directory.Exists(libDir))
-        {
-            throw new InvalidOperationException(
-                $"Package '{packageId}' does not contain a lib/ folder with any DLLs.");
-        }
+            throw new InvalidOperationException($"Package '{packageId}' does not contain a lib/ folder with any DLLs.");
 
-        var availableTfms = Directory.GetDirectories(libDir)
-            .Select(Path.GetFileName)
-            .Where(d => d is not null)
-            .Cast<string>()
-            .ToList();
-
+        var availableTfms = Directory.GetDirectories(libDir).Select(Path.GetFileName).Where(d => d is not null).Cast<string>().ToList();
         if (availableTfms.Count == 0)
-        {
-            throw new InvalidOperationException(
-                $"Package '{packageId}' lib/ folder contains no TFM subfolders.");
-        }
+            throw new InvalidOperationException($"Package '{packageId}' lib/ folder contains no TFM subfolders.");
 
         string chosenTfm;
-
         if (targetFramework is not null)
         {
-            // Exact match required.
-            chosenTfm = availableTfms.FirstOrDefault(
-                t => string.Equals(t, targetFramework, StringComparison.OrdinalIgnoreCase))
-                ?? throw new InvalidOperationException(
-                    $"Package '{packageId}' does not contain TFM '{targetFramework}'. " +
-                    $"Available: {string.Join(", ", availableTfms)}");
+            chosenTfm = availableTfms.FirstOrDefault(t => string.Equals(t, targetFramework, StringComparison.OrdinalIgnoreCase))
+                ?? throw new InvalidOperationException($"Package '{packageId}' does not contain TFM '{targetFramework}'. Available: {string.Join(", ", availableTfms)}");
         }
         else
         {
-            // Auto-select best match from preference order.
-            chosenTfm = PreferredTfms
-                .FirstOrDefault(pref => availableTfms.Any(
-                    t => string.Equals(t, pref, StringComparison.OrdinalIgnoreCase)))
-                ?? availableTfms[0]; // Fallback to first available.
+            chosenTfm = PreferredTfms.FirstOrDefault(pref => availableTfms.Any(t => string.Equals(t, pref, StringComparison.OrdinalIgnoreCase))) ?? availableTfms[0];
         }
 
         var tfmPath = Path.Combine(libDir, chosenTfm);
         var dlls = Directory.GetFiles(tfmPath, "*.dll");
-
         if (dlls.Length == 0)
-        {
-            throw new InvalidOperationException(
-                $"No DLLs found in '{tfmPath}' for package '{packageId}'.");
-        }
+            throw new InvalidOperationException($"No DLLs found in '{tfmPath}' for package '{packageId}'.");
 
-        // Prefer the DLL matching the package name, otherwise return the first.
-        var primaryDll = dlls.FirstOrDefault(
-            d => Path.GetFileNameWithoutExtension(d)
-                .Equals(packageId, StringComparison.OrdinalIgnoreCase))
-            ?? dlls[0];
+        var primaryDll = dlls.FirstOrDefault(d => Path.GetFileNameWithoutExtension(d).Equals(packageId, StringComparison.OrdinalIgnoreCase)) ?? dlls[0];
+        var relativePath = Path.GetRelativePath(packageDir, primaryDll).Replace('\\', '/');
+        return (primaryDll, chosenTfm, relativePath);
+    }
 
-        return primaryDll;
+    private static string ComputeSha256Hex(string path)
+    {
+        using var stream = File.OpenRead(path);
+        var hash = SHA256.HashData(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 }

--- a/WrapGod.Manifest/LockFileSerializer.cs
+++ b/WrapGod.Manifest/LockFileSerializer.cs
@@ -1,0 +1,12 @@
+using System.Text.Json;
+
+namespace WrapGod.Manifest;
+
+public static class LockFileSerializer
+{
+    public static string Serialize(WrapGodLockFile lockFile)
+        => JsonSerializer.Serialize(lockFile, ManifestSerializer.GetOptions());
+
+    public static WrapGodLockFile? Deserialize(string json)
+        => JsonSerializer.Deserialize<WrapGodLockFile>(json, ManifestSerializer.GetOptions());
+}

--- a/WrapGod.Manifest/WrapGodLockFile.cs
+++ b/WrapGod.Manifest/WrapGodLockFile.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace WrapGod.Manifest;
+
+public sealed class WrapGodLockFile
+{
+    public string SchemaVersion { get; set; } = "1.0";
+    public DateTimeOffset GeneratedAt { get; set; } = DateTimeOffset.UtcNow;
+    public LockToolchain Toolchain { get; set; } = new();
+    public List<LockSourceEntry> Sources { get; set; } = [];
+}
+
+public sealed class LockToolchain
+{
+    public string Tool { get; set; } = "wrap-god";
+    public string? Version { get; set; }
+    public string? Runtime { get; set; }
+}
+
+public sealed class LockSourceEntry
+{
+    public string PackageId { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+    public string SourceFeed { get; set; } = string.Empty;
+    public string PackageSha256 { get; set; } = string.Empty;
+    public string TargetFramework { get; set; } = string.Empty;
+    public string DllRelativePath { get; set; } = string.Empty;
+    public string DllSha256 { get; set; } = string.Empty;
+}

--- a/WrapGod.Tests/LockFileSerializerTests.cs
+++ b/WrapGod.Tests/LockFileSerializerTests.cs
@@ -1,0 +1,30 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Manifest;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("Lockfile serialization")]
+public sealed class LockFileSerializerTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    [Scenario("Lockfile serialize/deserialize roundtrip")]
+    [Fact]
+    public Task Lockfile_Roundtrips()
+        => Given("a lockfile", () => new WrapGodLockFile
+            {
+                Sources = [new LockSourceEntry
+                {
+                    PackageId = "Newtonsoft.Json",
+                    Version = "13.0.3",
+                    SourceFeed = "https://api.nuget.org/v3/index.json",
+                    PackageSha256 = new string('a', 64),
+                    TargetFramework = "net8.0",
+                    DllRelativePath = "lib/net8.0/Newtonsoft.Json.dll",
+                    DllSha256 = new string('b', 64)
+                }]
+            })
+            .When("serialized and deserialized", lf => LockFileSerializer.Deserialize(LockFileSerializer.Serialize(lf)))
+            .Then("identity is preserved", parsed => parsed is not null && parsed.Sources.Count == 1 && parsed.Sources[0].PackageId == "Newtonsoft.Json")
+            .AssertPassed();
+}

--- a/WrapGod.Tests/NuGetExtractorTests.cs
+++ b/WrapGod.Tests/NuGetExtractorTests.cs
@@ -19,6 +19,20 @@ public sealed class NuGetExtractorTests(ITestOutputHelper output) : TinyBddXunit
 
     private static NuGetPackageResolver CreateResolver() => new(TestCacheRoot);
 
+    private static void SeedMockPackage(NuGetPackageResolver resolver)
+    {
+        var pkgDir = resolver.GetPackageDirectory("MockPkg", "1.0.0");
+        foreach (var tfm in MockTfms)
+        {
+            var tfmDir = Path.Combine(pkgDir, "lib", tfm);
+            Directory.CreateDirectory(tfmDir);
+            File.WriteAllBytes(Path.Combine(tfmDir, "MockPkg.dll"), MzHeaderStub);
+        }
+
+        File.WriteAllText(Path.Combine(pkgDir, "MockPkg.1.0.0.nupkg"), "mock-nupkg-content");
+        File.WriteAllText(Path.Combine(pkgDir, ".extracted"), "done");
+    }
+
     private static Task<string> ResolveNewtonsoftJson()
     {
         var resolver = CreateResolver();
@@ -80,24 +94,37 @@ public sealed class NuGetExtractorTests(ITestOutputHelper output) : TinyBddXunit
         => Given("a mock package directory with multiple TFMs", () =>
             {
                 var resolver = CreateResolver();
-                var pkgDir = resolver.GetPackageDirectory("MockPkg", "1.0.0");
-
-                // Create mock lib structure with multiple TFMs.
-                foreach (var tfm in MockTfms)
-                {
-                    var tfmDir = Path.Combine(pkgDir, "lib", tfm);
-                    Directory.CreateDirectory(tfmDir);
-                    File.WriteAllBytes(Path.Combine(tfmDir, "MockPkg.dll"), MzHeaderStub);
-                }
-
-                // Write extraction marker.
-                File.WriteAllText(Path.Combine(pkgDir, ".extracted"), "done");
+                SeedMockPackage(resolver);
                 return resolver;
             })
             .Then("ResolveAsync selects net8.0", (Func<NuGetPackageResolver, Task<bool>>)(async resolver =>
             {
                 var path = await resolver.ResolveAsync("MockPkg", "1.0.0");
                 return path.Contains("net8.0", StringComparison.OrdinalIgnoreCase);
+            }))
+            .AssertPassed();
+
+    [Scenario("ResolveFromLock reports drift for mismatched identity")]
+    [Fact]
+    public Task ResolveFromLock_DetectsDrift()
+        => Given("a resolver with mock package", () =>
+            {
+                var resolver = CreateResolver();
+                SeedMockPackage(resolver);
+                return resolver;
+            })
+            .Then("mismatch hash throws drift", (Func<NuGetPackageResolver, Task<bool>>)(async resolver =>
+            {
+                var meta = await resolver.ResolveWithMetadataAsync("MockPkg", "1.0.0");
+                try
+                {
+                    await resolver.ResolveFromLockAsync(meta.PackageId, meta.Version, meta.SourceFeed, meta.PackageSha256, meta.TargetFramework, meta.DllRelativePath, new string('0', 64));
+                    return false;
+                }
+                catch (InvalidOperationException ex)
+                {
+                    return ex.Message.Contains("Lock drift detected", StringComparison.OrdinalIgnoreCase);
+                }
             }))
             .AssertPassed();
 

--- a/schemas/wrapgod.lock.v1.schema.json
+++ b/schemas/wrapgod.lock.v1.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.wrapgod.dev/wrapgod.lock.v1.schema.json",
+  "title": "WrapGod Lockfile v1",
+  "type": "object",
+  "required": ["schemaVersion", "generatedAt", "toolchain", "sources"],
+  "properties": {
+    "schemaVersion": { "type": "string", "const": "1.0" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "toolchain": {
+      "type": "object",
+      "required": ["tool"],
+      "properties": { "tool": { "type": "string" }, "version": { "type": "string" }, "runtime": { "type": "string" } },
+      "additionalProperties": false
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["packageId", "version", "sourceFeed", "packageSha256", "targetFramework", "dllRelativePath", "dllSha256"],
+        "properties": {
+          "packageId": { "type": "string", "minLength": 1 },
+          "version": { "type": "string", "minLength": 1 },
+          "sourceFeed": { "type": "string", "format": "uri" },
+          "packageSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+          "targetFramework": { "type": "string", "minLength": 1 },
+          "dllRelativePath": { "type": "string", "minLength": 1 },
+          "dllSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
Implements the first complete lockfile path for NuGet extraction reproducibility (`wrapgod.lock.json`).

### Included
- Added lockfile model + serializer in `WrapGod.Manifest`
- Added lock schema at `schemas/wrapgod.lock.v1.schema.json`
- Extended resolver metadata to capture:
  - package identity (`packageId`, `version`, `sourceFeed`)
  - package hash (`packageSha256`)
  - selected TFM (`targetFramework`)
  - selected DLL path + hash (`dllRelativePath`, `dllSha256`)
- Added lock verification path (`ResolveFromLockAsync`) with explicit drift diagnostics
- Added CLI support:
  - writes lockfile on single-package `--nuget` extraction
  - supports `--locked` + `--lockfile` for lockfile-only reproducible extraction
- Added tests:
  - `LockFileSerializerTests` roundtrip
  - `NuGetExtractorTests.ResolveFromLock_DetectsDrift`

## Compatibility path for #123
Lockfile stores explicit source identity + selected TFM/DLL and can remain stable even as source-discovery conventions evolve in #123.

## Validation
`dotnet test WrapGod.Tests/WrapGod.Tests.csproj -c Release --filter "FullyQualifiedName~NuGetExtractorTests|FullyQualifiedName~LockFileSerializerTests"`

Passed: 7

Closes #124
