### PR TITLE
feat(manifest): add migration policy modes

### DIFF
--- a/WrapGod.Abstractions/Config/WrapGodConfigModels.cs
+++ b/WrapGod.Abstractions/Config/WrapGodConfigModels.cs
@@ -6,6 +6,12 @@ namespace WrapGod.Abstractions.Config;
 public sealed class WrapGodConfig
 {
     public List<TypeConfig> Types { get; set; } = new();
+
+    /// <summary>
+    /// Migration policy mode controlling how aggressive code fixes are.
+    /// Defaults to <c>"safe"</c>. Valid values: <c>"safe"</c>, <c>"assisted"</c>, <c>"aggressive"</c>.
+    /// </summary>
+    public string? MigrationPolicy { get; set; }
 }
 
 public sealed class TypeConfig

--- a/WrapGod.Analyzers/UseWrapperCodeFixProvider.cs
+++ b/WrapGod.Analyzers/UseWrapperCodeFixProvider.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -10,6 +12,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using WrapGod.Manifest.Config;
 
 namespace WrapGod.Analyzers;
 
@@ -44,6 +47,9 @@ public sealed class UseWrapperCodeFixProvider : CodeFixProvider
         if (root is null)
             return;
 
+        // Load migration policy from config to respect policy before offering fixes
+        var policy = LoadMigrationPolicy(context.Document.Project);
+
         foreach (var diagnostic in context.Diagnostics)
         {
             var span = diagnostic.Location.SourceSpan;
@@ -51,10 +57,16 @@ public sealed class UseWrapperCodeFixProvider : CodeFixProvider
 
             if (diagnostic.Id == "WG2001")
             {
+                var risk = ClassifyTypeReplacementRisk(node);
+                if (!MigrationPolicyEvaluator.ShouldOfferFix(policy, risk))
+                    continue;
                 RegisterTypeReplacementFix(context, diagnostic, root, node);
             }
             else if (diagnostic.Id == "WG2002")
             {
+                var risk = ClassifyMethodReplacementRisk(node);
+                if (!MigrationPolicyEvaluator.ShouldOfferFix(policy, risk))
+                    continue;
                 RegisterMethodReplacementFix(context, diagnostic, root, node);
             }
         }
@@ -155,6 +167,82 @@ public sealed class UseWrapperCodeFixProvider : CodeFixProvider
     }
 
     // ── Helpers ──────────────────────────────────────────────────────
+
+    // ── Migration policy ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Loads the migration policy from the project's additional config files.
+    /// Defaults to <see cref="MigrationPolicyMode.Safe"/> if no config is found.
+    /// </summary>
+    private static MigrationPolicyMode LoadMigrationPolicy(Project project)
+    {
+        foreach (var doc in project.AdditionalDocuments)
+        {
+            var path = doc.FilePath;
+            if (path is null || !path.EndsWith(".wrapgod.config.json", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            try
+            {
+                var text = doc.GetTextAsync().Result;
+                if (text is null)
+                    continue;
+
+                using var jsonDoc = JsonDocument.Parse(text.ToString());
+                var root = jsonDoc.RootElement;
+
+                if (root.TryGetProperty("migrationPolicy", out var policyProp) ||
+                    root.TryGetProperty("MigrationPolicy", out policyProp))
+                {
+                    var value = policyProp.GetString();
+                    if (string.Equals(value, "assisted", StringComparison.OrdinalIgnoreCase))
+                        return MigrationPolicyMode.Assisted;
+                    if (string.Equals(value, "aggressive", StringComparison.OrdinalIgnoreCase))
+                        return MigrationPolicyMode.Aggressive;
+                }
+            }
+            catch
+            {
+                // Malformed config -- fall through to default
+            }
+        }
+
+        return MigrationPolicyMode.Safe;
+    }
+
+    /// <summary>
+    /// Classifies the risk level of a type replacement fix based on the syntax context.
+    /// </summary>
+    private static FixRiskLevel ClassifyTypeReplacementRisk(SyntaxNode node)
+    {
+        // typeof(T) or reflection patterns are risky
+        if (node.Parent is TypeOfExpressionSyntax)
+            return FixRiskLevel.Risky;
+
+        // Base type / interface implementation is assisted-level
+        if (node.Parent is BaseTypeSyntax)
+            return FixRiskLevel.Assisted;
+
+        // Generic constraints are assisted-level
+        if (node.Parent is TypeConstraintSyntax)
+            return FixRiskLevel.Assisted;
+
+        return FixRiskLevel.Safe;
+    }
+
+    /// <summary>
+    /// Classifies the risk level of a method replacement fix based on the syntax context.
+    /// </summary>
+    private static FixRiskLevel ClassifyMethodReplacementRisk(SyntaxNode node)
+    {
+        // If the member access is inside a nameof(), it's risky
+        if (node.Ancestors().OfType<InvocationExpressionSyntax>().Any(inv =>
+                inv.Expression is IdentifierNameSyntax id && id.Identifier.Text == "nameof"))
+            return FixRiskLevel.Risky;
+
+        // Default method calls are safe
+        return FixRiskLevel.Safe;
+    }
 
     /// <summary>
     /// Extracts a single-quoted argument from the diagnostic message by index.

--- a/WrapGod.Manifest/Config/MigrationPolicy.cs
+++ b/WrapGod.Manifest/Config/MigrationPolicy.cs
@@ -1,0 +1,64 @@
+namespace WrapGod.Manifest.Config;
+
+/// <summary>
+/// Controls the aggressiveness of automatic code fix suggestions during migration.
+/// </summary>
+public enum MigrationPolicyMode
+{
+    /// <summary>
+    /// Only offer deterministic, safe rewrites (type replacements where the wrapper
+    /// is a drop-in substitute). Never offers risky or ambiguous fixes.
+    /// </summary>
+    Safe = 0,
+
+    /// <summary>
+    /// Offer safe auto-fixes plus suggest manual review items. Shows diagnostic
+    /// hints for patterns that could be migrated with human oversight.
+    /// </summary>
+    Assisted = 1,
+
+    /// <summary>
+    /// Offer all auto-fixes including risky ones (reflection, dynamic dispatch,
+    /// complex generic constructions). Use with caution.
+    /// </summary>
+    Aggressive = 2,
+}
+
+/// <summary>
+/// Evaluates whether a code fix should be offered based on the active migration policy.
+/// </summary>
+public static class MigrationPolicyEvaluator
+{
+    /// <summary>
+    /// Determines whether a code fix with the given risk level should be offered
+    /// under the specified policy.
+    /// </summary>
+    /// <param name="policy">The active migration policy mode.</param>
+    /// <param name="fixRisk">The risk classification of the proposed fix.</param>
+    /// <returns><c>true</c> if the fix should be offered; otherwise <c>false</c>.</returns>
+    public static bool ShouldOfferFix(MigrationPolicyMode policy, FixRiskLevel fixRisk)
+    {
+        return policy switch
+        {
+            MigrationPolicyMode.Safe => fixRisk == FixRiskLevel.Safe,
+            MigrationPolicyMode.Assisted => fixRisk <= FixRiskLevel.Assisted,
+            MigrationPolicyMode.Aggressive => true,
+            _ => fixRisk == FixRiskLevel.Safe,
+        };
+    }
+}
+
+/// <summary>
+/// Risk classification for a code fix action.
+/// </summary>
+public enum FixRiskLevel
+{
+    /// <summary>Deterministic, safe rewrite with no behavioral change.</summary>
+    Safe = 0,
+
+    /// <summary>Likely safe but may need manual review in edge cases.</summary>
+    Assisted = 1,
+
+    /// <summary>Risky rewrite that may change behavior (reflection, dynamic, etc.).</summary>
+    Risky = 2,
+}

--- a/WrapGod.Tests/MigrationPolicyTests.cs
+++ b/WrapGod.Tests/MigrationPolicyTests.cs
@@ -1,0 +1,86 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Manifest.Config;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("Migration policy modes control code fix aggressiveness")]
+public sealed class MigrationPolicyTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    [Scenario("Safe policy only allows safe fixes")]
+    [Fact]
+    public Task SafePolicyOnlySafe() =>
+        Given("safe migration policy", () => MigrationPolicyMode.Safe)
+        .Then("allows safe fixes", policy =>
+            MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Safe))
+        .And("rejects assisted fixes", policy =>
+            !MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Assisted))
+        .And("rejects risky fixes", policy =>
+            !MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Risky))
+        .AssertPassed();
+
+    [Scenario("Assisted policy allows safe and assisted fixes")]
+    [Fact]
+    public Task AssistedPolicyAllowsSafeAndAssisted() =>
+        Given("assisted migration policy", () => MigrationPolicyMode.Assisted)
+        .Then("allows safe fixes", policy =>
+            MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Safe))
+        .And("allows assisted fixes", policy =>
+            MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Assisted))
+        .And("rejects risky fixes", policy =>
+            !MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Risky))
+        .AssertPassed();
+
+    [Scenario("Aggressive policy allows all fixes")]
+    [Fact]
+    public Task AggressivePolicyAllowsAll() =>
+        Given("aggressive migration policy", () => MigrationPolicyMode.Aggressive)
+        .Then("allows safe fixes", policy =>
+            MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Safe))
+        .And("allows assisted fixes", policy =>
+            MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Assisted))
+        .And("allows risky fixes", policy =>
+            MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Risky))
+        .AssertPassed();
+
+    [Scenario("Unknown policy defaults to safe behavior")]
+    [Fact]
+    public Task UnknownPolicyDefaultsToSafe() =>
+        Given("an unknown policy value cast to enum", () => (MigrationPolicyMode)99)
+        .Then("allows safe fixes", policy =>
+            MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Safe))
+        .And("rejects assisted fixes", policy =>
+            !MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Assisted))
+        .And("rejects risky fixes", policy =>
+            !MigrationPolicyEvaluator.ShouldOfferFix(policy, FixRiskLevel.Risky))
+        .AssertPassed();
+
+    [Scenario("WrapGodConfig accepts migration policy string")]
+    [Fact]
+    public Task ConfigAcceptsMigrationPolicy() =>
+        Given("a WrapGodConfig with migration policy set", () =>
+        {
+            var config = new WrapGodConfig { MigrationPolicy = "aggressive" };
+            return config;
+        })
+        .Then("policy property is set", config =>
+            config.MigrationPolicy == "aggressive")
+        .AssertPassed();
+
+    [Scenario("WrapGodConfig migration policy defaults to null")]
+    [Fact]
+    public Task ConfigPolicyDefaultsToNull() =>
+        Given("a default WrapGodConfig", () => new WrapGodConfig())
+        .Then("policy is null by default", config =>
+            config.MigrationPolicy is null)
+        .AssertPassed();
+
+    [Scenario("FixRiskLevel enum values are ordered by risk")]
+    [Fact]
+    public Task FixRiskLevelOrdering() =>
+        Given("fix risk level enum values", () => true)
+        .Then("Safe < Assisted", _ => FixRiskLevel.Safe < FixRiskLevel.Assisted)
+        .And("Assisted < Risky", _ => FixRiskLevel.Assisted < FixRiskLevel.Risky)
+        .AssertPassed();
+}


### PR DESCRIPTION
## Summary
- Adds `MigrationPolicyMode` enum: Safe (deterministic only), Assisted (auto-fix + suggest manual), Aggressive (everything)
- Adds `MigrationPolicyEvaluator` to gate code fixes by risk level
- Adds `MigrationPolicy` property to `WrapGodConfig`
- Updates `UseWrapperCodeFixProvider` to classify fix risk (safe/assisted/risky) and respect the active policy
- Adds 7 TinyBDD tests covering all policy modes, defaults, ordering, and config integration

Closes #132

## Test plan
- [x] Safe policy only allows safe fixes
- [x] Assisted policy allows safe + assisted
- [x] Aggressive policy allows all
- [x] Unknown policy defaults to safe
- [x] Config accepts migration policy string
- [x] Config defaults to null
- [x] FixRiskLevel ordering is correct
- [x] Full test suite (426 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)