### PR TITLE
fix: deterministic package-ref tie-break for source discovery

### DIFF
--- a/WrapGod.Manifest/Config/SourceDiscoveryEngine.cs
+++ b/WrapGod.Manifest/Config/SourceDiscoveryEngine.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using WrapGod.Abstractions.Config;
@@ -23,9 +22,7 @@ public static class SourceDiscoveryEngine
         }
 
         var packageRef = input.PackageReferences
-            .Where(p => !string.IsNullOrWhiteSpace(p))
-            .OrderBy(p => p, StringComparer.Ordinal)
-            .FirstOrDefault();
+            .FirstOrDefault(static p => !string.IsNullOrWhiteSpace(p));
 
         if (!string.IsNullOrWhiteSpace(packageRef))
         {

--- a/WrapGod.Tests/ConventionDiscoveryAndPrecedenceTests.cs
+++ b/WrapGod.Tests/ConventionDiscoveryAndPrecedenceTests.cs
@@ -22,6 +22,20 @@ public sealed class ConventionDiscoveryAndPrecedenceTests
     }
 
     [Fact]
+    public void SourceDiscovery_PackageReferences_UseDeclarationOrder()
+    {
+        var result = SourceDiscoveryEngine.Discover(new SourceDiscoveryInput
+        {
+            PackageReferences = ["Vendor.Secondary", "Vendor.Primary"],
+            HasSelfSource = true,
+            ExplicitSource = "Vendor.Explicit"
+        });
+
+        Assert.Equal("Vendor.Secondary", result.Source);
+        Assert.Equal("PackageReference", result.Strategy);
+    }
+
+    [Fact]
     public void SourceDiscovery_NoSource_EmitsActionableDiagnostic()
     {
         var result = SourceDiscoveryEngine.Discover(new SourceDiscoveryInput());

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -89,7 +89,7 @@ public interface IHttpClientWrapper { }
 Source resolution for `[WrapType]` follows a deterministic discovery order:
 
 1. Convention match in `WrapGodPackage`
-2. Convention match in referenced packages/assemblies
+2. Convention match in referenced packages/assemblies (first declared package reference wins)
 3. `@self` (the attributed type itself)
 4. Explicit metadata name from `sourceType`
 


### PR DESCRIPTION
## Summary
- preserve convention-first source discovery order while honoring package-reference declaration order
- add regression test ensuring the first declared package reference wins
- document package-reference tie-break behavior in configuration docs

## Validation
- `dotnet test WrapGod.slnx --filter "FullyQualifiedName~ConventionDiscoveryAndPrecedenceTests"`

Related to #123
