### PR TITLE
feat(cli): add CI bootstrap and parity report commands

### DIFF
--- a/WrapGod.Cli/CiBootstrapCommand.cs
+++ b/WrapGod.Cli/CiBootstrapCommand.cs
@@ -1,0 +1,126 @@
+using System.CommandLine;
+
+namespace WrapGod.Cli;
+
+internal static class CiBootstrapCommand
+{
+    public static Command Create()
+    {
+        var outputDirOption = new Option<DirectoryInfo>(
+            ["--output", "-o"],
+            () => new DirectoryInfo(Path.Combine(Directory.GetCurrentDirectory(), ".github", "workflows")),
+            "Output directory for generated workflow files");
+
+        var forceOption = new Option<bool>(
+            "--force",
+            "Overwrite existing workflow files");
+
+        var command = new Command("bootstrap", "Generate recommended CI workflow files for a WrapGod project")
+        {
+            outputDirOption,
+            forceOption
+        };
+
+        command.SetHandler((DirectoryInfo outputDir, bool force) =>
+        {
+            Environment.ExitCode = Handle(outputDir, force);
+        }, outputDirOption, forceOption);
+
+        return command;
+    }
+
+    private static int Handle(DirectoryInfo outputDir, bool force)
+    {
+        Console.WriteLine("WrapGod CI Bootstrap");
+        Console.WriteLine(new string('-', 40));
+        Console.WriteLine();
+
+        if (!outputDir.Exists)
+        {
+            outputDir.Create();
+            Console.WriteLine($"Created directory: {outputDir.FullName}");
+        }
+
+        var workflowPath = Path.Combine(outputDir.FullName, "wrapgod-ci.yml");
+
+        if (File.Exists(workflowPath) && !force)
+        {
+            Console.Error.WriteLine($"Workflow file already exists: {workflowPath}");
+            Console.Error.WriteLine("Use --force to overwrite.");
+            return 1;
+        }
+
+        var yaml = GenerateWorkflowYaml();
+        File.WriteAllText(workflowPath, yaml);
+
+        Console.WriteLine($"Generated: {workflowPath}");
+        Console.WriteLine();
+        Console.WriteLine("The workflow includes:");
+        Console.WriteLine("  - Build and test with coverage");
+        Console.WriteLine("  - WrapGod extract step");
+        Console.WriteLine("  - WrapGod generate step");
+        Console.WriteLine("  - WrapGod analyze step (diagnostic gate)");
+        Console.WriteLine();
+        Console.WriteLine("Next steps:");
+        Console.WriteLine("  1. Review the generated workflow file");
+        Console.WriteLine("  2. Commit and push to enable CI");
+        Console.WriteLine("  3. Run 'wrap-god ci parity' to verify alignment");
+
+        return 0;
+    }
+
+    internal static string GenerateWorkflowYaml()
+    {
+        return """
+               name: WrapGod CI
+
+               on:
+                 push:
+                   branches: [ main ]
+                 pull_request:
+                   branches: [ main ]
+
+               jobs:
+                 build-test:
+                   runs-on: ubuntu-latest
+
+                   steps:
+                     - name: Checkout
+                       uses: actions/checkout@v4
+
+                     - name: Setup .NET
+                       uses: actions/setup-dotnet@v4
+                       with:
+                         dotnet-version: '10.0.x'
+
+                     - name: Restore
+                       run: dotnet restore
+
+                     - name: Build
+                       run: dotnet build --configuration Release --no-restore
+
+                     - name: Test with Coverage
+                       run: |
+                         dotnet test --configuration Release --no-build \
+                           --collect:"XPlat Code Coverage" \
+                           --results-directory TestResults
+
+                     - name: WrapGod Extract
+                       run: dotnet wrap-god extract --output manifest.wrapgod.json
+
+                     - name: WrapGod Generate
+                       run: dotnet wrap-god generate manifest.wrapgod.json
+
+                     - name: WrapGod Analyze
+                       run: dotnet wrap-god analyze manifest.wrapgod.json --warnings-as-errors
+
+                     - name: Upload Coverage
+                       uses: actions/upload-artifact@v4
+                       if: always()
+                       with:
+                         name: coverage-report
+                         path: TestResults/**/coverage.cobertura.xml
+                         retention-days: 14
+               """;
+    }
+}

--- a/WrapGod.Cli/CiParityReportCommand.cs
+++ b/WrapGod.Cli/CiParityReportCommand.cs
@@ -1,0 +1,137 @@
+using System.CommandLine;
+
+namespace WrapGod.Cli;
+
+internal static class CiParityReportCommand
+{
+    /// <summary>
+    /// Required steps that the recommended WrapGod CI workflow should contain.
+    /// Each entry is a key phrase expected to appear in the workflow YAML.
+    /// </summary>
+    private static readonly (string Id, string Description, string SearchPattern)[] BaselineSteps =
+    [
+        ("checkout", "Checkout repository", "actions/checkout"),
+        ("setup-dotnet", "Setup .NET SDK", "actions/setup-dotnet"),
+        ("restore", "Restore NuGet packages", "dotnet restore"),
+        ("build", "Build solution", "dotnet build"),
+        ("test", "Run tests", "dotnet test"),
+        ("coverage", "Collect code coverage", "XPlat Code Coverage"),
+        ("wg-extract", "WrapGod extract step", "wrap-god extract"),
+        ("wg-generate", "WrapGod generate step", "wrap-god generate"),
+        ("wg-analyze", "WrapGod analyze step", "wrap-god analyze"),
+    ];
+
+    public static Command Create()
+    {
+        var workflowDirOption = new Option<DirectoryInfo>(
+            ["--workflow-dir", "-w"],
+            () => new DirectoryInfo(Path.Combine(Directory.GetCurrentDirectory(), ".github", "workflows")),
+            "Directory containing CI workflow files");
+
+        var command = new Command("parity", "Compare current CI config against the recommended WrapGod baseline")
+        {
+            workflowDirOption
+        };
+
+        command.SetHandler((DirectoryInfo workflowDir) =>
+        {
+            Environment.ExitCode = Handle(workflowDir);
+        }, workflowDirOption);
+
+        return command;
+    }
+
+    private static int Handle(DirectoryInfo workflowDir)
+    {
+        Console.WriteLine("WrapGod CI Parity Report");
+        Console.WriteLine(new string('-', 40));
+        Console.WriteLine();
+
+        if (!workflowDir.Exists)
+        {
+            Console.Error.WriteLine($"Workflow directory not found: {workflowDir.FullName}");
+            Console.Error.WriteLine("Run 'wrap-god ci bootstrap' to generate workflow files.");
+            return 1;
+        }
+
+        var yamlFiles = workflowDir.GetFiles("*.yml")
+            .Concat(workflowDir.GetFiles("*.yaml"))
+            .ToArray();
+
+        if (yamlFiles.Length == 0)
+        {
+            Console.Error.WriteLine("No workflow files (*.yml, *.yaml) found.");
+            Console.Error.WriteLine("Run 'wrap-god ci bootstrap' to generate workflow files.");
+            return 1;
+        }
+
+        Console.WriteLine($"Scanning {yamlFiles.Length} workflow file(s) in {workflowDir.FullName}");
+        Console.WriteLine();
+
+        // Read all workflow content
+        var allContent = string.Join(
+            Environment.NewLine,
+            yamlFiles.Select(f => File.ReadAllText(f.FullName)));
+
+        var missing = new List<(string Id, string Description)>();
+        var found = new List<(string Id, string Description)>();
+
+        foreach (var (id, description, pattern) in BaselineSteps)
+        {
+            if (allContent.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+            {
+                found.Add((id, description));
+            }
+            else
+            {
+                missing.Add((id, description));
+            }
+        }
+
+        // Report found steps
+        Console.WriteLine("Baseline steps found:");
+        if (found.Count == 0)
+        {
+            Console.WriteLine("  (none)");
+        }
+        else
+        {
+            foreach (var (id, description) in found)
+            {
+                Console.WriteLine($"  [PASS] {description} ({id})");
+            }
+        }
+
+        Console.WriteLine();
+
+        // Report missing steps
+        Console.WriteLine("Missing or outdated steps:");
+        if (missing.Count == 0)
+        {
+            Console.WriteLine("  (none -- full parity!)");
+        }
+        else
+        {
+            foreach (var (id, description) in missing)
+            {
+                Console.WriteLine($"  [MISS] {description} ({id})");
+            }
+        }
+
+        Console.WriteLine();
+
+        // Summary
+        var total = BaselineSteps.Length;
+        var pct = found.Count * 100 / total;
+        Console.WriteLine($"Parity: {found.Count}/{total} steps ({pct}%)");
+
+        if (missing.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Run 'wrap-god ci bootstrap --force' to regenerate the recommended workflow.");
+            return 2;
+        }
+
+        return 0;
+    }
+}

--- a/WrapGod.Cli/Program.cs
+++ b/WrapGod.Cli/Program.cs
@@ -1,6 +1,12 @@
 using System.CommandLine;
 using WrapGod.Cli;
 
+var ciCommand = new Command("ci", "CI/CD workflow tools")
+{
+    CiBootstrapCommand.Create(),
+    CiParityReportCommand.Create()
+};
+
 var rootCommand = new RootCommand("WrapGod CLI -- extract manifests, generate wrappers, and analyze migrations")
 {
     InitCommand.Create(),
@@ -9,7 +15,8 @@ var rootCommand = new RootCommand("WrapGod CLI -- extract manifests, generate wr
     AnalyzeCommand.Create(),
     DoctorCommand.Create(),
     ExplainCommand.Create(),
-    MigrateInitCommand.Create()
+    MigrateInitCommand.Create(),
+    ciCommand
 };
 
 return await rootCommand.InvokeAsync(args);


### PR DESCRIPTION
## Summary
- Add `wrap-god ci bootstrap` command that generates a recommended GitHub Actions workflow YAML with build, test, coverage, and WrapGod-specific steps (extract, generate, analyze)
- Add `wrap-god ci parity` command that compares existing CI workflow files against the recommended baseline and reports missing/outdated steps with a parity percentage

Closes #131

## Test plan
- [x] Solution builds cleanly (`dotnet build WrapGod.slnx --nologo -c Release`)
- [ ] Run `wrap-god ci bootstrap` and verify generated YAML
- [ ] Run `wrap-god ci parity` against a project with/without WrapGod CI steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)