### PR TITLE
feat(ci): coverage gate workflow + package threshold reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,65 @@ jobs:
 
       - name: Test
         run: dotnet test WrapGod.slnx --configuration Release --no-build --verbosity normal
+
+      - name: Test with Coverage
+        run: |
+          dotnet test WrapGod.Tests/WrapGod.Tests.csproj \
+            --configuration Release \
+            --no-build \
+            --verbosity quiet \
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./TestResults/coverage \
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
+
+      - name: Coverage Gate
+        shell: bash
+        run: |
+          THRESHOLD=90
+          REPORT=$(find ./TestResults/coverage -name "coverage.cobertura.xml" -type f | head -1)
+
+          if [ -z "$REPORT" ]; then
+            echo "::error::No coverage report found."
+            exit 1
+          fi
+
+          echo "## Coverage Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Package | Line Rate | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|-----------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+          FAILED=0
+
+          # Parse per-package line rates from cobertura XML.
+          # Each <package> element has a name and line-rate attribute.
+          while IFS= read -r line; do
+            PACKAGE_NAME=$(echo "$line" | sed -n 's/.*name="\([^"]*\)".*/\1/p')
+            LINE_RATE=$(echo "$line" | sed -n 's/.*line-rate="\([^"]*\)".*/\1/p')
+
+            if [ -z "$PACKAGE_NAME" ] || [ -z "$LINE_RATE" ]; then
+              continue
+            fi
+
+            # Convert rate (0.0-1.0) to percentage.
+            PCT=$(echo "$LINE_RATE * 100" | bc -l | xargs printf "%.1f")
+
+            if (( $(echo "$PCT < $THRESHOLD" | bc -l) )); then
+              STATUS="FAIL"
+              FAILED=1
+              echo "::error::Package '$PACKAGE_NAME' coverage ${PCT}% is below ${THRESHOLD}% threshold."
+            else
+              STATUS="PASS"
+            fi
+
+            echo "| $PACKAGE_NAME | ${PCT}% | $STATUS |" >> "$GITHUB_STEP_SUMMARY"
+          done < <(grep '<package ' "$REPORT")
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Threshold: ${THRESHOLD}%" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo "::error::One or more packages failed the coverage gate."
+            exit 1
+          fi
+
+          echo "All packages meet the ${THRESHOLD}% coverage threshold."

--- a/docs/COVERAGE-POLICY.md
+++ b/docs/COVERAGE-POLICY.md
@@ -1,0 +1,44 @@
+# Coverage Policy
+
+## Thresholds
+
+| Scope | Metric | Minimum |
+|-------|--------|---------|
+| Per-package | Line rate | 90% |
+
+The CI workflow enforces these thresholds on every PR and push to `main`.
+If any package drops below the minimum, the build fails.
+
+## How It Works
+
+1. **Collection**: `dotnet test` runs with `coverlet.collector` producing
+   a Cobertura XML report (`coverage.cobertura.xml`).
+2. **Parsing**: The CI workflow parses each `<package>` element's `line-rate`
+   attribute from the Cobertura XML.
+3. **Gate**: Each package's line rate is compared against the threshold.
+   If any package falls below 90%, the workflow fails with an error annotation.
+4. **Reporting**: A coverage summary table is posted to the GitHub Actions
+   job summary, showing per-package line rates and pass/fail status.
+
+## Adjusting Thresholds
+
+To change the threshold, update the `THRESHOLD` variable in
+`.github/workflows/ci.yml` under the "Coverage Gate" step.
+
+Threshold changes require team review and should be accompanied by a rationale
+in the PR description.
+
+## Exceptions
+
+If a package legitimately cannot meet the threshold (e.g., generated code,
+platform-specific branches), document the exception here with a justification:
+
+| Package | Actual | Justification |
+|---------|--------|---------------|
+| *(none currently)* | | |
+
+## Adding Coverage to New Packages
+
+New packages are automatically included in coverage collection. Ensure the test
+project references the new package and that `coverlet.collector` is included
+as a test dependency.


### PR DESCRIPTION
## Summary
- Updated `.github/workflows/ci.yml` with coverage collection (coverlet/cobertura) and per-package gate at 90% threshold
- Coverage gate parses cobertura XML, extracts per-package line rates, fails build if any package is below threshold
- Posts a coverage summary table to GitHub Actions job summary
- Added `docs/COVERAGE-POLICY.md` documenting thresholds, adjustment process, and exception handling

## Test plan
- [x] CI workflow YAML is valid
- [x] Coverage gate logic handles missing reports with clear error
- [x] Per-package parsing extracts name and line-rate correctly

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)