### PR TITLE
feat(manifest): wrapgod.lock.json reproducibility lockfile

### DIFF
--- a/WrapGod.Manifest/Lockfile/WrapGodLockfile.cs
+++ b/WrapGod.Manifest/Lockfile/WrapGodLockfile.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WrapGod.Manifest.Lockfile;
+
+/// <summary>
+/// Root schema for the wrapgod.lock.json reproducibility lockfile.
+/// Captures the exact resolution state so builds are deterministic.
+/// </summary>
+public sealed class WrapGodLockfile
+{
+    [JsonPropertyName("version")]
+    public int Version { get; set; } = 1;
+
+    [JsonPropertyName("generatedAt")]
+    public DateTimeOffset GeneratedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    [JsonPropertyName("toolchainVersion")]
+    public string ToolchainVersion { get; set; } = string.Empty;
+
+    [JsonPropertyName("sources")]
+    public List<LockfileSource> Sources { get; set; } = new List<LockfileSource>();
+}
+
+/// <summary>
+/// A single resolved source entry in the lockfile.
+/// </summary>
+public sealed class LockfileSource
+{
+    [JsonPropertyName("packageId")]
+    public string PackageId { get; set; } = string.Empty;
+
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = string.Empty;
+
+    [JsonPropertyName("feed")]
+    public string Feed { get; set; } = string.Empty;
+
+    [JsonPropertyName("fileHash")]
+    public string FileHash { get; set; } = string.Empty;
+
+    [JsonPropertyName("tfm")]
+    public string Tfm { get; set; } = string.Empty;
+
+    [JsonPropertyName("resolvedPath")]
+    public string ResolvedPath { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Serializes a <see cref="WrapGodLockfile"/> to JSON.
+/// </summary>
+public static class WrapGodLockfileWriter
+{
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Serializes the lockfile to a JSON string.
+    /// </summary>
+    public static string Serialize(WrapGodLockfile lockfile)
+    {
+        if (lockfile is null) throw new ArgumentNullException(nameof(lockfile));
+        return JsonSerializer.Serialize(lockfile, s_options);
+    }
+
+    /// <summary>
+    /// Writes the lockfile to the specified file path.
+    /// </summary>
+    public static void WriteToFile(WrapGodLockfile lockfile, string path)
+    {
+        if (lockfile is null) throw new ArgumentNullException(nameof(lockfile));
+        if (path is null) throw new ArgumentNullException(nameof(path));
+        File.WriteAllText(path, Serialize(lockfile));
+    }
+}
+
+/// <summary>
+/// Deserializes and validates a <see cref="WrapGodLockfile"/> from JSON.
+/// </summary>
+public static class WrapGodLockfileReader
+{
+    /// <summary>
+    /// Deserializes a lockfile from a JSON string.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the JSON is invalid or the lockfile version is unsupported.</exception>
+    public static WrapGodLockfile Deserialize(string json)
+    {
+        if (json is null) throw new ArgumentNullException(nameof(json));
+
+        var lockfile = JsonSerializer.Deserialize<WrapGodLockfile>(json)
+            ?? throw new InvalidOperationException("Failed to deserialize lockfile: result was null.");
+
+        Validate(lockfile);
+        return lockfile;
+    }
+
+    /// <summary>
+    /// Reads and deserializes a lockfile from the specified file path.
+    /// </summary>
+    public static WrapGodLockfile ReadFromFile(string path)
+    {
+        if (path is null) throw new ArgumentNullException(nameof(path));
+        var json = File.ReadAllText(path);
+        return Deserialize(json);
+    }
+
+    private static void Validate(WrapGodLockfile lockfile)
+    {
+        if (lockfile.Version < 1)
+        {
+            throw new InvalidOperationException(
+                $"Unsupported lockfile version: {lockfile.Version}. Expected >= 1.");
+        }
+
+        foreach (var source in lockfile.Sources)
+        {
+            if (string.IsNullOrWhiteSpace(source.PackageId))
+            {
+                throw new InvalidOperationException(
+                    "Lockfile source has an empty packageId.");
+            }
+
+            if (string.IsNullOrWhiteSpace(source.Version))
+            {
+                throw new InvalidOperationException(
+                    $"Lockfile source '{source.PackageId}' has an empty version.");
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Represents a single difference detected between the current resolution and a lockfile.
+/// </summary>
+public sealed class LockfileDrift
+{
+    /// <summary>The package that drifted.</summary>
+    public string PackageId { get; set; } = string.Empty;
+
+    /// <summary>Human-readable description of the drift.</summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>The field that changed (e.g. "version", "fileHash").</summary>
+    public string Field { get; set; } = string.Empty;
+
+    /// <summary>The expected (lockfile) value.</summary>
+    public string Expected { get; set; } = string.Empty;
+
+    /// <summary>The actual (current resolution) value.</summary>
+    public string Actual { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Compares a current resolution against a persisted lockfile and reports drifts.
+/// </summary>
+public static class DriftDetector
+{
+    /// <summary>
+    /// Detects differences between the locked sources and the current sources.
+    /// </summary>
+    /// <param name="locked">The persisted lockfile (source of truth).</param>
+    /// <param name="current">The current resolution result.</param>
+    /// <returns>A list of drifts. Empty means no drift.</returns>
+    public static IReadOnlyList<LockfileDrift> Detect(
+        WrapGodLockfile locked,
+        WrapGodLockfile current)
+    {
+        if (locked is null) throw new ArgumentNullException(nameof(locked));
+        if (current is null) throw new ArgumentNullException(nameof(current));
+
+        var drifts = new List<LockfileDrift>();
+
+        var lockedByPackage = new Dictionary<string, LockfileSource>(StringComparer.OrdinalIgnoreCase);
+        foreach (var s in locked.Sources)
+        {
+            lockedByPackage[s.PackageId] = s;
+        }
+
+        var currentByPackage = new Dictionary<string, LockfileSource>(StringComparer.OrdinalIgnoreCase);
+        foreach (var s in current.Sources)
+        {
+            currentByPackage[s.PackageId] = s;
+        }
+
+        // Check for changed or removed packages.
+        foreach (var kvp in lockedByPackage)
+        {
+            var packageId = kvp.Key;
+            var lockedSource = kvp.Value;
+
+            LockfileSource currentSource;
+            if (!currentByPackage.TryGetValue(packageId, out currentSource))
+            {
+                drifts.Add(new LockfileDrift
+                {
+                    PackageId = packageId,
+                    Description = $"Package '{packageId}' was removed from resolution.",
+                    Field = "presence",
+                    Expected = "present",
+                    Actual = "absent",
+                });
+                continue;
+            }
+
+            CompareField(drifts, packageId, "version", lockedSource.Version, currentSource.Version);
+            CompareField(drifts, packageId, "fileHash", lockedSource.FileHash, currentSource.FileHash);
+            CompareField(drifts, packageId, "feed", lockedSource.Feed, currentSource.Feed);
+            CompareField(drifts, packageId, "tfm", lockedSource.Tfm, currentSource.Tfm);
+            CompareField(drifts, packageId, "resolvedPath", lockedSource.ResolvedPath, currentSource.ResolvedPath);
+        }
+
+        // Check for added packages.
+        foreach (var packageId in currentByPackage.Keys)
+        {
+            if (!lockedByPackage.ContainsKey(packageId))
+            {
+                drifts.Add(new LockfileDrift
+                {
+                    PackageId = packageId,
+                    Description = $"Package '{packageId}' was added (not in lockfile).",
+                    Field = "presence",
+                    Expected = "absent",
+                    Actual = "present",
+                });
+            }
+        }
+
+        return drifts;
+    }
+
+    private static void CompareField(
+        List<LockfileDrift> drifts,
+        string packageId,
+        string field,
+        string expected,
+        string actual)
+    {
+        if (!string.Equals(expected, actual, StringComparison.Ordinal))
+        {
+            drifts.Add(new LockfileDrift
+            {
+                PackageId = packageId,
+                Description = $"Package '{packageId}' has {field} drift: expected '{expected}', got '{actual}'.",
+                Field = field,
+                Expected = expected,
+                Actual = actual,
+            });
+        }
+    }
+}

--- a/WrapGod.Tests/LockfileTests.cs
+++ b/WrapGod.Tests/LockfileTests.cs
@@ -1,0 +1,197 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Manifest.Lockfile;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("wrapgod.lock.json reproducibility lockfile")]
+public sealed class LockfileTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    private static WrapGodLockfile CreateSampleLockfile() => new()
+    {
+        Version = 1,
+        GeneratedAt = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero),
+        ToolchainVersion = "0.1.0-alpha",
+        Sources =
+        [
+            new LockfileSource
+            {
+                PackageId = "Newtonsoft.Json",
+                Version = "13.0.3",
+                Feed = "https://api.nuget.org/v3/index.json",
+                FileHash = "sha256:abc123def456",
+                Tfm = "netstandard2.0",
+                ResolvedPath = "packages/newtonsoft.json/13.0.3/lib/netstandard2.0/Newtonsoft.Json.dll",
+            },
+            new LockfileSource
+            {
+                PackageId = "Serilog",
+                Version = "4.0.0",
+                Feed = "https://api.nuget.org/v3/index.json",
+                FileHash = "sha256:789ghi012jkl",
+                Tfm = "net8.0",
+                ResolvedPath = "packages/serilog/4.0.0/lib/net8.0/Serilog.dll",
+            },
+        ],
+    };
+
+    [Scenario("Write and read lockfile roundtrip preserves all data")]
+    [Fact]
+    public Task WriteReadRoundtrip() =>
+        Given("a sample lockfile serialized and deserialized", () =>
+        {
+            var original = CreateSampleLockfile();
+            var json = WrapGodLockfileWriter.Serialize(original);
+            var deserialized = WrapGodLockfileReader.Deserialize(json);
+            return (Original: original, Roundtrip: deserialized, Json: json);
+        })
+        .Then("version is preserved", r => r.Roundtrip.Version == 1)
+        .And("generatedAt is preserved", r => r.Roundtrip.GeneratedAt == r.Original.GeneratedAt)
+        .And("toolchainVersion is preserved", r => r.Roundtrip.ToolchainVersion == "0.1.0-alpha")
+        .And("source count is preserved", r => r.Roundtrip.Sources.Count == 2)
+        .And("first source packageId is preserved", r =>
+            r.Roundtrip.Sources[0].PackageId == "Newtonsoft.Json")
+        .And("first source version is preserved", r =>
+            r.Roundtrip.Sources[0].Version == "13.0.3")
+        .And("first source feed is preserved", r =>
+            r.Roundtrip.Sources[0].Feed == "https://api.nuget.org/v3/index.json")
+        .And("first source fileHash is preserved", r =>
+            r.Roundtrip.Sources[0].FileHash == "sha256:abc123def456")
+        .And("first source tfm is preserved", r =>
+            r.Roundtrip.Sources[0].Tfm == "netstandard2.0")
+        .And("first source resolvedPath is preserved", r =>
+            r.Roundtrip.Sources[0].ResolvedPath ==
+                "packages/newtonsoft.json/13.0.3/lib/netstandard2.0/Newtonsoft.Json.dll")
+        .And("second source packageId is preserved", r =>
+            r.Roundtrip.Sources[1].PackageId == "Serilog")
+        .And("JSON is valid", r => r.Json.Contains("\"version\": 1"))
+        .AssertPassed();
+
+    [Scenario("Drift detection reports hash change")]
+    [Fact]
+    public Task DriftDetection_HashChange() =>
+        Given("a locked and current lockfile with different hash", () =>
+        {
+            var current = CreateSampleLockfile();
+            current.Sources[0].FileHash = "sha256:CHANGED";
+            return DriftDetector.Detect(CreateSampleLockfile(), current);
+        })
+        .Then("exactly one drift is reported", drifts => drifts.Count == 1)
+        .And("drift field is fileHash", drifts => drifts[0].Field == "fileHash")
+        .And("expected value is original hash", drifts =>
+            drifts[0].Expected == "sha256:abc123def456")
+        .And("actual value is changed hash", drifts =>
+            drifts[0].Actual == "sha256:CHANGED")
+        .And("drift packageId is Newtonsoft.Json", drifts =>
+            drifts[0].PackageId == "Newtonsoft.Json")
+        .AssertPassed();
+
+    [Scenario("Drift detection reports version change")]
+    [Fact]
+    public Task DriftDetection_VersionChange() =>
+        Given("a locked and current lockfile with different version", () =>
+        {
+            var current = CreateSampleLockfile();
+            current.Sources[1].Version = "5.0.0";
+            return DriftDetector.Detect(CreateSampleLockfile(), current);
+        })
+        .Then("exactly one drift is reported", drifts => drifts.Count == 1)
+        .And("drift field is version", drifts => drifts[0].Field == "version")
+        .And("expected value is 4.0.0", drifts => drifts[0].Expected == "4.0.0")
+        .And("actual value is 5.0.0", drifts => drifts[0].Actual == "5.0.0")
+        .And("drift packageId is Serilog", drifts =>
+            drifts[0].PackageId == "Serilog")
+        .AssertPassed();
+
+    [Scenario("Drift detection reports added package")]
+    [Fact]
+    public Task DriftDetection_AddedPackage() =>
+        Given("a current lockfile with an extra package", () =>
+        {
+            var current = CreateSampleLockfile();
+            current.Sources.Add(new LockfileSource
+            {
+                PackageId = "NewPackage",
+                Version = "1.0.0",
+                Feed = "https://api.nuget.org/v3/index.json",
+                FileHash = "sha256:new",
+                Tfm = "net8.0",
+                ResolvedPath = "packages/newpackage/1.0.0/lib/net8.0/NewPackage.dll",
+            });
+            return DriftDetector.Detect(CreateSampleLockfile(), current);
+        })
+        .Then("exactly one drift is reported", drifts => drifts.Count == 1)
+        .And("drift field is presence", drifts => drifts[0].Field == "presence")
+        .And("drift indicates addition", drifts => drifts[0].Actual == "present")
+        .AssertPassed();
+
+    [Scenario("Drift detection reports removed package")]
+    [Fact]
+    public Task DriftDetection_RemovedPackage() =>
+        Given("a current lockfile missing a package", () =>
+        {
+            var current = CreateSampleLockfile();
+            current.Sources.RemoveAt(1);
+            return DriftDetector.Detect(CreateSampleLockfile(), current);
+        })
+        .Then("exactly one drift is reported", drifts => drifts.Count == 1)
+        .And("drift field is presence", drifts => drifts[0].Field == "presence")
+        .And("drift indicates removal", drifts => drifts[0].Actual == "absent")
+        .And("drift packageId is Serilog", drifts => drifts[0].PackageId == "Serilog")
+        .AssertPassed();
+
+    [Scenario("No drift when lockfiles match")]
+    [Fact]
+    public Task NoDrift_WhenIdentical() =>
+        Given("two identical lockfiles", () =>
+            DriftDetector.Detect(CreateSampleLockfile(), CreateSampleLockfile()))
+        .Then("no drifts are reported", drifts => drifts.Count == 0)
+        .AssertPassed();
+
+    [Scenario("Reader rejects invalid lockfile version")]
+    [Fact]
+    public Task Reader_RejectsInvalidVersion() =>
+        Given("a lockfile JSON with version 0", () =>
+        {
+            var lockfile = CreateSampleLockfile();
+            lockfile.Version = 0;
+            return WrapGodLockfileWriter.Serialize(lockfile);
+        })
+        .Then("deserialization throws InvalidOperationException", json =>
+        {
+            try
+            {
+                WrapGodLockfileReader.Deserialize(json);
+                return false;
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+        })
+        .AssertPassed();
+
+    [Scenario("Reader rejects source with empty packageId")]
+    [Fact]
+    public Task Reader_RejectsEmptyPackageId() =>
+        Given("a lockfile JSON with empty packageId", () =>
+        {
+            var lockfile = CreateSampleLockfile();
+            lockfile.Sources[0].PackageId = "";
+            return WrapGodLockfileWriter.Serialize(lockfile);
+        })
+        .Then("deserialization throws InvalidOperationException", json =>
+        {
+            try
+            {
+                WrapGodLockfileReader.Deserialize(json);
+                return false;
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+        })
+        .AssertPassed();
+}


### PR DESCRIPTION
## Summary
- Adds `WrapGodLockfile` schema with version, generatedAt, sources[], and toolchainVersion fields
- Implements `WrapGodLockfileWriter` (JSON serialization) and `WrapGodLockfileReader` (deserialization + validation)
- Implements `DriftDetector` to compare current resolution against a persisted lockfile and report field-level diffs
- 8 TinyBDD tests: roundtrip, hash drift, version drift, added/removed package drift, no-drift baseline, and validation rejection

## Test plan
- [x] Build passes: `dotnet build WrapGod.slnx --nologo -c Release`
- [x] All 8 new lockfile tests pass
- [x] Existing tests unaffected

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)