### PR TITLE
fix: CA1861 — static readonly array

### DIFF
--- a/WrapGod.Tests/ConventionDiscoveryAndPrecedenceTests.cs
+++ b/WrapGod.Tests/ConventionDiscoveryAndPrecedenceTests.cs
@@ -6,13 +6,15 @@ namespace WrapGod.Tests;
 
 public sealed class ConventionDiscoveryAndPrecedenceTests
 {
+    private static readonly string[] SecondaryPackages = ["Vendor.Secondary"];
+
     [Fact]
     public void SourceDiscovery_UsesConfiguredOrder()
     {
         var result = SourceDiscoveryEngine.Discover(new SourceDiscoveryInput
         {
             WrapGodPackage = "Vendor.Primary",
-            PackageReferences = new[] { "Vendor.Secondary" },
+            PackageReferences = SecondaryPackages,
             HasSelfSource = true,
             ExplicitSource = "Vendor.Explicit"
         });


### PR DESCRIPTION
Extract constant array arg to static readonly field. Build clean.