### PR TITLE
feat: standardize version-divergence compatibility reports

### DIFF
--- a/WrapGod.Tests/CompatibilityReportSchemaTests.cs
+++ b/WrapGod.Tests/CompatibilityReportSchemaTests.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Json.Schema;
+using TinyBDD;
+using TinyBDD.Xunit;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests;
+
+[Feature("Compatibility report JSON schema validation")]
+public sealed class CompatibilityReportSchemaTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    private static readonly string RepoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
+    private static readonly JsonSchema Schema = JsonSchema.FromText(
+        File.ReadAllText(Path.Combine(RepoRoot, "schemas", "compatibility-report.v1.schema.json")));
+
+    private static EvaluationResults EvaluateFile(string relativePath)
+    {
+        var text = File.ReadAllText(Path.Combine(RepoRoot, relativePath));
+        using var doc = JsonDocument.Parse(text);
+        return Schema.Evaluate(doc.RootElement);
+    }
+
+    [Scenario("FluentAssertions compatibility report passes schema validation")]
+    [Fact]
+    public Task FluentAssertionsReport_PassesValidation()
+        => Given("the FluentAssertions report is evaluated against the schema", () =>
+                EvaluateFile("examples/migrations/nuget-version-matrix/fluent-assertions/compatibility-report.json"))
+            .Then("the validation passes", result => result.IsValid)
+            .AssertPassed();
+
+    [Scenario("Moq compatibility report passes schema validation")]
+    [Fact]
+    public Task MoqReport_PassesValidation()
+        => Given("the Moq report is evaluated against the schema", () =>
+                EvaluateFile("examples/migrations/nuget-version-matrix/moq/compatibility-report.json"))
+            .Then("the validation passes", result => result.IsValid)
+            .AssertPassed();
+
+    [Scenario("Serilog compatibility report passes schema validation")]
+    [Fact]
+    public Task SerilogReport_PassesValidation()
+        => Given("the Serilog report is evaluated against the schema", () =>
+                EvaluateFile("examples/migrations/nuget-version-matrix/serilog/compatibility-report.json"))
+            .Then("the validation passes", result => result.IsValid)
+            .AssertPassed();
+
+    [Scenario("Compatibility report missing migration recommendation fails schema validation")]
+    [Fact]
+    public Task MissingMigrationRecommendation_FailsValidation()
+        => Given("an invalid compatibility report is evaluated against the schema", () =>
+                EvaluateFile("schemas/examples/compatibility-report.invalid.missing-migration.json"))
+            .Then("the validation fails", result => !result.IsValid)
+            .AssertPassed();
+}

--- a/examples/migrations/nuget-version-matrix/_shared/compatibility-report.template.md
+++ b/examples/migrations/nuget-version-matrix/_shared/compatibility-report.template.md
@@ -1,0 +1,55 @@
+# {{package.name}} Version Compatibility Report
+
+API delta analysis across {{package.versions}}.
+
+## Summary
+
+- Baseline: `{{versionMatrix.baseline}}`
+- Latest: `{{versionMatrix.latest}}`
+- Deltas: `{{summary.totalDeltas}}`
+- Introduced members: `{{summary.introducedMembers}}`
+- Removed members: `{{summary.removedMembers}}`
+- Changed members: `{{summary.changedMembers}}`
+
+---
+
+{{#each deltas}}
+## {{title}} ({{id}})
+
+**Severity:** `{{severity}}`
+
+**Migration recommendation:** {{migrationRecommendation}}
+
+### Introduced members
+{{#if members.introduced.length}}
+{{#each members.introduced}}
+- `{{displayName}}` ({{kind}}, introduced in {{version}})
+{{/each}}
+{{else}}
+- None
+{{/if}}
+
+### Removed members
+{{#if members.removed.length}}
+{{#each members.removed}}
+- `{{displayName}}` ({{kind}}, removed by {{version}})
+{{/each}}
+{{else}}
+- None
+{{/if}}
+
+### Changed members
+{{#if members.changed.length}}
+{{#each members.changed}}
+- `{{displayName}}` ({{kind}}, changed in {{version}}): {{changeSummary}}
+{{/each}}
+{{else}}
+- None
+{{/if}}
+
+{{#if notes}}
+**Notes:** {{notes}}
+{{/if}}
+
+---
+{{/each}}

--- a/examples/migrations/nuget-version-matrix/fluent-assertions/compatibility-report.json
+++ b/examples/migrations/nuget-version-matrix/fluent-assertions/compatibility-report.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": "1.0",
+  "package": {
+    "name": "FluentAssertions",
+    "versions": ["v5", "v6", "v8"]
+  },
+  "versionMatrix": {
+    "baseline": "v5",
+    "latest": "v8",
+    "intermediate": ["v6"]
+  },
+  "summary": {
+    "totalDeltas": 3,
+    "introducedMembers": 2,
+    "removedMembers": 1,
+    "changedMembers": 2
+  },
+  "deltas": [
+    {
+      "id": "delta-1",
+      "title": "AssertionScope async behavior improvements",
+      "severity": "review",
+      "migrationRecommendation": "Prefer async-safe assertion scope usage and update helper wrappers when targeting v8.",
+      "members": {
+        "introduced": [
+          {
+            "kind": "method",
+            "displayName": "FluentAssertions.Execution.AssertionScope.DisposeAsync()",
+            "version": "v8"
+          }
+        ],
+        "removed": [],
+        "changed": [
+          {
+            "kind": "method",
+            "displayName": "FluentAssertions.Execution.AssertionScope.Dispose()",
+            "version": "v8",
+            "changeSummary": "Async disposal path introduced alongside sync disposal semantics."
+          }
+        ]
+      }
+    },
+    {
+      "id": "delta-2",
+      "title": "Collection assertion API tightening",
+      "severity": "breaking",
+      "migrationRecommendation": "Adjust wrappers to the stricter generic constraints and expose LCD-only overloads for cross-version compatibility.",
+      "members": {
+        "introduced": [],
+        "removed": [
+          {
+            "kind": "method",
+            "displayName": "GenericCollectionAssertions<T>.ContainSingle(Expression<Func<T, bool>>)",
+            "version": "v8"
+          }
+        ],
+        "changed": [
+          {
+            "kind": "method",
+            "displayName": "GenericCollectionAssertions<T>.ContainSingle(...)",
+            "version": "v6",
+            "changeSummary": "Signature and overload shape evolved between v5-v8."
+          }
+        ]
+      }
+    },
+    {
+      "id": "delta-3",
+      "title": "Equivalency options extension points",
+      "severity": "safe",
+      "migrationRecommendation": "Expose new extension points in targeted/adaptive strategy while keeping LCD subset stable.",
+      "members": {
+        "introduced": [
+          {
+            "kind": "method",
+            "displayName": "EquivalencyOptions<T>.UsingRuntimeTyping()",
+            "version": "v6"
+          }
+        ],
+        "removed": [],
+        "changed": []
+      }
+    }
+  ]
+}

--- a/examples/migrations/nuget-version-matrix/fluent-assertions/compatibility-report.md
+++ b/examples/migrations/nuget-version-matrix/fluent-assertions/compatibility-report.md
@@ -1,0 +1,63 @@
+# FluentAssertions Version Compatibility Report
+
+API delta analysis across v5, v6, v8.
+
+## Summary
+
+- Baseline: `v5`
+- Latest: `v8`
+- Deltas: `3`
+- Introduced members: `2`
+- Removed members: `1`
+- Changed members: `2`
+
+---
+
+## AssertionScope async behavior improvements (delta-1)
+
+**Severity:** `review`
+
+**Migration recommendation:** Prefer async-safe assertion scope usage and update helper wrappers when targeting v8.
+
+### Introduced members
+- `FluentAssertions.Execution.AssertionScope.DisposeAsync()` (method, introduced in v8)
+
+### Removed members
+- None
+
+### Changed members
+- `FluentAssertions.Execution.AssertionScope.Dispose()` (method, changed in v8): Async disposal path introduced alongside sync disposal semantics.
+
+---
+
+## Collection assertion API tightening (delta-2)
+
+**Severity:** `breaking`
+
+**Migration recommendation:** Adjust wrappers to the stricter generic constraints and expose LCD-only overloads for cross-version compatibility.
+
+### Introduced members
+- None
+
+### Removed members
+- `GenericCollectionAssertions<T>.ContainSingle(Expression<Func<T, bool>>)` (method, removed by v8)
+
+### Changed members
+- `GenericCollectionAssertions<T>.ContainSingle(...)` (method, changed in v6): Signature and overload shape evolved between v5-v8.
+
+---
+
+## Equivalency options extension points (delta-3)
+
+**Severity:** `safe`
+
+**Migration recommendation:** Expose new extension points in targeted/adaptive strategy while keeping LCD subset stable.
+
+### Introduced members
+- `EquivalencyOptions<T>.UsingRuntimeTyping()` (method, introduced in v6)
+
+### Removed members
+- None
+
+### Changed members
+- None

--- a/examples/migrations/nuget-version-matrix/moq/compatibility-report.json
+++ b/examples/migrations/nuget-version-matrix/moq/compatibility-report.json
@@ -1,0 +1,83 @@
+{
+  "schemaVersion": "1.0",
+  "package": {
+    "name": "Moq",
+    "versions": ["v4.10", "v4.16", "v4.20"]
+  },
+  "versionMatrix": {
+    "baseline": "v4.10",
+    "latest": "v4.20",
+    "intermediate": ["v4.16"]
+  },
+  "summary": {
+    "totalDeltas": 3,
+    "introducedMembers": 4,
+    "removedMembers": 0,
+    "changedMembers": 1
+  },
+  "deltas": [
+    {
+      "id": "delta-1",
+      "title": "Protected mocking type-safety",
+      "severity": "review",
+      "migrationRecommendation": "Use Protected().As<TAnalog>() when minimum supported version is >= 4.15; keep string-based fallback for LCD.",
+      "members": {
+        "introduced": [
+          {
+            "kind": "method",
+            "displayName": "IProtectedMock<T>.As<TAnalog>()",
+            "version": "v4.15"
+          }
+        ],
+        "removed": [],
+        "changed": []
+      }
+    },
+    {
+      "id": "delta-2",
+      "title": "Event subscription setup APIs",
+      "severity": "review",
+      "migrationRecommendation": "Gate SetupAdd/SetupRemove and VerifyAdd/VerifyRemove behind >= 4.13 in adaptive wrappers.",
+      "members": {
+        "introduced": [
+          {
+            "kind": "method",
+            "displayName": "Mock<T>.SetupAdd(...)",
+            "version": "v4.13"
+          },
+          {
+            "kind": "method",
+            "displayName": "Mock<T>.SetupRemove(...)",
+            "version": "v4.13"
+          }
+        ],
+        "removed": [],
+        "changed": []
+      }
+    },
+    {
+      "id": "delta-3",
+      "title": "Verifiable Times overload",
+      "severity": "safe",
+      "migrationRecommendation": "Expose Verifiable(Times) only for targeted v4.20+ strategy and omit from LCD.",
+      "members": {
+        "introduced": [
+          {
+            "kind": "method",
+            "displayName": "ISetup.Verifiable(Times)",
+            "version": "v4.20"
+          }
+        ],
+        "removed": [],
+        "changed": [
+          {
+            "kind": "method",
+            "displayName": "ISetup.Verifiable()",
+            "version": "v4.20",
+            "changeSummary": "New overload supports setup-time invocation count expectations."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/migrations/nuget-version-matrix/moq/compatibility-report.md
+++ b/examples/migrations/nuget-version-matrix/moq/compatibility-report.md
@@ -1,0 +1,64 @@
+# Moq Version Compatibility Report
+
+API delta analysis across v4.10, v4.16, v4.20.
+
+## Summary
+
+- Baseline: `v4.10`
+- Latest: `v4.20`
+- Deltas: `3`
+- Introduced members: `4`
+- Removed members: `0`
+- Changed members: `1`
+
+---
+
+## Protected mocking type-safety (delta-1)
+
+**Severity:** `review`
+
+**Migration recommendation:** Use Protected().As<TAnalog>() when minimum supported version is >= 4.15; keep string-based fallback for LCD.
+
+### Introduced members
+- `IProtectedMock<T>.As<TAnalog>()` (method, introduced in v4.15)
+
+### Removed members
+- None
+
+### Changed members
+- None
+
+---
+
+## Event subscription setup APIs (delta-2)
+
+**Severity:** `review`
+
+**Migration recommendation:** Gate SetupAdd/SetupRemove and VerifyAdd/VerifyRemove behind >= 4.13 in adaptive wrappers.
+
+### Introduced members
+- `Mock<T>.SetupAdd(...)` (method, introduced in v4.13)
+- `Mock<T>.SetupRemove(...)` (method, introduced in v4.13)
+
+### Removed members
+- None
+
+### Changed members
+- None
+
+---
+
+## Verifiable Times overload (delta-3)
+
+**Severity:** `safe`
+
+**Migration recommendation:** Expose Verifiable(Times) only for targeted v4.20+ strategy and omit from LCD.
+
+### Introduced members
+- `ISetup.Verifiable(Times)` (method, introduced in v4.20)
+
+### Removed members
+- None
+
+### Changed members
+- `ISetup.Verifiable()` (method, changed in v4.20): New overload supports setup-time invocation count expectations.

--- a/examples/migrations/nuget-version-matrix/serilog/compatibility-report.json
+++ b/examples/migrations/nuget-version-matrix/serilog/compatibility-report.json
@@ -1,0 +1,77 @@
+{
+  "schemaVersion": "1.0",
+  "package": {
+    "name": "Serilog",
+    "versions": ["v2.12.0", "v3.1.1", "v4.2.0"]
+  },
+  "versionMatrix": {
+    "baseline": "v2.12.0",
+    "latest": "v4.2.0",
+    "intermediate": ["v3.1.1"]
+  },
+  "summary": {
+    "totalDeltas": 3,
+    "introducedMembers": 3,
+    "removedMembers": 0,
+    "changedMembers": 1
+  },
+  "deltas": [
+    {
+      "id": "delta-1",
+      "title": "Async shutdown API",
+      "severity": "safe",
+      "migrationRecommendation": "Prefer CloseAndFlushAsync() where available; keep CloseAndFlush() fallback for LCD compatibility.",
+      "members": {
+        "introduced": [
+          {
+            "kind": "method",
+            "displayName": "Serilog.Log.CloseAndFlushAsync()",
+            "version": "v3.0.0"
+          }
+        ],
+        "removed": [],
+        "changed": []
+      }
+    },
+    {
+      "id": "delta-2",
+      "title": "Trace context members on LogEvent",
+      "severity": "review",
+      "migrationRecommendation": "Add nullable wrappers for TraceId/SpanId and branch behavior by runtime version.",
+      "members": {
+        "introduced": [
+          {
+            "kind": "property",
+            "displayName": "Serilog.Events.LogEvent.TraceId",
+            "version": "v3.1.0"
+          },
+          {
+            "kind": "property",
+            "displayName": "Serilog.Events.LogEvent.SpanId",
+            "version": "v3.1.0"
+          }
+        ],
+        "removed": [],
+        "changed": []
+      }
+    },
+    {
+      "id": "delta-3",
+      "title": "Override matching behavior",
+      "severity": "guided",
+      "migrationRecommendation": "Normalize source context casing to avoid behavior drift between v2/v3 and v4.",
+      "members": {
+        "introduced": [],
+        "removed": [],
+        "changed": [
+          {
+            "kind": "method",
+            "displayName": "LoggerMinimumLevelConfiguration.Override(string, LogEventLevel)",
+            "version": "v4.0.0",
+            "changeSummary": "Source context matching became case-insensitive in v4."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/migrations/nuget-version-matrix/serilog/compatibility-report.md
+++ b/examples/migrations/nuget-version-matrix/serilog/compatibility-report.md
@@ -1,0 +1,64 @@
+# Serilog Version Compatibility Report
+
+API delta analysis across v2.12.0, v3.1.1, v4.2.0.
+
+## Summary
+
+- Baseline: `v2.12.0`
+- Latest: `v4.2.0`
+- Deltas: `3`
+- Introduced members: `3`
+- Removed members: `0`
+- Changed members: `1`
+
+---
+
+## Async shutdown API (delta-1)
+
+**Severity:** `safe`
+
+**Migration recommendation:** Prefer CloseAndFlushAsync() where available; keep CloseAndFlush() fallback for LCD compatibility.
+
+### Introduced members
+- `Serilog.Log.CloseAndFlushAsync()` (method, introduced in v3.0.0)
+
+### Removed members
+- None
+
+### Changed members
+- None
+
+---
+
+## Trace context members on LogEvent (delta-2)
+
+**Severity:** `review`
+
+**Migration recommendation:** Add nullable wrappers for TraceId/SpanId and branch behavior by runtime version.
+
+### Introduced members
+- `Serilog.Events.LogEvent.TraceId` (property, introduced in v3.1.0)
+- `Serilog.Events.LogEvent.SpanId` (property, introduced in v3.1.0)
+
+### Removed members
+- None
+
+### Changed members
+- None
+
+---
+
+## Override matching behavior (delta-3)
+
+**Severity:** `guided`
+
+**Migration recommendation:** Normalize source context casing to avoid behavior drift between v2/v3 and v4.
+
+### Introduced members
+- None
+
+### Removed members
+- None
+
+### Changed members
+- `LoggerMinimumLevelConfiguration.Override(string, LogEventLevel)` (method, changed in v4.0.0): Source context matching became case-insensitive in v4.

--- a/schemas/compatibility-report.v1.schema.json
+++ b/schemas/compatibility-report.v1.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wrapgod.dev/schemas/compatibility-report.v1.schema.json",
+  "title": "WrapGod Compatibility Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "package",
+    "versionMatrix",
+    "deltas"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0" },
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "versions"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "versions": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "versionMatrix": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseline", "latest"],
+      "properties": {
+        "baseline": { "type": "string", "minLength": 1 },
+        "latest": { "type": "string", "minLength": 1 },
+        "intermediate": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "totalDeltas": { "type": "integer", "minimum": 0 },
+        "introducedMembers": { "type": "integer", "minimum": 0 },
+        "removedMembers": { "type": "integer", "minimum": 0 },
+        "changedMembers": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "deltas": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "title",
+          "severity",
+          "migrationRecommendation",
+          "members"
+        ],
+        "properties": {
+          "id": { "type": "string", "pattern": "^delta-[0-9]+$" },
+          "title": { "type": "string", "minLength": 1 },
+          "severity": {
+            "type": "string",
+            "enum": ["safe", "review", "guided", "breaking", "manual"]
+          },
+          "migrationRecommendation": { "type": "string", "minLength": 1 },
+          "notes": { "type": "string" },
+          "members": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["introduced", "removed", "changed"],
+            "properties": {
+              "introduced": {
+                "type": "array",
+                "items": { "$ref": "#/$defs/memberRef" }
+              },
+              "removed": {
+                "type": "array",
+                "items": { "$ref": "#/$defs/memberRef" }
+              },
+              "changed": {
+                "type": "array",
+                "items": {
+                  "allOf": [
+                    { "$ref": "#/$defs/memberRef" },
+                    {
+                      "type": "object",
+                      "required": ["changeSummary"]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "memberRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "displayName", "version"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["type", "method", "property", "field", "event", "constructor"]
+        },
+        "displayName": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "changeSummary": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/schemas/examples/compatibility-report.invalid.missing-migration.json
+++ b/schemas/examples/compatibility-report.invalid.missing-migration.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.0",
+  "package": {
+    "name": "Sample.Pkg",
+    "versions": ["v1", "v2"]
+  },
+  "versionMatrix": {
+    "baseline": "v1",
+    "latest": "v2"
+  },
+  "deltas": [
+    {
+      "id": "delta-1",
+      "title": "Missing recommendation field",
+      "severity": "review",
+      "members": {
+        "introduced": [],
+        "removed": [],
+        "changed": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add shared compatibility report JSON schema (`schemas/compatibility-report.v1.schema.json`)
- add reusable markdown render template for report output (`examples/migrations/nuget-version-matrix/_shared/compatibility-report.template.md`)
- add standardized compatibility report JSON+Markdown artifacts for fluent-assertions, moq, and serilog examples
- add schema validation tests that enforce report structure in CI

## Validation
- `dotnet test WrapGod.Tests/WrapGod.Tests.csproj --filter "CompatibilityReportSchemaTests|ManifestSchemaTests"`
- `dotnet test WrapGod.slnx`

Closes #168
