### PR TITLE
feat(manifest): add unified run report contract

### DIFF
--- a/WrapGod.Manifest/Reports/RunReport.cs
+++ b/WrapGod.Manifest/Reports/RunReport.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WrapGod.Manifest.Reports;
+
+/// <summary>
+/// Unified run report capturing the outcome of a WrapGod pipeline execution.
+/// </summary>
+public sealed class RunReport
+{
+    [JsonPropertyName("schemaVersion")]
+    public string SchemaVersion { get; set; } = "1.0";
+
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;
+
+    [JsonPropertyName("sourcesResolved")]
+    public List<ResolvedSource> SourcesResolved { get; set; } = new List<ResolvedSource>();
+
+    [JsonPropertyName("typesExtracted")]
+    public int TypesExtracted { get; set; }
+
+    [JsonPropertyName("wrappersGenerated")]
+    public int WrappersGenerated { get; set; }
+
+    [JsonPropertyName("diagnosticsFound")]
+    public int DiagnosticsFound { get; set; }
+
+    [JsonPropertyName("fixesApplied")]
+    public int FixesApplied { get; set; }
+
+    [JsonPropertyName("diagnostics")]
+    public List<ReportDiagnostic> Diagnostics { get; set; } = new List<ReportDiagnostic>();
+}
+
+/// <summary>
+/// A source that was resolved during the run.
+/// </summary>
+public sealed class ResolvedSource
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = string.Empty;
+
+    [JsonPropertyName("sourceType")]
+    public string SourceType { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// A diagnostic entry in the run report.
+/// </summary>
+public sealed class ReportDiagnostic
+{
+    [JsonPropertyName("code")]
+    public string Code { get; set; } = string.Empty;
+
+    [JsonPropertyName("severity")]
+    public string Severity { get; set; } = string.Empty;
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    [JsonPropertyName("file")]
+    public string File { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Writes a <see cref="RunReport"/> as JSON or human-readable text.
+/// </summary>
+public static class RunReportWriter
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Serializes the run report to a JSON string.
+    /// </summary>
+    public static string SerializeJson(RunReport report)
+    {
+        if (report is null) throw new ArgumentNullException(nameof(report));
+        return JsonSerializer.Serialize(report, s_jsonOptions);
+    }
+
+    /// <summary>
+    /// Writes the run report to a JSON file.
+    /// </summary>
+    public static void WriteJsonToFile(RunReport report, string path)
+    {
+        if (report is null) throw new ArgumentNullException(nameof(report));
+        if (path is null) throw new ArgumentNullException(nameof(path));
+        System.IO.File.WriteAllText(path, SerializeJson(report));
+    }
+
+    /// <summary>
+    /// Formats the run report as human-readable text.
+    /// </summary>
+    public static string FormatText(RunReport report)
+    {
+        if (report is null) throw new ArgumentNullException(nameof(report));
+
+        var sb = new StringBuilder();
+        sb.AppendLine("WrapGod Run Report");
+        sb.AppendLine(new string('-', 40));
+        sb.AppendLine($"Timestamp:          {report.Timestamp:u}");
+        sb.AppendLine($"Sources resolved:   {report.SourcesResolved.Count}");
+        sb.AppendLine($"Types extracted:    {report.TypesExtracted}");
+        sb.AppendLine($"Wrappers generated: {report.WrappersGenerated}");
+        sb.AppendLine($"Diagnostics found:  {report.DiagnosticsFound}");
+        sb.AppendLine($"Fixes applied:      {report.FixesApplied}");
+
+        if (report.SourcesResolved.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Sources:");
+            foreach (var source in report.SourcesResolved)
+            {
+                sb.AppendLine($"  {source.Name} {source.Version} ({source.SourceType})");
+            }
+        }
+
+        if (report.Diagnostics.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Diagnostics:");
+            foreach (var diag in report.Diagnostics)
+            {
+                sb.AppendLine($"  [{diag.Severity}] {diag.Code}: {diag.Message}");
+                if (!string.IsNullOrEmpty(diag.File))
+                {
+                    sb.AppendLine($"         {diag.File}");
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Writes the run report as human-readable text to a file.
+    /// </summary>
+    public static void WriteTextToFile(RunReport report, string path)
+    {
+        if (report is null) throw new ArgumentNullException(nameof(report));
+        if (path is null) throw new ArgumentNullException(nameof(path));
+        System.IO.File.WriteAllText(path, FormatText(report));
+    }
+}
+
+/// <summary>
+/// Reads and validates a <see cref="RunReport"/> from JSON.
+/// </summary>
+public static class RunReportReader
+{
+    /// <summary>
+    /// Deserializes a run report from a JSON string.
+    /// </summary>
+    public static RunReport Deserialize(string json)
+    {
+        if (json is null) throw new ArgumentNullException(nameof(json));
+
+        var report = JsonSerializer.Deserialize<RunReport>(json)
+            ?? throw new InvalidOperationException("Failed to deserialize run report: result was null.");
+
+        return report;
+    }
+
+    /// <summary>
+    /// Reads and deserializes a run report from the specified file path.
+    /// </summary>
+    public static RunReport ReadFromFile(string path)
+    {
+        if (path is null) throw new ArgumentNullException(nameof(path));
+        var json = System.IO.File.ReadAllText(path);
+        return Deserialize(json);
+    }
+}

--- a/WrapGod.Tests/RunReportTests.cs
+++ b/WrapGod.Tests/RunReportTests.cs
@@ -1,0 +1,160 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Manifest.Reports;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("Unified run report contract")]
+public sealed class RunReportTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    private static RunReport CreateSampleReport() => new()
+    {
+        SchemaVersion = "1.0",
+        Timestamp = new DateTimeOffset(2026, 3, 27, 12, 0, 0, TimeSpan.Zero),
+        TypesExtracted = 15,
+        WrappersGenerated = 12,
+        DiagnosticsFound = 3,
+        FixesApplied = 2,
+        SourcesResolved =
+        [
+            new ResolvedSource
+            {
+                Name = "Newtonsoft.Json",
+                Version = "13.0.3",
+                SourceType = "nuget"
+            },
+            new ResolvedSource
+            {
+                Name = "Serilog",
+                Version = "4.0.0",
+                SourceType = "nuget"
+            }
+        ],
+        Diagnostics =
+        [
+            new ReportDiagnostic
+            {
+                Code = "WG2001",
+                Severity = "Warning",
+                Message = "Direct usage of JsonConvert detected",
+                File = "Services/DataService.cs"
+            }
+        ]
+    };
+
+    [Scenario("JSON roundtrip preserves all data")]
+    [Fact]
+    public Task JsonRoundtrip() =>
+        Given("a sample run report serialized and deserialized", () =>
+        {
+            var original = CreateSampleReport();
+            var json = RunReportWriter.SerializeJson(original);
+            var deserialized = RunReportReader.Deserialize(json);
+            return (Original: original, Roundtrip: deserialized, Json: json);
+        })
+        .Then("schema version is preserved", r => r.Roundtrip.SchemaVersion == "1.0")
+        .And("timestamp is preserved", r => r.Roundtrip.Timestamp == r.Original.Timestamp)
+        .And("types extracted is preserved", r => r.Roundtrip.TypesExtracted == 15)
+        .And("wrappers generated is preserved", r => r.Roundtrip.WrappersGenerated == 12)
+        .And("diagnostics found is preserved", r => r.Roundtrip.DiagnosticsFound == 3)
+        .And("fixes applied is preserved", r => r.Roundtrip.FixesApplied == 2)
+        .And("sources count is preserved", r => r.Roundtrip.SourcesResolved.Count == 2)
+        .And("first source name is preserved", r =>
+            r.Roundtrip.SourcesResolved[0].Name == "Newtonsoft.Json")
+        .And("diagnostics list is preserved", r => r.Roundtrip.Diagnostics.Count == 1)
+        .And("diagnostic code is preserved", r =>
+            r.Roundtrip.Diagnostics[0].Code == "WG2001")
+        .AssertPassed();
+
+    [Scenario("Text format contains all sections")]
+    [Fact]
+    public Task TextFormat() =>
+        Given("a sample run report formatted as text", () =>
+        {
+            var report = CreateSampleReport();
+            return RunReportWriter.FormatText(report);
+        })
+        .Then("contains header", text => text.Contains("WrapGod Run Report"))
+        .And("contains types extracted", text => text.Contains("Types extracted:    15"))
+        .And("contains wrappers generated", text => text.Contains("Wrappers generated: 12"))
+        .And("contains source name", text => text.Contains("Newtonsoft.Json"))
+        .And("contains diagnostic code", text => text.Contains("WG2001"))
+        .AssertPassed();
+
+    [Scenario("Empty report serializes with defaults")]
+    [Fact]
+    public Task EmptyReport() =>
+        Given("an empty run report", () =>
+        {
+            var report = new RunReport();
+            var json = RunReportWriter.SerializeJson(report);
+            return RunReportReader.Deserialize(json);
+        })
+        .Then("types extracted defaults to 0", r => r.TypesExtracted == 0)
+        .And("wrappers generated defaults to 0", r => r.WrappersGenerated == 0)
+        .And("diagnostics found defaults to 0", r => r.DiagnosticsFound == 0)
+        .And("fixes applied defaults to 0", r => r.FixesApplied == 0)
+        .And("sources list is empty", r => r.SourcesResolved.Count == 0)
+        .And("diagnostics list is empty", r => r.Diagnostics.Count == 0)
+        .AssertPassed();
+
+    [Scenario("File roundtrip via temp file")]
+    [Fact]
+    public Task FileRoundtrip() =>
+        Given("a report written to and read from a temp file", () =>
+        {
+            var original = CreateSampleReport();
+            var path = Path.GetTempFileName();
+            try
+            {
+                RunReportWriter.WriteJsonToFile(original, path);
+                var loaded = RunReportReader.ReadFromFile(path);
+                return (Original: original, Loaded: loaded);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        })
+        .Then("types extracted matches", r => r.Loaded.TypesExtracted == r.Original.TypesExtracted)
+        .And("sources count matches", r =>
+            r.Loaded.SourcesResolved.Count == r.Original.SourcesResolved.Count)
+        .AssertPassed();
+
+    [Scenario("Null arguments throw ArgumentNullException")]
+    [Fact]
+    public Task NullGuards() =>
+        Given("null argument scenarios", () => true)
+        .Then("SerializeJson throws on null", _ =>
+        {
+            try { RunReportWriter.SerializeJson(null!); return false; }
+            catch (ArgumentNullException) { return true; }
+        })
+        .And("WriteJsonToFile throws on null report", _ =>
+        {
+            try { RunReportWriter.WriteJsonToFile(null!, "test.json"); return false; }
+            catch (ArgumentNullException) { return true; }
+        })
+        .And("WriteJsonToFile throws on null path", _ =>
+        {
+            try { RunReportWriter.WriteJsonToFile(new RunReport(), null!); return false; }
+            catch (ArgumentNullException) { return true; }
+        })
+        .And("FormatText throws on null", _ =>
+        {
+            try { RunReportWriter.FormatText(null!); return false; }
+            catch (ArgumentNullException) { return true; }
+        })
+        .And("Deserialize throws on null", _ =>
+        {
+            try { RunReportReader.Deserialize(null!); return false; }
+            catch (ArgumentNullException) { return true; }
+        })
+        .And("ReadFromFile throws on null", _ =>
+        {
+            try { RunReportReader.ReadFromFile(null!); return false; }
+            catch (ArgumentNullException) { return true; }
+        })
+        .AssertPassed();
+}


### PR DESCRIPTION
## Summary
- Adds `RunReport` model capturing pipeline execution outcomes: timestamp, sources, types, wrappers, diagnostics, fixes
- Adds `RunReportWriter` for JSON and human-readable text output
- Adds `RunReportReader` for deserialization
- Adds comprehensive TinyBDD tests: roundtrip, text format, empty defaults, file I/O, null guards

Closes #126

## Test plan
- [x] JSON roundtrip preserves all fields
- [x] Text format contains all sections
- [x] Empty report uses correct defaults
- [x] File roundtrip via temp file works
- [x] Null arguments throw ArgumentNullException

🤖 Generated with [Claude Code](https://claude.com/claude-code)