### PR TITLE
docs(epic): concrete orchestration/hygiene update path for #163

### DIFF
--- a/docs/active/issue-163-orchestration-hygiene-update-path.md
+++ b/docs/active/issue-163-orchestration-hygiene-update-path.md
@@ -1,0 +1,41 @@
+# Issue #163 — NuGet Version-Matrix Epic Orchestration (Concrete Update Path)
+
+Status: In progress
+Owner: Jarvis
+
+## Objective
+Keep the #163 epic execution concrete, reviewable, and merge-safe while child implementation issues land independently.
+
+## Current child issue state
+- [x] #164 FluentAssertions version-matrix example
+- [x] #165 Moq version-matrix example
+- [x] #166 Serilog version-matrix example
+- [x] #167 Generic-heavy package version-matrix example
+- [ ] #168 Version-divergence compatibility report standard for examples
+- [ ] #169 CI matrix job for multi-version NuGet examples
+
+## Concrete update path
+1. **Lock report contract first (#168)**
+   - Finalize canonical report sections and required fields
+   - Add one reference report example under `examples/migrations/nuget-version-matrix/`
+   - Document pass/fail criteria for example completeness
+2. **Wire CI consumption (#169)**
+   - Consume the report contract in matrix jobs
+   - Validate each package-version matrix emits a compliant report
+   - Fail CI on schema/required-field drift
+3. **Close epic (#163)**
+   - Confirm all child issues closed
+   - Link merged PRs and workflow run proving matrix coverage
+   - Move this file to historical notes or remove once no longer active
+
+## Hygiene rules for this epic
+- Open draft PR early for visibility, then iterate in small commits
+- Every PR must include test command(s) and output summary in description
+- Keep issue/PR cross-links explicit (`Closes #...`, `Refs #...`)
+- Prefer deterministic examples (stable inputs, fixed version labels)
+
+## Done definition for #163
+- #168 and #169 merged
+- NuGet version-matrix packs produce compatibility reports conforming to the standard
+- CI validates the full matrix and blocks regressions
+- Epic issue checklist fully checked and closed

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -30,7 +30,11 @@
   href: api/index.md
   homepage: api/index.md
 - name: Active work
-  href: active/issue-6-config-ingestion.md
+  items:
+    - name: Issue #6 - Config ingestion
+      href: active/issue-6-config-ingestion.md
+    - name: Issue #163 - NuGet matrix orchestration
+      href: active/issue-163-orchestration-hygiene-update-path.md
 - name: Operations
   href: ops/workflow-parity-matrix.md
 - name: RFCs


### PR DESCRIPTION
## Summary\n- add active-work document for issue #163 epic orchestration\n- capture concrete update path sequencing (#168 -> #169 -> #163 close)\n- add hygiene rules and done-definition for deterministic execution\n- include #163 active-work page in docs toc\n\n## Validation\n- docs-only change; no runtime code touched\n\nRefs #163