### PR TITLE
feat(tests): flake audit + determinism hardening

### DIFF
--- a/WrapGod.Tests/ExtractorCoverageBoostTests.cs
+++ b/WrapGod.Tests/ExtractorCoverageBoostTests.cs
@@ -1104,7 +1104,7 @@ namespace Ns
         {
             CacheKeyHash = "abc123",
             CacheKey = key,
-            CreatedAtUtc = DateTimeOffset.UtcNow,
+            CreatedAtUtc = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
             Manifest = new ApiManifest { SchemaVersion = "1.0" },
         };
 
@@ -1123,7 +1123,7 @@ namespace Ns
         {
             CacheKeyHash = "hash1",
             PayloadHash = "payload1",
-            CreatedAtUtc = DateTimeOffset.UtcNow,
+            CreatedAtUtc = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
         };
 
         return Given("an ExtractorCacheIndexRecord", () => record)

--- a/WrapGod.Tests/NuGetExtractorTests.cs
+++ b/WrapGod.Tests/NuGetExtractorTests.cs
@@ -11,21 +11,22 @@ public sealed class NuGetExtractorTests(ITestOutputHelper output) : TinyBddXunit
 {
     // ── Helpers ──────────────────────────────────────────────────────
 
-    private static readonly string TestCacheRoot =
+    // Instance-level cache root so each test method gets an isolated directory.
+    private readonly string _testCacheRoot =
         Path.Combine(Path.GetTempPath(), "wrapgod-test-cache", Guid.NewGuid().ToString("N"));
 
     private static readonly byte[] MzHeaderStub = [0x4D, 0x5A];
     private static readonly string[] MockTfms = ["netstandard2.0", "netstandard2.1", "net8.0"];
 
-    private static NuGetPackageResolver CreateResolver() => new(TestCacheRoot);
+    private NuGetPackageResolver CreateResolver() => new(_testCacheRoot);
 
-    private static Task<string> ResolveNewtonsoftJson()
+    private Task<string> ResolveNewtonsoftJson()
     {
         var resolver = CreateResolver();
         return resolver.ResolveAsync("Newtonsoft.Json", "13.0.3");
     }
 
-    private static Task<ApiManifest> ExtractNewtonsoftJson()
+    private Task<ApiManifest> ExtractNewtonsoftJson()
     {
         var resolver = CreateResolver();
         var extractor = new NuGetExtractor(resolver);

--- a/docs/FLAKE-POLICY.md
+++ b/docs/FLAKE-POLICY.md
@@ -1,0 +1,59 @@
+# Flake Policy
+
+## Identifying Flaky Tests
+
+A test is considered flaky when it produces non-deterministic results across runs
+without code changes. Common root causes:
+
+- **Timing dependence**: Assertions on wall-clock time (`DateTime.Now`,
+  `DateTimeOffset.UtcNow`) or tests that rely on `Task.Delay`/`Thread.Sleep`
+  for synchronization.
+- **Order dependence**: Static mutable state shared between test methods, or
+  reliance on test execution order.
+- **Shared file system state**: Temp directories reused across tests without
+  per-test isolation (missing `Guid.NewGuid()` scoping).
+- **Network dependence**: Tests that call live NuGet feeds, HTTP endpoints, or
+  DNS without mocking or stubbing.
+- **Platform dependence**: Path separators, line endings, or locale-sensitive
+  string comparisons.
+
+## Prevention Guidelines
+
+1. **Deterministic timestamps**: Use fixed `DateTimeOffset` values in test setup
+   rather than `DateTimeOffset.UtcNow`.
+2. **Per-test isolation**: Temp directories must use `Guid.NewGuid()` per test
+   instance, not per class (`static readonly`).
+3. **No static mutable state**: Test helper methods that create resources should
+   be instance methods, not static, to prevent cross-test contamination.
+4. **Deterministic seeds**: If randomness is needed, use a fixed seed and log it
+   so failures are reproducible.
+5. **Generous timeouts**: Integration tests touching the file system or NuGet
+   should use timeouts at least 2x the expected duration.
+
+## Quarantine Rules
+
+When a test is identified as flaky:
+
+1. Apply the `[Trait("Category", "Quarantined")]` attribute to the test method.
+2. Add a comment referencing the tracking issue: `// Quarantined: see #NNN`.
+3. Quarantined tests are excluded from the CI gate via filter:
+   `--filter "Category!=Quarantined"`.
+4. The quarantined test must have a GitHub issue assigned within 48 hours.
+
+## Re-entry Criteria
+
+A quarantined test may be restored to the main suite when:
+
+1. The root cause is identified and fixed.
+2. The fix is verified by running the test at least 50 times locally without failure:
+   ```bash
+   for i in $(seq 1 50); do dotnet test --filter "FullyQualifiedName~TheTest" --nologo -v q || break; done
+   ```
+3. The `[Trait("Category", "Quarantined")]` attribute and comment are removed.
+4. The associated GitHub issue is closed.
+
+## Audit Cadence
+
+- On each PR that modifies test files, reviewers should check for new timing or
+  order dependencies.
+- Monthly: run the full suite 10x in CI to surface intermittent failures.


### PR DESCRIPTION
## Summary
- Audited all 40+ test files for timing, ordering, and state-sharing issues
- Fixed `NuGetExtractorTests` static cache root to instance-level for per-test isolation
- Replaced `DateTimeOffset.UtcNow` with fixed timestamps in `ExtractorCoverageBoostTests`
- Added `docs/FLAKE-POLICY.md` with quarantine rules (trait-based), re-entry criteria, and audit cadence

## Test plan
- [x] All 401 tests pass after changes
- [x] Build succeeds in Release configuration

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)