### PR TITLE
feat(examples): add MediatR generic-heavy version-matrix pack (#167)

### DIFF
--- a/examples/migrations/nuget-version-matrix/mediatr/README.md
+++ b/examples/migrations/nuget-version-matrix/mediatr/README.md
@@ -1,0 +1,104 @@
+# MediatR Version-Matrix Example
+
+Demonstrates how WrapGod handles API drift across different versions of [MediatR](https://github.com/jbogard/MediatR), the most popular .NET mediator/CQRS library -- specifically focusing on **generic parameter changes** across major versions.
+
+## Why This Matters
+
+MediatR is heavily generic: `IRequest<TResponse>`, `IRequestHandler<TRequest, TResponse>`, `IPipelineBehavior<TRequest, TResponse>`, `IStreamRequest<TResponse>`, and more. Between v10, v11, and v12, the library underwent significant generic API changes:
+
+- **Constraint tightening** (v10): Pipeline behaviors gained strict `where TRequest : IRequest<TResponse>` constraints
+- **Signature normalization** (v11): CancellationToken parameter position standardized per CA1068
+- **Constraint relaxation** (v12): All strict constraints replaced with `where TRequest : notnull`
+- **Hierarchy restructuring** (v12): `IRequest` decoupled from `IRequest<Unit>`, void handlers return `Task` instead of `Task<Unit>`
+
+These changes break wrapper generation strategies that assume stable generic signatures. WrapGod solves this by generating version-aware wrappers from per-version manifests.
+
+## Versions Covered
+
+| Version | Era | Key Generic Changes |
+|---------|-----|---------------------|
+| **10.0** | 2022 -- streaming era | Strict `IRequest<TResponse>` constraints on pipelines, `IStreamRequest<TResponse>` introduced with covariant `out TResponse`, contracts moved to separate package |
+| **11.0** | 2022 -- normalization | CancellationToken moved to last parameter in pipeline behaviors (CA1068), strict constraints retained |
+| **12.0** | 2023 -- simplification | All constraints relaxed to `notnull`, `IRequest` decoupled from `IRequest<Unit>`, void handlers return `Task` directly, `INotificationPublisher` added |
+
+## Directory Structure
+
+```
+mediatr/
+  v10/manifest.wrapgod.json          # API surface for MediatR 10.0.1
+  v11/manifest.wrapgod.json          # API surface for MediatR 11.1.0
+  v12/manifest.wrapgod.json          # API surface for MediatR 12.2.0
+  strategies/
+    lcd.wrapgod.config.json           # Lowest Common Denominator (v10 baseline)
+    targeted-v12.wrapgod.config.json  # Full v12 surface
+    adaptive.wrapgod.config.json      # Tier-based with preprocessor gates
+  diff-report.md                      # Detailed API delta analysis
+  SampleTests/
+    VersionMatrixTests.cs             # Patterns showing per-version differences
+```
+
+## Strategies
+
+### LCD (Lowest Common Denominator)
+
+Generates wrappers using only APIs compatible with **all** targeted versions (>= v10). Uses the most restrictive generic constraints:
+
+- Pipeline behaviors constrained to `where TRequest : IRequest<TResponse>` (v10/v11 strict)
+- Void handlers return `Task<Unit>` (v10/v11 pattern)
+- Pre/post processors constrained to `where TRequest : IBaseRequest`
+- No `INotificationPublisher` (v12-only)
+- No open-generic pipeline registration support
+
+### Targeted v12
+
+Generates wrappers with the **complete** v12 API surface. Recommended for greenfield projects:
+
+- All constraints relaxed to `notnull` -- enables open-generic pipeline registration
+- Void handlers return `Task` directly -- no Unit ceremony
+- `INotificationPublisher` included for custom dispatch strategies
+- NOT backward-compatible with v10/v11
+
+### Adaptive
+
+Generates wrappers with **compile-time version detection** using preprocessor directives:
+
+```
+Tier: baseline (>= v10)              -- Core CQRS with strict constraints
+Tier: streaming (>= v10)             -- IStreamRequest, IStreamRequestHandler
+Tier: relaxed-constraints (>= v12)   -- notnull constraints, open-generic pipelines
+Tier: void-simplification (>= v12)   -- Task-returning void handlers
+Tier: notification-publishers (>= v12) -- INotificationPublisher, custom dispatch
+```
+
+## Key API Deltas
+
+See [diff-report.md](diff-report.md) for the full analysis. Highlights:
+
+1. **Pipeline behavior constraints** -- Evolved from strict `IRequest<TResponse>` (v10/v11) to relaxed `notnull` (v12), fundamentally changing DI registration patterns
+2. **Void handler return type** -- `Task<Unit>` (v10/v11) to `Task` (v12), with `IRequest` decoupled from `IRequest<Unit>` hierarchy
+3. **Handler constraint relaxation** -- Every handler and processor interface had its `TRequest` constraint loosened in v12
+4. **Streaming constraint evolution** -- `IStreamRequest<TResponse>` constraint (v10/v11) relaxed to `notnull` (v12)
+5. **CancellationToken normalization** -- Parameter position standardized to last in v11 pipeline behaviors
+6. **Custom notification publishers** -- v12 added `INotificationPublisher` as a new extension point
+7. **Package consolidation** -- v12 merged contracts and DI packages into main MediatR package
+
+## How WrapGod Uses This
+
+```
+1. Load manifests:  v10/manifest.wrapgod.json
+                    v11/manifest.wrapgod.json
+                    v12/manifest.wrapgod.json
+
+2. Apply strategy:  strategies/lcd.wrapgod.config.json
+                    -- OR --
+                    strategies/adaptive.wrapgod.config.json
+
+3. Generate:        IMediatRWrapper interface + implementation
+                    with version-appropriate generic constraints
+```
+
+The generated wrapper insulates consuming code from version-specific generic signatures. A shared library can safely reference the wrapper whether the consuming project uses MediatR v10 or v12 -- the wrapper emits the correct constraints, return types, and interface hierarchy for the target version.
+
+### Generic-Specific Value
+
+Unlike the Moq example (which focuses on feature additions/removals), MediatR demonstrates WrapGod's handling of **generic parameter drift**: the same interfaces exist across all versions but with different constraints, variance annotations, and type hierarchies. This is the harder problem for source generators because the type structure changes, not just the member list.

--- a/examples/migrations/nuget-version-matrix/mediatr/SampleTests/VersionMatrixTests.cs
+++ b/examples/migrations/nuget-version-matrix/mediatr/SampleTests/VersionMatrixTests.cs
@@ -1,0 +1,255 @@
+// VersionMatrixTests.cs
+// Demonstrates MediatR patterns that differ across v10, v11, and v12.
+// This file is illustrative -- it does not compile standalone (no .csproj).
+// Focus: generic parameter changes, constraint differences, and handler signatures.
+
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WrapGod.Examples.MediatR.VersionMatrix;
+
+// =============================================================================
+// Common types used across all version examples
+// =============================================================================
+
+public record GetUserQuery(int Id) : IRequest<UserDto>;
+public record UserDto(int Id, string Name, string Email);
+
+public record CreateUserCommand(string Name, string Email) : IRequest<int>;
+
+public record UserCreatedNotification(int UserId, string Name) : INotification;
+
+// =============================================================================
+// PATTERN 1: Void request handler -- Unit vs Task return type
+// v10/v11: IRequestHandler<TRequest> returns Task<Unit>, inherits IRequestHandler<TRequest, Unit>
+// v12: IRequestHandler<TRequest> returns Task directly, standalone interface
+// =============================================================================
+
+#if MEDIATR_V12
+// v12 pattern: Task-returning void handler
+public record DeleteUserCommand(int Id) : IRequest;  // IRequest inherits IBaseRequest directly
+
+public class DeleteUserHandler : IRequestHandler<DeleteUserCommand>
+{
+    public async Task Handle(DeleteUserCommand request, CancellationToken cancellationToken)
+    {
+        // Delete user logic...
+        await Task.CompletedTask;
+        // No return statement needed -- clean async void pattern
+    }
+}
+#else
+// v10/v11 pattern: Unit-returning void handler
+public record DeleteUserCommand(int Id) : IRequest;  // IRequest inherits IRequest<Unit>
+
+public class DeleteUserHandler : IRequestHandler<DeleteUserCommand>
+{
+    public async Task<Unit> Handle(DeleteUserCommand request, CancellationToken cancellationToken)
+    {
+        // Delete user logic...
+        await Task.CompletedTask;
+        return Unit.Value;  // Must return Unit.Value or Unit.Task
+    }
+}
+#endif
+
+// =============================================================================
+// PATTERN 2: Pipeline behavior generic constraints
+// v10/v11: where TRequest : IRequest<TResponse> (STRICT)
+// v12: where TRequest : notnull (RELAXED)
+// =============================================================================
+
+#if MEDIATR_V12
+// v12 pattern: relaxed constraint enables open-generic pipeline registration
+public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull  // <-- relaxed constraint
+{
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        Console.WriteLine($"Handling {typeof(TRequest).Name}");
+        var response = await next();
+        Console.WriteLine($"Handled {typeof(TRequest).Name}");
+        return response;
+    }
+}
+
+// v12: This open-generic registration WORKS because of 'notnull' constraint
+// services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+#else
+// v10/v11 pattern: strict constraint prevents some open-generic patterns
+public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>  // <-- strict constraint
+{
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        Console.WriteLine($"Handling {typeof(TRequest).Name}");
+        var response = await next();
+        Console.WriteLine($"Handled {typeof(TRequest).Name}");
+        return response;
+    }
+}
+
+// v10/v11: This open-generic registration may FAIL at DI resolution time
+// because TRequest cannot be proven to satisfy IRequest<TResponse> for all T.
+// Workaround: register closed-generic versions explicitly.
+#endif
+
+// =============================================================================
+// PATTERN 3: Validation behavior -- constraint impact on cross-cutting concerns
+// v10/v11: Must constrain to IRequest<TResponse>, can't share with streaming
+// v12: notnull works across both regular and stream requests
+// =============================================================================
+
+#if MEDIATR_V12
+// v12: single validation behavior works for ANY request type
+public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        // Validate using FluentValidation, DataAnnotations, etc.
+        // Works for IRequest<T>, IRequest, and any other request type
+        return await next();
+    }
+}
+#else
+// v10/v11: separate behaviors needed for regular vs stream requests
+public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>  // Only works with IRequest<TResponse>
+{
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        return await next();
+    }
+}
+
+// v10/v11: need a SEPARATE behavior for stream requests
+public class StreamValidationBehavior<TRequest, TResponse> : IStreamPipelineBehavior<TRequest, TResponse>
+    where TRequest : IStreamRequest<TResponse>  // Different constraint!
+{
+    public async IAsyncEnumerable<TResponse> Handle(
+        TRequest request,
+        StreamHandlerDelegate<TResponse> next,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        // Same validation logic, duplicated due to constraint incompatibility
+        await foreach (var item in next().WithCancellation(cancellationToken))
+        {
+            yield return item;
+        }
+    }
+}
+#endif
+
+// =============================================================================
+// PATTERN 4: Stream request handlers -- constraint evolution
+// v10/v11: where TRequest : IStreamRequest<TResponse>
+// v12: where TRequest : notnull
+// =============================================================================
+
+public record GetUsersStreamQuery(string? NameFilter) : IStreamRequest<UserDto>;
+
+#if MEDIATR_V12
+public class GetUsersStreamHandler : IStreamRequestHandler<GetUsersStreamQuery, UserDto>
+    // v12: implicit 'where GetUsersStreamQuery : notnull' -- satisfied by record type
+{
+    public async IAsyncEnumerable<UserDto> Handle(
+        GetUsersStreamQuery request,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        for (var i = 1; i <= 10; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new UserDto(i, $"User {i}", $"user{i}@test.com");
+            await Task.Delay(100, cancellationToken);
+        }
+    }
+}
+#else
+public class GetUsersStreamHandler : IStreamRequestHandler<GetUsersStreamQuery, UserDto>
+    // v10/v11: implicit 'where GetUsersStreamQuery : IStreamRequest<UserDto>'
+{
+    public async IAsyncEnumerable<UserDto> Handle(
+        GetUsersStreamQuery request,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        for (var i = 1; i <= 10; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new UserDto(i, $"User {i}", $"user{i}@test.com");
+            await Task.Delay(100, cancellationToken);
+        }
+    }
+}
+#endif
+
+// =============================================================================
+// PATTERN 5: Custom notification publisher (v12 only)
+// v10/v11: No way to customize how notifications are dispatched to handlers
+// v12: INotificationPublisher enables parallel, sequential, fire-and-forget
+// =============================================================================
+
+#if MEDIATR_V12
+public class ParallelNotificationPublisher : INotificationPublisher
+{
+    public Task Publish(
+        IEnumerable<NotificationHandlerExecutor> handlerExecutors,
+        INotification notification,
+        CancellationToken cancellationToken)
+    {
+        // Dispatch to all handlers in parallel
+        var tasks = new List<Task>();
+        foreach (var executor in handlerExecutors)
+        {
+            tasks.Add(executor.HandlerCallback(notification, cancellationToken));
+        }
+        return Task.WhenAll(tasks);
+    }
+}
+
+// Registration: services.AddSingleton<INotificationPublisher, ParallelNotificationPublisher>();
+#endif
+
+// =============================================================================
+// PATTERN 6: Pre/post processor constraint changes
+// v10/v11: where TRequest : IBaseRequest
+// v12: where TRequest : notnull
+// =============================================================================
+
+#if MEDIATR_V12
+public class TimingPreProcessor<TRequest> : IRequestPreProcessor<TRequest>
+    where TRequest : notnull  // v12: relaxed
+{
+    public Task Process(TRequest request, CancellationToken cancellationToken)
+    {
+        Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] Pre-processing {typeof(TRequest).Name}");
+        return Task.CompletedTask;
+    }
+}
+#else
+public class TimingPreProcessor<TRequest> : IRequestPreProcessor<TRequest>
+    where TRequest : IBaseRequest  // v10/v11: must implement IBaseRequest
+{
+    public Task Process(TRequest request, CancellationToken cancellationToken)
+    {
+        Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}] Pre-processing {typeof(TRequest).Name}");
+        return Task.CompletedTask;
+    }
+}
+#endif

--- a/examples/migrations/nuget-version-matrix/mediatr/diff-report.md
+++ b/examples/migrations/nuget-version-matrix/mediatr/diff-report.md
@@ -1,0 +1,163 @@
+# MediatR Version-Matrix Diff Report
+
+API delta analysis across MediatR v10 -> v11 -> v12, focused on generic parameter changes.
+
+## Delta 1: Pipeline Behavior Generic Constraint Relaxation
+
+| Aspect | v10 | v11 | v12 |
+|--------|-----|-----|-----|
+| `IPipelineBehavior<TRequest, TResponse>` constraint | `where TRequest : IRequest<TResponse>` | Same as v10 | `where TRequest : notnull` |
+| `IStreamPipelineBehavior<TRequest, TResponse>` constraint | `where TRequest : IStreamRequest<TResponse>` | Same as v10 | `where TRequest : notnull` |
+| Open-generic pipeline registration | Blocked (constraint too strict) | Blocked | Enabled |
+
+**Migration safety:** `breaking`
+
+This is the most impactful generic delta. In v10/v11, the tight coupling `where TRequest : IRequest<TResponse>` prevented common open-generic pipeline registration patterns:
+
+```csharp
+// v10/v11: FAILS -- TRequest cannot satisfy IRequest<TResponse> in open-generic context
+services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+
+// v12: WORKS -- notnull constraint allows open-generic registration
+services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+```
+
+**Guidance:** For LCD, wrap pipeline behaviors with the strict `IRequest<TResponse>` constraint. For v12-targeted wrappers, use `notnull` to enable flexible DI registration. Code written for v10/v11 constraints still compiles on v12, but not the reverse.
+
+---
+
+## Delta 2: Void Handler Return Type and IRequest Hierarchy
+
+| Aspect | v10 | v11 | v12 |
+|--------|-----|-----|-----|
+| `IRequest` inherits | `IRequest<Unit>` | `IRequest<Unit>` | `IBaseRequest` (directly) |
+| `IRequestHandler<TRequest>` inherits | `IRequestHandler<TRequest, Unit>` | `IRequestHandler<TRequest, Unit>` | Standalone (no inheritance) |
+| Void handler return type | `Task<Unit>` | `Task<Unit>` | `Task` |
+| Void handler return idiom | `return Unit.Value;` / `return Unit.Task;` | Same | `return;` / `return Task.CompletedTask;` |
+| `IRequestHandler<TRequest>` constraint | `where TRequest : IRequest<Unit>` | `where TRequest : IRequest<Unit>` | `where TRequest : IRequest` |
+
+**Migration safety:** `breaking`
+
+This is a two-part generic hierarchy change. First, `IRequest` no longer extends `IRequest<Unit>`, breaking any code that treats void requests as `IRequest<Unit>`. Second, the single-generic `IRequestHandler<TRequest>` changes its return type from `Task<Unit>` to `Task`, requiring handler implementations to be updated.
+
+```csharp
+// v10/v11: Unit-based void handler
+public class DeleteUserHandler : IRequestHandler<DeleteUserCommand>
+{
+    public async Task<Unit> Handle(DeleteUserCommand request, CancellationToken ct)
+    {
+        // ...
+        return Unit.Value;
+    }
+}
+
+// v12: Task-based void handler
+public class DeleteUserHandler : IRequestHandler<DeleteUserCommand>
+{
+    public async Task Handle(DeleteUserCommand request, CancellationToken ct)
+    {
+        // ...
+    }
+}
+```
+
+**Guidance:** LCD normalizes to `Task<Unit>` (v10/v11 style) since Unit still exists in v12 for backward compatibility. Targeted v12 uses `Task` directly. Adaptive wrappers gate with `MEDIATR_V12`.
+
+---
+
+## Delta 3: Request Handler Generic Constraint Changes
+
+| Aspect | v10 | v11 | v12 |
+|--------|-----|-----|-----|
+| `IRequestHandler<TRequest, TResponse>` constraint on TRequest | `IRequest<TResponse>` | `IRequest<TResponse>` | `notnull` |
+| `IStreamRequestHandler<TRequest, TResponse>` constraint on TRequest | `IStreamRequest<TResponse>` | `IStreamRequest<TResponse>` | `notnull` |
+| `IRequestPreProcessor<TRequest>` constraint on TRequest | `IBaseRequest` | `IBaseRequest` | `notnull` |
+| `IRequestPostProcessor<TRequest, TResponse>` constraint on TRequest | `IBaseRequest` | `IBaseRequest` | `notnull` |
+
+**Migration safety:** `review`
+
+The constraint relaxation across ALL handler and processor interfaces in v12 is a consistent pattern -- every `TRequest` constraint was loosened. While this enables more flexible patterns, it means v12-written code that relies on the looser constraints will not compile against v10/v11.
+
+**Guidance:** Wrappers that must support v10/v11 must emit the stricter constraints. The strict constraints are a subset of `notnull` (anything satisfying `IRequest<TResponse>` also satisfies `notnull`), so strict-constrained code compiles on v12.
+
+---
+
+## Delta 4: Streaming Support Introduction (v10) and Constraint Evolution
+
+| Aspect | v10 | v11 | v12 |
+|--------|-----|-----|-----|
+| `IStreamRequest<TResponse>` | NEW -- covariant `out TResponse` | Unchanged | Unchanged |
+| `IStreamRequestHandler<TRequest, TResponse>` | NEW -- `where TRequest : IStreamRequest<TResponse>` | Unchanged | `where TRequest : notnull` |
+| `IStreamPipelineBehavior<TRequest, TResponse>` | NEW -- `where TRequest : IStreamRequest<TResponse>` | CancellationToken moved to last param | `where TRequest : notnull` |
+| `StreamHandlerDelegate<TResponse>` | NEW | Unchanged | Unchanged |
+| `ISender.CreateStream` | NEW | Unchanged | Unchanged |
+
+**Migration safety:** `review`
+
+Streaming was introduced in v10 as a complete subsystem. The generic variance pattern (`out TResponse` on `IStreamRequest<TResponse>`) enables covariant stream results. In v12, the strict `IStreamRequest<TResponse>` constraint was relaxed to `notnull`, matching the pattern applied to all other handler interfaces.
+
+**Guidance:** LCD includes streaming types with strict constraints (since they exist across all three versions). The covariant `out TResponse` on `IStreamRequest<TResponse>` is unchanged across versions and can be safely exposed in all strategies.
+
+---
+
+## Delta 5: CancellationToken Parameter Position (v11)
+
+| Aspect | v10 | v11 | v12 |
+|--------|-----|-----|-----|
+| `IPipelineBehavior.Handle` param order | `(TRequest, RequestHandlerDelegate<TResponse>, CancellationToken)` | Same (finalized) | Same |
+| `IStreamPipelineBehavior.Handle` param order | `(TRequest, StreamHandlerDelegate<TResponse>, CancellationToken)` | CancellationToken moved to last | Same |
+| Design rule alignment | Partial CA1068 compliance | Full CA1068 compliance | Same |
+
+**Migration safety:** `breaking`
+
+v11 enforced C# design guideline CA1068 (CancellationToken should be last parameter) across pipeline behavior interfaces. This is a signature-level breaking change for any custom pipeline behavior implementations.
+
+**Guidance:** All versions in the matrix (v10+) have CancellationToken as the last parameter for `IPipelineBehavior`. The change primarily affected `IStreamPipelineBehavior` and internal processor behaviors between v10 and v11. LCD wrappers use the v11+ parameter order since it is the most widely compatible.
+
+---
+
+## Delta 6: Custom Notification Publisher (v12)
+
+| Aspect | v10 | v11 | v12 |
+|--------|-----|-----|-----|
+| `INotificationPublisher` | Not available | Not available | NEW |
+| `NotificationHandlerExecutor` | Not available | Not available | NEW |
+| Custom dispatch strategies | Not possible | Not possible | Parallel, sequential, fire-and-forget |
+
+**Migration safety:** `safe`
+
+Purely additive. `INotificationPublisher` is a new extension point in v12 that allows custom notification dispatch strategies. It does not change existing interfaces -- code that does not use it is unaffected.
+
+**Guidance:** LCD excludes these types. Targeted v12 and adaptive strategies (with `MEDIATR_V12` symbol) include them for advanced notification dispatch scenarios.
+
+---
+
+## Delta 7: Contracts Package Consolidation
+
+| Aspect | v10 | v11 | v12 |
+|--------|-----|-----|-----|
+| Contract interfaces location | `MediatR.Contracts` (separate NuGet) | `MediatR.Contracts` (separate NuGet) | `MediatR` (consolidated) |
+| DI extension package | `MediatR.Extensions.Microsoft.DependencyInjection` (separate) | Same | `MediatR` (consolidated) |
+| `AddMediatR` registration | Extension method with assemblies parameter | Same | Single `MediatRServiceConfiguration` object |
+
+**Migration safety:** `review`
+
+v12 consolidated the contracts and DI extension packages into the main `MediatR` package. The generic interfaces themselves are unchanged, but their assembly location changed, which affects `typeof()` references and assembly scanning in DI registration.
+
+**Guidance:** WrapGod manifests reference types by fully-qualified name, which is unaffected by package consolidation. However, DI registration patterns in wrapper consumers need version-specific configuration code.
+
+---
+
+## Summary Matrix
+
+| Feature | v10 | v11 | v12 | LCD (v10+) | Targeted v12 | Adaptive |
+|---------|-----|-----|-----|------------|--------------|----------|
+| `IRequest<Unit>` hierarchy | Yes | Yes | No (IBaseRequest) | v10/v11 style | v12 style | `MEDIATR_V12` gate |
+| Void handler returns `Task<Unit>` | Yes | Yes | No (returns `Task`) | `Task<Unit>` | `Task` | `MEDIATR_V12` gate |
+| Pipeline `where TRequest : IRequest<TResponse>` | Yes | Yes | No (`notnull`) | Strict | Relaxed | `MEDIATR_V12` gate |
+| Stream handler `where TRequest : IStreamRequest<TResponse>` | Yes | Yes | No (`notnull`) | Strict | Relaxed | `MEDIATR_V12` gate |
+| Pre/post processor `where TRequest : IBaseRequest` | Yes | Yes | No (`notnull`) | Strict | Relaxed | `MEDIATR_V12` gate |
+| `IStreamRequest<TResponse>` (covariant) | Yes | Yes | Yes | Included | Included | All tiers |
+| `INotificationPublisher` | No | No | Yes | Excluded | Included | `MEDIATR_V12` gate |
+| CancellationToken last in pipeline | Yes | Yes (enforced) | Yes | Included | Included | All tiers |
+| Contracts in main package | No | No | Yes | N/A (type names unchanged) | N/A | N/A |

--- a/examples/migrations/nuget-version-matrix/mediatr/strategies/adaptive.wrapgod.config.json
+++ b/examples/migrations/nuget-version-matrix/mediatr/strategies/adaptive.wrapgod.config.json
@@ -1,0 +1,84 @@
+{
+  "strategyName": "adaptive",
+  "description": "Generates wrappers with compile-time version detection using preprocessor directives and runtime capability checks. Exposes maximum API for the detected version while maintaining backward compatibility.",
+  "sourceLibrary": "MediatR",
+  "versionRange": {
+    "minimum": "10.0.1",
+    "maximum": "12.2.0"
+  },
+  "strategy": "adaptive",
+  "versionTiers": [
+    {
+      "tier": "baseline",
+      "versionRange": ">=10.0.1",
+      "description": "Core CQRS: IRequest<TResponse>, IRequestHandler<TRequest, TResponse> with strict IRequest<TResponse> constraint, INotification, INotificationHandler, IPipelineBehavior with strict constraint, Unit-returning void handlers",
+      "preprocessorSymbol": "MEDIATR_V10",
+      "includes": [
+        "MediatR.IRequest`1",
+        "MediatR.IRequest",
+        "MediatR.IBaseRequest",
+        "MediatR.IRequestHandler`2",
+        "MediatR.IRequestHandler`1",
+        "MediatR.INotification",
+        "MediatR.INotificationHandler`1",
+        "MediatR.IPipelineBehavior`2",
+        "MediatR.IMediator",
+        "MediatR.ISender",
+        "MediatR.IPublisher",
+        "MediatR.Unit",
+        "MediatR.RequestHandlerDelegate`1",
+        "MediatR.IRequestPreProcessor`1",
+        "MediatR.IRequestPostProcessor`2"
+      ]
+    },
+    {
+      "tier": "streaming",
+      "versionRange": ">=10.0.1",
+      "description": "Streaming support: IStreamRequest<TResponse>, IStreamRequestHandler, IStreamPipelineBehavior, StreamHandlerDelegate. Available from v10 but with strict IStreamRequest<TResponse> constraints.",
+      "preprocessorSymbol": "MEDIATR_STREAMING",
+      "includes": [
+        "MediatR.IStreamRequest`1",
+        "MediatR.IStreamRequestHandler`2",
+        "MediatR.IStreamPipelineBehavior`2",
+        "MediatR.StreamHandlerDelegate`1"
+      ]
+    },
+    {
+      "tier": "relaxed-constraints",
+      "versionRange": ">=12.0.0",
+      "description": "Relaxed generic constraints: pipeline behaviors use 'notnull' instead of IRequest<TResponse>. Enables open-generic pipeline registrations that were blocked in v10/v11.",
+      "preprocessorSymbol": "MEDIATR_V12",
+      "constraintOverrides": {
+        "MediatR.IPipelineBehavior`2.TRequest": "notnull",
+        "MediatR.IStreamPipelineBehavior`2.TRequest": "notnull",
+        "MediatR.IStreamRequestHandler`2.TRequest": "notnull",
+        "MediatR.IRequestHandler`2.TRequest": "notnull",
+        "MediatR.IRequestPreProcessor`1.TRequest": "notnull",
+        "MediatR.IRequestPostProcessor`2.TRequest": "notnull"
+      }
+    },
+    {
+      "tier": "void-simplification",
+      "versionRange": ">=12.0.0",
+      "description": "Void handler simplification: IRequestHandler<TRequest> returns Task directly instead of Task<Unit>. IRequest no longer inherits IRequest<Unit>.",
+      "preprocessorSymbol": "MEDIATR_V12",
+      "returnTypeOverrides": {
+        "MediatR.IRequestHandler`1.Handle": "Task"
+      },
+      "hierarchyOverrides": {
+        "MediatR.IRequest": { "baseTypes": ["MediatR.IBaseRequest"] }
+      }
+    },
+    {
+      "tier": "notification-publishers",
+      "versionRange": ">=12.0.0",
+      "description": "Custom notification publishing: INotificationPublisher, NotificationHandlerExecutor for custom dispatch strategies.",
+      "preprocessorSymbol": "MEDIATR_V12",
+      "includes": [
+        "MediatR.INotificationPublisher",
+        "MediatR.NotificationHandlerExecutor"
+      ]
+    }
+  ],
+  "notes": "Adaptive strategy provides maximum API coverage per consumer. v10/v11 consumers get strict constraints and Unit-based void handlers. v12 consumers additionally get relaxed constraints, Task-returning void handlers, and custom notification publishers."
+}

--- a/examples/migrations/nuget-version-matrix/mediatr/strategies/lcd.wrapgod.config.json
+++ b/examples/migrations/nuget-version-matrix/mediatr/strategies/lcd.wrapgod.config.json
@@ -1,0 +1,72 @@
+{
+  "strategyName": "lcd",
+  "description": "Lowest Common Denominator -- generates wrappers using only APIs available in ALL targeted MediatR versions (10, 11, 12). Safest for multi-targeting but requires Unit-based return types and strict generic constraints.",
+  "sourceLibrary": "MediatR",
+  "versionRange": {
+    "minimum": "10.0.1",
+    "maximum": "12.2.0"
+  },
+  "strategy": "intersect",
+  "rules": [
+    {
+      "description": "Exclude INotificationPublisher (v12-only)",
+      "action": "exclude",
+      "target": "MediatR.INotificationPublisher",
+      "reason": "INotificationPublisher introduced in v12. Not available in v10/v11. LCD strategy uses default notification publishing."
+    },
+    {
+      "description": "Exclude NotificationHandlerExecutor (v12-only)",
+      "action": "exclude",
+      "target": "MediatR.NotificationHandlerExecutor",
+      "reason": "NotificationHandlerExecutor introduced in v12 alongside INotificationPublisher."
+    },
+    {
+      "description": "Use strict IRequest<TResponse> constraint on pipeline behaviors",
+      "action": "constrain",
+      "target": "MediatR.IPipelineBehavior`2",
+      "genericParameter": "TRequest",
+      "constraint": "IRequest<TResponse>",
+      "reason": "v10/v11 require 'where TRequest : IRequest<TResponse>'. v12 relaxed to 'notnull'. LCD must use the strictest constraint to compile against all versions."
+    },
+    {
+      "description": "Use strict IStreamRequest<TResponse> constraint on stream pipeline behaviors",
+      "action": "constrain",
+      "target": "MediatR.IStreamPipelineBehavior`2",
+      "genericParameter": "TRequest",
+      "constraint": "IStreamRequest<TResponse>",
+      "reason": "v10/v11 require 'where TRequest : IStreamRequest<TResponse>'. LCD uses the strictest constraint."
+    },
+    {
+      "description": "Use strict IRequest<TResponse> constraint on stream request handlers",
+      "action": "constrain",
+      "target": "MediatR.IStreamRequestHandler`2",
+      "genericParameter": "TRequest",
+      "constraint": "IStreamRequest<TResponse>",
+      "reason": "v10/v11 require 'where TRequest : IStreamRequest<TResponse>'. LCD uses the strictest constraint."
+    },
+    {
+      "description": "Void handlers must return Task<Unit> (v10/v11 pattern)",
+      "action": "normalize",
+      "target": "MediatR.IRequestHandler`1",
+      "returnType": "Task<Unit>",
+      "reason": "v10/v11 void handlers return Task<Unit>. v12 returns Task directly. LCD normalizes to Task<Unit> because both v10/v11 require it. v12 code that returns Task<Unit> still compiles (Unit still exists)."
+    },
+    {
+      "description": "Use IBaseRequest constraint on pre-processors",
+      "action": "constrain",
+      "target": "MediatR.IRequestPreProcessor`1",
+      "genericParameter": "TRequest",
+      "constraint": "IBaseRequest",
+      "reason": "v10/v11 require 'where TRequest : IBaseRequest'. v12 relaxed to 'notnull'. LCD uses the strictest constraint."
+    },
+    {
+      "description": "Use IBaseRequest constraint on post-processors",
+      "action": "constrain",
+      "target": "MediatR.IRequestPostProcessor`2",
+      "genericParameter": "TRequest",
+      "constraint": "IBaseRequest",
+      "reason": "v10/v11 require 'where TRequest : IBaseRequest'. v12 relaxed to 'notnull'. LCD uses the strictest constraint."
+    }
+  ],
+  "notes": "LCD wrappers compile against MediatR >= 10.0.1. Consumers lose: custom notification publishers (v12), relaxed generic constraints (v12), Task-returning void handlers (v12). The strict constraints from v10/v11 are the LCD baseline because v12 is backward-compatible with stricter constraints but not vice versa."
+}

--- a/examples/migrations/nuget-version-matrix/mediatr/strategies/targeted-v12.wrapgod.config.json
+++ b/examples/migrations/nuget-version-matrix/mediatr/strategies/targeted-v12.wrapgod.config.json
@@ -1,0 +1,46 @@
+{
+  "strategyName": "targeted-v12",
+  "description": "Generates wrappers targeting MediatR v12. Full API surface with relaxed generic constraints, Task-returning void handlers, and custom notification publishers. Best for greenfield projects or teams standardized on MediatR 12.x.",
+  "sourceLibrary": "MediatR",
+  "versionRange": {
+    "minimum": "12.0.0",
+    "maximum": "12.2.0"
+  },
+  "strategy": "full",
+  "rules": [
+    {
+      "description": "Include INotificationPublisher for custom publishing strategies",
+      "action": "include",
+      "target": "MediatR.INotificationPublisher",
+      "reason": "v12 custom notification publisher enables parallel, sequential, and fire-and-forget notification dispatch."
+    },
+    {
+      "description": "Include NotificationHandlerExecutor",
+      "action": "include",
+      "target": "MediatR.NotificationHandlerExecutor",
+      "reason": "Required companion type for INotificationPublisher implementations."
+    },
+    {
+      "description": "Use relaxed 'notnull' constraint on pipeline behaviors",
+      "action": "constrain",
+      "target": "MediatR.IPipelineBehavior`2",
+      "genericParameter": "TRequest",
+      "constraint": "notnull",
+      "reason": "v12 relaxed from IRequest<TResponse> to notnull. Enables open-generic pipeline registrations."
+    },
+    {
+      "description": "Void handlers return Task directly",
+      "action": "normalize",
+      "target": "MediatR.IRequestHandler`1",
+      "returnType": "Task",
+      "reason": "v12 void handlers return Task, not Task<Unit>. Cleaner API -- no Unit.Value/Unit.Task ceremony."
+    },
+    {
+      "description": "Include all streaming types",
+      "action": "include",
+      "target": "MediatR.IStreamRequest`1",
+      "reason": "Full streaming support with relaxed constraints."
+    }
+  ],
+  "notes": "Targeted v12 wrappers require MediatR >= 12.0.0. Provides the cleanest API surface with relaxed constraints and modern patterns. NOT backward-compatible with v10/v11."
+}

--- a/examples/migrations/nuget-version-matrix/mediatr/v10/manifest.wrapgod.json
+++ b/examples/migrations/nuget-version-matrix/mediatr/v10/manifest.wrapgod.json
@@ -1,0 +1,336 @@
+{
+  "$schema": "../../../../../schemas/wrapgod.manifest.v1.schema.json",
+  "name": "MediatR",
+  "version": "10.0.1",
+  "description": "MediatR v10 API surface. Introduced streaming support (IStreamRequest), stricter generic constraints on pipeline behaviors, and moved contracts to MediatR.Contracts package.",
+  "types": [
+    {
+      "name": "MediatR.IRequest`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "out" }
+      ],
+      "baseTypes": ["MediatR.IBaseRequest"],
+      "members": [],
+      "notes": "Marker interface for requests returning TResponse. In v10, IRequest (non-generic) inherits IRequest<Unit>."
+    },
+    {
+      "name": "MediatR.IRequest",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "baseTypes": ["MediatR.IRequest`1<Unit>"],
+      "members": [],
+      "notes": "Non-generic IRequest inherits IRequest<Unit> in v10. Handlers must return Task<Unit>."
+    },
+    {
+      "name": "MediatR.IBaseRequest",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": [],
+      "notes": "Root marker interface. Moved to MediatR.Contracts package in v10."
+    },
+    {
+      "name": "MediatR.IRequestHandler`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IRequest<TResponse>"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "Two-generic-param handler. TRequest constrained to IRequest<TResponse> in v10 (stricter than v9)."
+    },
+    {
+      "name": "MediatR.IRequestHandler`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IRequest<Unit>"] }
+      ],
+      "baseTypes": ["MediatR.IRequestHandler`2<TRequest, Unit>"],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task<Unit>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "Single-generic-param handler for void requests. Returns Task<Unit> in v10. Derives from IRequestHandler<TRequest, Unit>."
+    },
+    {
+      "name": "MediatR.INotification",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": [],
+      "notes": "Marker interface for notification messages. Unchanged across v10-v12."
+    },
+    {
+      "name": "MediatR.INotificationHandler`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TNotification", "variance": "in", "constraints": ["INotification"] }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "notification", "type": "TNotification" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.IPipelineBehavior`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IRequest<TResponse>"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "next", "type": "RequestHandlerDelegate<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "Pipeline behavior with STRICT constraint: where TRequest : IRequest<TResponse>. This prevents open-generic registration patterns that worked in v9. CancellationToken is LAST parameter (changed from v9 where it was second)."
+    },
+    {
+      "name": "MediatR.IStreamRequest`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "out" }
+      ],
+      "baseTypes": ["MediatR.IBaseRequest"],
+      "members": [],
+      "notes": "NEW in v10. Marker interface for streaming requests that return IAsyncEnumerable<TResponse>."
+    },
+    {
+      "name": "MediatR.IStreamRequestHandler`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IStreamRequest<TResponse>"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "NEW in v10. Handler for streaming requests. TRequest constrained to IStreamRequest<TResponse>."
+    },
+    {
+      "name": "MediatR.IStreamPipelineBehavior`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IStreamRequest<TResponse>"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "next", "type": "StreamHandlerDelegate<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "NEW in v10. Pipeline behavior for streaming requests. Same strict constraint pattern as IPipelineBehavior."
+    },
+    {
+      "name": "MediatR.IMediator",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "baseTypes": ["MediatR.ISender", "MediatR.IPublisher"],
+      "members": [],
+      "notes": "Combines ISender and IPublisher. Unchanged across v10-v12."
+    },
+    {
+      "name": "MediatR.ISender",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": [
+        {
+          "name": "Send",
+          "kind": "Method",
+          "returnType": "Task<TResponse>",
+          "genericParameters": [
+            { "name": "TResponse", "variance": "none" }
+          ],
+          "parameters": [
+            { "name": "request", "type": "IRequest<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "Send",
+          "kind": "Method",
+          "returnType": "Task<object?>",
+          "parameters": [
+            { "name": "request", "type": "object" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "CreateStream",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<TResponse>",
+          "genericParameters": [
+            { "name": "TResponse", "variance": "none" }
+          ],
+          "parameters": [
+            { "name": "request", "type": "IStreamRequest<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "CreateStream",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<object?>",
+          "parameters": [
+            { "name": "request", "type": "object" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "Request sender. CreateStream methods NEW in v10 for streaming support."
+    },
+    {
+      "name": "MediatR.IPublisher",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": [
+        {
+          "name": "Publish",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "notification", "type": "object" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "Publish",
+          "kind": "Method",
+          "returnType": "Task",
+          "genericParameters": [
+            { "name": "TNotification", "variance": "none", "constraints": ["INotification"] }
+          ],
+          "parameters": [
+            { "name": "notification", "type": "TNotification" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.Unit",
+      "namespace": "MediatR",
+      "kind": "Struct",
+      "members": [
+        { "name": "Value", "kind": "Property", "returnType": "Unit", "isStatic": true },
+        { "name": "Task", "kind": "Property", "returnType": "Task<Unit>", "isStatic": true }
+      ],
+      "notes": "Void-equivalent return type. IRequest (non-generic) handlers return Task<Unit> in v10. Idiomatic return: Unit.Value or Unit.Task."
+    },
+    {
+      "name": "MediatR.RequestHandlerDelegate`1",
+      "namespace": "MediatR",
+      "kind": "Delegate",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "returnType": "Task<TResponse>",
+      "members": [],
+      "notes": "Pipeline continuation delegate. Invoked as 'await next()' in pipeline behaviors."
+    },
+    {
+      "name": "MediatR.StreamHandlerDelegate`1",
+      "namespace": "MediatR",
+      "kind": "Delegate",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "returnType": "IAsyncEnumerable<TResponse>",
+      "members": [],
+      "notes": "NEW in v10. Stream pipeline continuation delegate."
+    },
+    {
+      "name": "MediatR.IRequestPreProcessor`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IBaseRequest"] }
+      ],
+      "members": [
+        {
+          "name": "Process",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.IRequestPostProcessor`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IBaseRequest"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Process",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "response", "type": "TResponse" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/migrations/nuget-version-matrix/mediatr/v11/manifest.wrapgod.json
+++ b/examples/migrations/nuget-version-matrix/mediatr/v11/manifest.wrapgod.json
@@ -1,0 +1,328 @@
+{
+  "$schema": "../../../../../schemas/wrapgod.manifest.v1.schema.json",
+  "name": "MediatR",
+  "version": "11.1.0",
+  "description": "MediatR v11 API surface. CancellationToken parameter moved to last position in pipeline behaviors per CA1068. Strict generic constraints on pipeline behaviors retained from v10.",
+  "types": [
+    {
+      "name": "MediatR.IRequest`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "out" }
+      ],
+      "baseTypes": ["MediatR.IBaseRequest"],
+      "members": [],
+      "notes": "Unchanged from v10. Covariant marker interface."
+    },
+    {
+      "name": "MediatR.IRequest",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "baseTypes": ["MediatR.IRequest`1<Unit>"],
+      "members": [],
+      "notes": "Still inherits IRequest<Unit> in v11. Handlers still return Task<Unit>."
+    },
+    {
+      "name": "MediatR.IBaseRequest",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": []
+    },
+    {
+      "name": "MediatR.IRequestHandler`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IRequest<TResponse>"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "Same strict constraint as v10: where TRequest : IRequest<TResponse>."
+    },
+    {
+      "name": "MediatR.IRequestHandler`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IRequest<Unit>"] }
+      ],
+      "baseTypes": ["MediatR.IRequestHandler`2<TRequest, Unit>"],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task<Unit>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "Still returns Task<Unit>. Unit.Value / Unit.Task idiom."
+    },
+    {
+      "name": "MediatR.INotification",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": []
+    },
+    {
+      "name": "MediatR.INotificationHandler`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TNotification", "variance": "in", "constraints": ["INotification"] }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "notification", "type": "TNotification" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.IPipelineBehavior`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IRequest<TResponse>"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "next", "type": "RequestHandlerDelegate<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "BREAKING from v9->v10->v11: CancellationToken moved to LAST parameter in v11 (was second in v9, third in v10). Strict constraint retained: where TRequest : IRequest<TResponse>."
+    },
+    {
+      "name": "MediatR.IStreamRequest`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "out" }
+      ],
+      "baseTypes": ["MediatR.IBaseRequest"],
+      "members": []
+    },
+    {
+      "name": "MediatR.IStreamRequestHandler`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IStreamRequest<TResponse>"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.IStreamPipelineBehavior`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IStreamRequest<TResponse>"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "next", "type": "StreamHandlerDelegate<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "CancellationToken moved to last position in v11 (matching IPipelineBehavior change)."
+    },
+    {
+      "name": "MediatR.IMediator",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "baseTypes": ["MediatR.ISender", "MediatR.IPublisher"],
+      "members": []
+    },
+    {
+      "name": "MediatR.ISender",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": [
+        {
+          "name": "Send",
+          "kind": "Method",
+          "returnType": "Task<TResponse>",
+          "genericParameters": [
+            { "name": "TResponse", "variance": "none" }
+          ],
+          "parameters": [
+            { "name": "request", "type": "IRequest<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "Send",
+          "kind": "Method",
+          "returnType": "Task<object?>",
+          "parameters": [
+            { "name": "request", "type": "object" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "CreateStream",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<TResponse>",
+          "genericParameters": [
+            { "name": "TResponse", "variance": "none" }
+          ],
+          "parameters": [
+            { "name": "request", "type": "IStreamRequest<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "CreateStream",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<object?>",
+          "parameters": [
+            { "name": "request", "type": "object" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.IPublisher",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": [
+        {
+          "name": "Publish",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "notification", "type": "object" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "Publish",
+          "kind": "Method",
+          "returnType": "Task",
+          "genericParameters": [
+            { "name": "TNotification", "variance": "none", "constraints": ["INotification"] }
+          ],
+          "parameters": [
+            { "name": "notification", "type": "TNotification" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.Unit",
+      "namespace": "MediatR",
+      "kind": "Struct",
+      "members": [
+        { "name": "Value", "kind": "Property", "returnType": "Unit", "isStatic": true },
+        { "name": "Task", "kind": "Property", "returnType": "Task<Unit>", "isStatic": true }
+      ],
+      "notes": "Still required in v11 for void handler returns."
+    },
+    {
+      "name": "MediatR.RequestHandlerDelegate`1",
+      "namespace": "MediatR",
+      "kind": "Delegate",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "returnType": "Task<TResponse>",
+      "members": []
+    },
+    {
+      "name": "MediatR.StreamHandlerDelegate`1",
+      "namespace": "MediatR",
+      "kind": "Delegate",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "returnType": "IAsyncEnumerable<TResponse>",
+      "members": []
+    },
+    {
+      "name": "MediatR.IRequestPreProcessor`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IBaseRequest"] }
+      ],
+      "members": [
+        {
+          "name": "Process",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.IRequestPostProcessor`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IBaseRequest"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Process",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "response", "type": "TResponse" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/migrations/nuget-version-matrix/mediatr/v12/manifest.wrapgod.json
+++ b/examples/migrations/nuget-version-matrix/mediatr/v12/manifest.wrapgod.json
@@ -1,0 +1,363 @@
+{
+  "$schema": "../../../../../schemas/wrapgod.manifest.v1.schema.json",
+  "name": "MediatR",
+  "version": "12.2.0",
+  "description": "MediatR v12 API surface. Major generic simplification: IRequest no longer inherits IRequest<Unit>, void handlers return Task directly, pipeline behavior constraints relaxed to 'notnull', DI consolidated into main package, custom notification publishers added.",
+  "types": [
+    {
+      "name": "MediatR.IRequest`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "out" }
+      ],
+      "baseTypes": ["MediatR.IBaseRequest"],
+      "members": [],
+      "notes": "Unchanged. Covariant marker interface for typed responses."
+    },
+    {
+      "name": "MediatR.IRequest",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "baseTypes": ["MediatR.IBaseRequest"],
+      "members": [],
+      "notes": "BREAKING: No longer inherits IRequest<Unit>. Now inherits IBaseRequest directly. This decouples void requests from the Unit type entirely."
+    },
+    {
+      "name": "MediatR.IBaseRequest",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": [],
+      "notes": "Root marker. Now the direct base of both IRequest and IRequest<TResponse>."
+    },
+    {
+      "name": "MediatR.IRequestHandler`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["notnull"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "BREAKING: Constraint relaxed from 'where TRequest : IRequest<TResponse>' to 'where TRequest : notnull'. Enables open-generic registration patterns that were blocked in v10/v11."
+    },
+    {
+      "name": "MediatR.IRequestHandler`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["IRequest"] }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "BREAKING: No longer inherits IRequestHandler<TRequest, Unit>. Returns Task directly instead of Task<Unit>. Constraint changed from IRequest<Unit> to IRequest. Handlers use 'return;' or 'return Task.CompletedTask' instead of 'return Unit.Value'."
+    },
+    {
+      "name": "MediatR.INotification",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": []
+    },
+    {
+      "name": "MediatR.INotificationHandler`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TNotification", "variance": "in", "constraints": ["INotification"] }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "notification", "type": "TNotification" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.IPipelineBehavior`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["notnull"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "Task<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "next", "type": "RequestHandlerDelegate<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "BREAKING: Constraint relaxed from 'where TRequest : IRequest<TResponse>' to 'where TRequest : notnull'. This is the key generic delta -- v10/v11 required the tight coupling which prevented open-generic pipeline registrations. v12 restores flexibility."
+    },
+    {
+      "name": "MediatR.IStreamRequest`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "out" }
+      ],
+      "baseTypes": ["MediatR.IBaseRequest"],
+      "members": []
+    },
+    {
+      "name": "MediatR.IStreamRequestHandler`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["notnull"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "BREAKING: Constraint relaxed from 'where TRequest : IStreamRequest<TResponse>' to 'where TRequest : notnull'. Matches IPipelineBehavior relaxation."
+    },
+    {
+      "name": "MediatR.IStreamPipelineBehavior`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["notnull"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Handle",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<TResponse>",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "next", "type": "StreamHandlerDelegate<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "Constraint relaxed from 'where TRequest : IStreamRequest<TResponse>' to 'where TRequest : notnull'."
+    },
+    {
+      "name": "MediatR.IMediator",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "baseTypes": ["MediatR.ISender", "MediatR.IPublisher"],
+      "members": []
+    },
+    {
+      "name": "MediatR.ISender",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": [
+        {
+          "name": "Send",
+          "kind": "Method",
+          "returnType": "Task<TResponse>",
+          "genericParameters": [
+            { "name": "TResponse", "variance": "none" }
+          ],
+          "parameters": [
+            { "name": "request", "type": "IRequest<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "Send",
+          "kind": "Method",
+          "returnType": "Task<object?>",
+          "parameters": [
+            { "name": "request", "type": "object" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "CreateStream",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<TResponse>",
+          "genericParameters": [
+            { "name": "TResponse", "variance": "none" }
+          ],
+          "parameters": [
+            { "name": "request", "type": "IStreamRequest<TResponse>" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "CreateStream",
+          "kind": "Method",
+          "returnType": "IAsyncEnumerable<object?>",
+          "parameters": [
+            { "name": "request", "type": "object" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.IPublisher",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": [
+        {
+          "name": "Publish",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "notification", "type": "object" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        },
+        {
+          "name": "Publish",
+          "kind": "Method",
+          "returnType": "Task",
+          "genericParameters": [
+            { "name": "TNotification", "variance": "none", "constraints": ["INotification"] }
+          ],
+          "parameters": [
+            { "name": "notification", "type": "TNotification" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MediatR.INotificationPublisher",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "members": [
+        {
+          "name": "Publish",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "handlerExecutors", "type": "IEnumerable<NotificationHandlerExecutor>" },
+            { "name": "notification", "type": "INotification" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "NEW in v12. Allows custom notification publishing strategies (parallel, sequential, fire-and-forget, etc.). Replaces the internal NotificationPublisher pattern."
+    },
+    {
+      "name": "MediatR.NotificationHandlerExecutor",
+      "namespace": "MediatR",
+      "kind": "Class",
+      "members": [
+        { "name": "HandlerInstance", "kind": "Property", "returnType": "object" },
+        {
+          "name": "HandlerCallback",
+          "kind": "Property",
+          "returnType": "Func<INotification, CancellationToken, Task>"
+        }
+      ],
+      "notes": "NEW in v12. Wraps a notification handler instance and its callback for use with INotificationPublisher."
+    },
+    {
+      "name": "MediatR.Unit",
+      "namespace": "MediatR",
+      "kind": "Struct",
+      "members": [
+        { "name": "Value", "kind": "Property", "returnType": "Unit", "isStatic": true },
+        { "name": "Task", "kind": "Property", "returnType": "Task<Unit>", "isStatic": true }
+      ],
+      "notes": "Still exists for backward compatibility with IRequestHandler<TRequest, TResponse> where TResponse is Unit. However, IRequestHandler<TRequest> (single generic) no longer uses Unit -- it returns Task directly."
+    },
+    {
+      "name": "MediatR.RequestHandlerDelegate`1",
+      "namespace": "MediatR",
+      "kind": "Delegate",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "returnType": "Task<TResponse>",
+      "members": []
+    },
+    {
+      "name": "MediatR.StreamHandlerDelegate`1",
+      "namespace": "MediatR",
+      "kind": "Delegate",
+      "genericParameters": [
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "returnType": "IAsyncEnumerable<TResponse>",
+      "members": []
+    },
+    {
+      "name": "MediatR.IRequestPreProcessor`1",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["notnull"] }
+      ],
+      "members": [
+        {
+          "name": "Process",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "BREAKING: Constraint relaxed from 'where TRequest : IBaseRequest' to 'where TRequest : notnull'."
+    },
+    {
+      "name": "MediatR.IRequestPostProcessor`2",
+      "namespace": "MediatR",
+      "kind": "Interface",
+      "genericParameters": [
+        { "name": "TRequest", "variance": "in", "constraints": ["notnull"] },
+        { "name": "TResponse", "variance": "none" }
+      ],
+      "members": [
+        {
+          "name": "Process",
+          "kind": "Method",
+          "returnType": "Task",
+          "parameters": [
+            { "name": "request", "type": "TRequest" },
+            { "name": "response", "type": "TResponse" },
+            { "name": "cancellationToken", "type": "CancellationToken" }
+          ]
+        }
+      ],
+      "notes": "BREAKING: Constraint relaxed from 'where TRequest : IBaseRequest' to 'where TRequest : notnull'."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds MediatR version-matrix example under `examples/migrations/nuget-version-matrix/mediatr/`
- Manifests for MediatR v10, v11, v12 focusing on **generic constraint/variance evolution**
- 7 documented API deltas: pipeline constraint relaxation, void handler hierarchy, streaming constraints, CancellationToken normalization, notification publishers
- 3 strategy configs (LCD, targeted-v12, adaptive with preprocessor gates)
- Sample tests with `#if MEDIATR_V12` demonstrating version-conditional patterns

Closes #167
Progresses #163

## Test plan
- [ ] All JSON manifests parse correctly
- [ ] Build passes
- [ ] Diff report covers generic-specific deltas (constraints, variance, arity)
- [ ] Strategy configs use normalized field names

🤖 Generated with [Claude Code](https://claude.com/claude-code)