### PR TITLE
feat(targets): add MSBuild targets for zero-touch pipeline

### DIFF
--- a/WrapGod.Targets/WrapGod.Targets.csproj
+++ b/WrapGod.Targets/WrapGod.Targets.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+
+    <PackageId>WrapGod.Targets</PackageId>
+    <Description>MSBuild props and targets for zero-touch WrapGod build integration. Automatically restores, extracts manifests, and feeds source generators during build.</Description>
+    <PackageTags>wrapgod;msbuild;codegen;source-generator;build-automation</PackageTags>
+    <DevelopmentDependency>true</DevelopmentDependency>
+  </PropertyGroup>
+
+  <!-- Package the .props and .targets files for NuGet distribution -->
+  <ItemGroup>
+    <None Include="build\WrapGod.Targets.props" Pack="true" PackagePath="build\" />
+    <None Include="build\WrapGod.Targets.targets" Pack="true" PackagePath="build\" />
+    <None Include="WrapGod.props" Pack="true" PackagePath="build\" />
+    <None Include="WrapGod.targets" Pack="true" PackagePath="build\" />
+  </ItemGroup>
+
+</Project>

--- a/WrapGod.Targets/WrapGod.props
+++ b/WrapGod.Targets/WrapGod.props
@@ -1,0 +1,22 @@
+<Project>
+  <!--
+    WrapGod.props — Default property definitions for WrapGod build integration.
+    Imported early so consuming projects can override values.
+  -->
+  <PropertyGroup>
+    <!-- Path to the WrapGod manifest file (*.wrapgod.json) -->
+    <WrapGodManifestPath Condition="'$(WrapGodManifestPath)' == ''">$(MSBuildProjectDirectory)\manifest.wrapgod.json</WrapGodManifestPath>
+
+    <!-- Path to the WrapGod configuration file -->
+    <WrapGodConfigPath Condition="'$(WrapGodConfigPath)' == ''">$(MSBuildProjectDirectory)\wrapgod.config.json</WrapGodConfigPath>
+
+    <!-- Directory used for caching resolved packages and intermediate artifacts -->
+    <WrapGodCacheDir Condition="'$(WrapGodCacheDir)' == ''">$(MSBuildProjectDirectory)\.wrapgod-cache</WrapGodCacheDir>
+
+    <!-- Enables/disables WrapGod build integration (default: true when WrapGodPackage items exist) -->
+    <EnableWrapGod Condition="'$(EnableWrapGod)' == ''">true</EnableWrapGod>
+
+    <!-- Hash file used for incremental build checks -->
+    <_WrapGodHashFile>$(WrapGodCacheDir)\wrapgod-inputs.hash</_WrapGodHashFile>
+  </PropertyGroup>
+</Project>

--- a/WrapGod.Targets/WrapGod.targets
+++ b/WrapGod.Targets/WrapGod.targets
@@ -1,0 +1,108 @@
+<Project>
+  <!--
+    WrapGod.targets — MSBuild targets for zero-touch WrapGod pipeline integration.
+    Provides restore, extract, and generate steps that run automatically during build.
+  -->
+
+  <!-- ============================================================
+       WrapGodRestore — Resolves NuGet packages listed as WrapGodPackage items.
+       Runs before the standard Restore target.
+       ============================================================ -->
+  <Target Name="WrapGodRestore"
+          BeforeTargets="Restore"
+          Condition="'$(EnableWrapGod)' == 'true' AND '@(WrapGodPackage)' != ''">
+
+    <Message Importance="normal" Text="WrapGod: Resolving packages for wrapping..." />
+
+    <!-- Ensure cache directory exists -->
+    <MakeDir Directories="$(WrapGodCacheDir)" Condition="!Exists('$(WrapGodCacheDir)')" />
+
+    <!-- Resolve each WrapGodPackage to a local path via dotnet restore -->
+    <Exec Command="dotnet restore &quot;$(MSBuildProjectFullPath)&quot; --packages &quot;$(WrapGodCacheDir)\packages&quot;"
+          WorkingDirectory="$(MSBuildProjectDirectory)"
+          StandardOutputImportance="low"
+          StandardErrorImportance="high"
+          IgnoreExitCode="false" />
+
+    <Message Importance="normal" Text="WrapGod: Package resolution complete." />
+  </Target>
+
+  <!-- ============================================================
+       WrapGodExtract — Extracts manifests from resolved assemblies.
+       Runs before CoreCompile so generated code is available for compilation.
+       Uses incremental build: skips if inputs haven't changed.
+       ============================================================ -->
+  <Target Name="WrapGodExtract"
+          BeforeTargets="CoreCompile"
+          DependsOnTargets="WrapGodRestore"
+          Condition="'$(EnableWrapGod)' == 'true' AND '@(WrapGodPackage)' != ''"
+          Inputs="@(WrapGodPackage);$(WrapGodConfigPath)"
+          Outputs="$(WrapGodManifestPath);$(_WrapGodHashFile)">
+
+    <Message Importance="normal" Text="WrapGod: Extracting manifest from resolved assemblies..." />
+
+    <!-- Build list of assembly paths from resolved packages -->
+    <ItemGroup>
+      <_WrapGodResolvedAssembly Include="$(WrapGodCacheDir)\packages\**\lib\**\%(WrapGodPackage.Identity).dll" />
+    </ItemGroup>
+
+    <!-- Compute a hash of inputs to detect changes -->
+    <Hash ItemsToHash="@(_WrapGodResolvedAssembly);$(WrapGodConfigPath)">
+      <Output TaskParameter="HashResult" PropertyName="_WrapGodCurrentHash" />
+    </Hash>
+
+    <!-- Read the previous hash if it exists -->
+    <ReadLinesFromFile File="$(_WrapGodHashFile)" Condition="Exists('$(_WrapGodHashFile)')">
+      <Output TaskParameter="Lines" PropertyName="_WrapGodPreviousHash" />
+    </ReadLinesFromFile>
+
+    <!-- Only extract if the hash has changed -->
+    <Exec Command="dotnet wrap-god extract &quot;@(_WrapGodResolvedAssembly)&quot; --config &quot;$(WrapGodConfigPath)&quot; --output &quot;$(WrapGodManifestPath)&quot;"
+          WorkingDirectory="$(MSBuildProjectDirectory)"
+          StandardOutputImportance="low"
+          StandardErrorImportance="high"
+          IgnoreExitCode="false"
+          Condition="'$(_WrapGodCurrentHash)' != '$(_WrapGodPreviousHash)'" />
+
+    <!-- Write the new hash -->
+    <WriteLinesToFile File="$(_WrapGodHashFile)"
+                     Lines="$(_WrapGodCurrentHash)"
+                     Overwrite="true"
+                     Condition="'$(_WrapGodCurrentHash)' != '$(_WrapGodPreviousHash)'" />
+
+    <Message Importance="normal" Text="WrapGod: Manifest extraction complete." />
+  </Target>
+
+  <!-- ============================================================
+       WrapGodGenerate — Feeds manifest + config as AdditionalFiles
+       so the Roslyn source generator can pick them up.
+       ============================================================ -->
+  <Target Name="WrapGodGenerate"
+          BeforeTargets="CoreCompile"
+          DependsOnTargets="WrapGodExtract"
+          Condition="'$(EnableWrapGod)' == 'true'">
+
+    <Message Importance="normal" Text="WrapGod: Registering manifest and config as AdditionalFiles..." />
+
+    <!-- Add manifest as an AdditionalFile for the source generator -->
+    <ItemGroup Condition="Exists('$(WrapGodManifestPath)')">
+      <AdditionalFiles Include="$(WrapGodManifestPath)" />
+    </ItemGroup>
+
+    <!-- Add config as an AdditionalFile for the source generator -->
+    <ItemGroup Condition="Exists('$(WrapGodConfigPath)')">
+      <AdditionalFiles Include="$(WrapGodConfigPath)" />
+    </ItemGroup>
+
+    <Message Importance="normal" Text="WrapGod: AdditionalFiles registered. Source generator will run during compile." />
+  </Target>
+
+  <!-- ============================================================
+       Clean integration — remove cached artifacts on Clean
+       ============================================================ -->
+  <Target Name="WrapGodClean" AfterTargets="Clean" Condition="'$(EnableWrapGod)' == 'true'">
+    <RemoveDir Directories="$(WrapGodCacheDir)" Condition="Exists('$(WrapGodCacheDir)')" />
+    <Message Importance="normal" Text="WrapGod: Cache cleaned." />
+  </Target>
+
+</Project>

--- a/WrapGod.Targets/build/WrapGod.Targets.props
+++ b/WrapGod.Targets/build/WrapGod.Targets.props
@@ -1,0 +1,7 @@
+<Project>
+  <!--
+    WrapGod.Targets.props — Auto-imported when the WrapGod.Targets NuGet package
+    is referenced. Delegates to the main WrapGod.props file.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)..\WrapGod.props" />
+</Project>

--- a/WrapGod.Targets/build/WrapGod.Targets.targets
+++ b/WrapGod.Targets/build/WrapGod.Targets.targets
@@ -1,0 +1,7 @@
+<Project>
+  <!--
+    WrapGod.Targets.targets — Auto-imported when the WrapGod.Targets NuGet package
+    is referenced. Delegates to the main WrapGod.targets file.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)..\WrapGod.targets" />
+</Project>

--- a/WrapGod.slnx
+++ b/WrapGod.slnx
@@ -10,4 +10,5 @@
   <Project Path="WrapGod.TypeMap/WrapGod.TypeMap.csproj" />
   <Project Path="WrapGod.Cli/WrapGod.Cli.csproj" />
   <Project Path="WrapGod.Benchmarks/WrapGod.Benchmarks.csproj" />
+  <Project Path="WrapGod.Targets/WrapGod.Targets.csproj" />
 </Solution>

--- a/docs/MSBUILD-INTEGRATION.md
+++ b/docs/MSBUILD-INTEGRATION.md
@@ -1,0 +1,59 @@
+# MSBuild Integration
+
+WrapGod ships an MSBuild targets package (`WrapGod.Targets`) that automates the
+extract-and-generate pipeline so consuming projects need zero manual build steps.
+
+## Quick Start
+
+Add the NuGet package and declare the packages you want to wrap:
+
+```xml
+<PackageReference Include="WrapGod.Targets" Version="0.1.0-alpha" PrivateAssets="all" />
+```
+
+Then declare the packages to wrap as `WrapGodPackage` items:
+
+```xml
+<ItemGroup>
+  <WrapGodPackage Include="SomeVendor.Lib" />
+</ItemGroup>
+```
+
+Build as normal -- the targets handle everything automatically.
+
+## How It Works
+
+The package injects three MSBuild targets into the build pipeline:
+
+| Target             | Runs Before    | Purpose |
+|--------------------|----------------|---------|
+| `WrapGodRestore`   | `Restore`      | Resolves NuGet packages listed as `WrapGodPackage` items into the local cache. |
+| `WrapGodExtract`   | `CoreCompile`  | Extracts the API manifest from resolved assemblies. Incremental -- skips if inputs are unchanged. |
+| `WrapGodGenerate`  | `CoreCompile`  | Registers the manifest and config as `AdditionalFiles` so the Roslyn source generator picks them up. |
+
+A `WrapGodClean` target also runs after `Clean` to remove cached artifacts.
+
+## Properties
+
+All properties have sensible defaults. Override them in your project file if needed:
+
+| Property               | Default                                    | Description |
+|------------------------|--------------------------------------------|-------------|
+| `WrapGodManifestPath`  | `$(MSBuildProjectDirectory)\manifest.wrapgod.json` | Path to the generated manifest file. |
+| `WrapGodConfigPath`    | `$(MSBuildProjectDirectory)\wrapgod.config.json`   | Path to the WrapGod configuration file. |
+| `WrapGodCacheDir`      | `$(MSBuildProjectDirectory)\.wrapgod-cache`        | Directory for cached packages and intermediate artifacts. |
+| `EnableWrapGod`        | `true`                                     | Set to `false` to disable all WrapGod targets. |
+
+## Incremental Builds
+
+The `WrapGodExtract` target hashes its inputs (resolved assemblies + config file)
+and compares against a stored hash in the cache directory. Extraction only runs
+when inputs have actually changed, keeping rebuilds fast.
+
+## Troubleshooting
+
+- **Targets not running?** Ensure `WrapGodPackage` items are declared and
+  `EnableWrapGod` is not set to `false`.
+- **Stale output?** Run `dotnet clean` to clear the WrapGod cache, then rebuild.
+- **Custom tool path?** The extract step invokes `dotnet wrap-god` via the
+  global tool. Ensure it is installed: `dotnet tool install -g WrapGod.Cli`.


### PR DESCRIPTION
## Summary
- Add `WrapGod.Targets/` project with MSBuild `.props` and `.targets` files that automate the restore/extract/generate pipeline during build
- Three targets: `WrapGodRestore` (before Restore), `WrapGodExtract` (before CoreCompile, incremental via input hashing), `WrapGodGenerate` (registers AdditionalFiles for the source generator)
- NuGet-distributable via `build/` folder convention with packable csproj
- Documentation in `docs/MSBUILD-INTEGRATION.md`

Closes #125

## Test plan
- [x] Solution builds cleanly (`dotnet build WrapGod.slnx --nologo -c Release`)
- [ ] Verify targets fire correctly in a consuming project with `WrapGodPackage` items
- [ ] Verify incremental build skips extraction when inputs are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)