### PR TITLE
feat: Serilog <-> NLog bidirectional integration pack

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ This folder contains a runnable, end-to-end workflow demo for issue #43.
 
 - `Acme.Lib` — tiny third-party library we will wrap
 - `WrapGod.WorkflowDemo` — console app that executes the full WrapGod flow
+- `migrations/serilog-nlog-bidirectional` — bidirectional Serilog <-> NLog integration pack with parity tests
 
 ## What the demo does
 

--- a/examples/WrapGod.Examples.slnx
+++ b/examples/WrapGod.Examples.slnx
@@ -15,4 +15,9 @@
     <Project Path="NUnitToXUnit/SampleTests.Before/SampleTests.Before.csproj" />
     <Project Path="NUnitToXUnit/SampleTests.After/SampleTests.After.csproj" />
   </Folder>
+  <Folder Name="/migrations/serilog-nlog-bidirectional/">
+    <Project Path="migrations/serilog-nlog-bidirectional/SerilogApp/SerilogApp.csproj" />
+    <Project Path="migrations/serilog-nlog-bidirectional/NLogApp/NLogApp.csproj" />
+    <Project Path="migrations/serilog-nlog-bidirectional/ParityTests/ParityTests.csproj" />
+  </Folder>
 </Solution>

--- a/examples/migrations/serilog-nlog-bidirectional/NLogApp/LoggingModels.cs
+++ b/examples/migrations/serilog-nlog-bidirectional/NLogApp/LoggingModels.cs
@@ -1,0 +1,7 @@
+namespace NLogApp;
+
+public sealed record LogEventRecord(
+    string Level,
+    string Message,
+    IReadOnlyDictionary<string, object?> Properties,
+    Exception? Exception = null);

--- a/examples/migrations/serilog-nlog-bidirectional/NLogApp/NLogApp.csproj
+++ b/examples/migrations/serilog-nlog-bidirectional/NLogApp/NLogApp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="6.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/examples/migrations/serilog-nlog-bidirectional/NLogApp/NLogOrderLogger.cs
+++ b/examples/migrations/serilog-nlog-bidirectional/NLogApp/NLogOrderLogger.cs
@@ -1,0 +1,89 @@
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+
+namespace NLogApp;
+
+public static class NLogOrderLogger
+{
+    public static IReadOnlyList<LogEventRecord> CaptureOrderWorkflowLogs(string orderId, decimal total)
+    {
+        var sink = new InMemoryTarget();
+        var config = new LoggingConfiguration();
+        config.AddRuleForAllLevels(sink);
+
+        LogManager.Configuration = config;
+        var logger = LogManager.GetLogger("checkout");
+
+        var contextProperties = new Dictionary<string, object?> { ["service"] = "checkout" };
+
+        LogWithProperties(logger, LogLevel.Info, "Order {OrderId} started", contextProperties, orderId);
+        LogWithProperties(logger, LogLevel.Debug, "Order {OrderId} total {Total}", contextProperties, orderId, total);
+
+        try
+        {
+            ThrowIfInvalid(total);
+            LogWithProperties(logger, LogLevel.Info, "Order {OrderId} completed", contextProperties, orderId);
+        }
+        catch (InvalidOperationException ex)
+        {
+            LogWithProperties(logger, LogLevel.Error, "Order {OrderId} failed", contextProperties, orderId, exception: ex);
+        }
+
+        LogManager.Shutdown();
+        return sink.Events;
+    }
+
+    private static void LogWithProperties(
+        Logger logger,
+        LogLevel level,
+        string template,
+        IReadOnlyDictionary<string, object?> baseProperties,
+        object? arg1,
+        object? arg2 = null,
+        Exception? exception = null)
+    {
+        var evt = new LogEventInfo
+        {
+            Level = level,
+            LoggerName = logger.Name,
+            Message = template,
+            Parameters = new[] { arg1, arg2 }.Where(v => v is not null).ToArray(),
+            Exception = exception
+        };
+        foreach (var (key, value) in baseProperties)
+        {
+            evt.Properties[key] = value;
+        }
+
+        logger.Log(evt);
+    }
+
+    private static void ThrowIfInvalid(decimal total)
+    {
+        if (total <= 0)
+        {
+            throw new InvalidOperationException("Total must be greater than zero.");
+        }
+    }
+
+    private sealed class InMemoryTarget : TargetWithLayout
+    {
+        private readonly List<LogEventRecord> _events = [];
+
+        public IReadOnlyList<LogEventRecord> Events => _events;
+
+        protected override void Write(LogEventInfo logEvent)
+        {
+            var properties = logEvent.Properties.ToDictionary(
+                kvp => kvp.Key.ToString()!,
+                kvp => kvp.Value);
+
+            _events.Add(new LogEventRecord(
+                logEvent.Level.Name.ToUpperInvariant(),
+                logEvent.FormattedMessage,
+                properties,
+                logEvent.Exception));
+        }
+    }
+}

--- a/examples/migrations/serilog-nlog-bidirectional/ParityTests/LogParityTests.cs
+++ b/examples/migrations/serilog-nlog-bidirectional/ParityTests/LogParityTests.cs
@@ -1,0 +1,60 @@
+using NLogApp;
+using SerilogApp;
+using Xunit;
+
+namespace ParityTests;
+
+public class LogParityTests
+{
+    [Fact]
+    public void Serilog_and_NLog_emit_equivalent_events_for_happy_path()
+    {
+        var serilogEvents = SerilogOrderLogger.CaptureOrderWorkflowLogs("A-100", 42.5m);
+        var nlogEvents = NLogOrderLogger.CaptureOrderWorkflowLogs("A-100", 42.5m);
+
+        AssertParity(serilogEvents, nlogEvents);
+    }
+
+    [Fact]
+    public void Serilog_and_NLog_emit_equivalent_events_for_error_path()
+    {
+        var serilogEvents = SerilogOrderLogger.CaptureOrderWorkflowLogs("A-101", 0m);
+        var nlogEvents = NLogOrderLogger.CaptureOrderWorkflowLogs("A-101", 0m);
+
+        AssertParity(serilogEvents, nlogEvents, expectError: true);
+    }
+
+    private static void AssertParity(
+        IReadOnlyList<SerilogApp.LogEventRecord> serilogEvents,
+        IReadOnlyList<NLogApp.LogEventRecord> nlogEvents,
+        bool expectError = false)
+    {
+        Assert.Equal(serilogEvents.Count, nlogEvents.Count);
+
+        for (var i = 0; i < serilogEvents.Count; i++)
+        {
+            var s = serilogEvents[i];
+            var n = nlogEvents[i];
+
+            Assert.Equal(NormalizeLevel(s.Level), NormalizeLevel(n.Level));
+            Assert.Equal(NormalizeMessage(s.Message), NormalizeMessage(n.Message));
+            Assert.Equal(s.Properties["service"], n.Properties["service"]);
+        }
+
+        if (expectError)
+        {
+            Assert.NotNull(serilogEvents[^1].Exception);
+            Assert.NotNull(nlogEvents[^1].Exception);
+        }
+    }
+
+    private static string NormalizeLevel(string level)
+        => level.ToUpperInvariant() switch
+        {
+            "INFORMATION" => "INFO",
+            _ => level.ToUpperInvariant()
+        };
+
+    private static string NormalizeMessage(string message)
+        => message.Replace("\"", string.Empty, StringComparison.Ordinal);
+}

--- a/examples/migrations/serilog-nlog-bidirectional/ParityTests/ParityTests.csproj
+++ b/examples/migrations/serilog-nlog-bidirectional/ParityTests/ParityTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SerilogApp\SerilogApp.csproj" />
+    <ProjectReference Include="..\NLogApp\NLogApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/migrations/serilog-nlog-bidirectional/README.md
+++ b/examples/migrations/serilog-nlog-bidirectional/README.md
@@ -1,0 +1,33 @@
+# Serilog <-> NLog Bidirectional Integration Pack
+
+This migration pack demonstrates bidirectional API coverage between
+[Serilog](https://serilog.net/) and [NLog](https://nlog-project.org/),
+including structured-property behavior and parity tests.
+
+## Layout
+
+- `SerilogApp/` — source-side sample implementation with Serilog APIs
+- `NLogApp/` — destination-side equivalent implementation with NLog APIs
+- `ParityTests/` — CI-friendly parity tests to verify equivalent log output
+- `mapping-matrix.md` — API mapping table for both migration directions
+- `diagnostics.md` — unsupported/unsafe patterns and manual migration paths
+
+## Scope covered
+
+- Logger acquisition and level methods (`Debug/Info/Error`)
+- Structured property capture (`OrderId`, `Total`, global `service` property)
+- Exception logging parity in failure paths
+- Runtime config caveats for sinks/targets
+
+## Run locally
+
+```bash
+dotnet test examples/migrations/serilog-nlog-bidirectional/ParityTests/ParityTests.csproj
+```
+
+## Notes
+
+This pack intentionally focuses on portable logging semantics.
+Advanced sink/target behavior (buffering, batching, async wrappers,
+layout/rendering differences) is tracked as analyzer/manual-review guidance
+in `diagnostics.md`.

--- a/examples/migrations/serilog-nlog-bidirectional/SerilogApp/LoggingModels.cs
+++ b/examples/migrations/serilog-nlog-bidirectional/SerilogApp/LoggingModels.cs
@@ -1,0 +1,7 @@
+namespace SerilogApp;
+
+public sealed record LogEventRecord(
+    string Level,
+    string Message,
+    IReadOnlyDictionary<string, object?> Properties,
+    Exception? Exception = null);

--- a/examples/migrations/serilog-nlog-bidirectional/SerilogApp/SerilogApp.csproj
+++ b/examples/migrations/serilog-nlog-bidirectional/SerilogApp/SerilogApp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="4.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/migrations/serilog-nlog-bidirectional/SerilogApp/SerilogOrderLogger.cs
+++ b/examples/migrations/serilog-nlog-bidirectional/SerilogApp/SerilogOrderLogger.cs
@@ -1,0 +1,71 @@
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SerilogApp;
+
+public static class SerilogOrderLogger
+{
+    public static IReadOnlyList<LogEventRecord> CaptureOrderWorkflowLogs(string orderId, decimal total)
+    {
+        var sink = new InMemorySink();
+
+        using var logger = new LoggerConfiguration()
+            .MinimumLevel.Debug()
+            .Enrich.WithProperty("service", "checkout")
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        logger.Information("Order {OrderId} started", orderId);
+        logger.Debug("Order {OrderId} total {Total}", orderId, total);
+
+        try
+        {
+            ThrowIfInvalid(total);
+            logger.Information("Order {OrderId} completed", orderId);
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.Error(ex, "Order {OrderId} failed", orderId);
+        }
+
+        return sink.Events;
+    }
+
+    private static void ThrowIfInvalid(decimal total)
+    {
+        if (total <= 0)
+        {
+            throw new InvalidOperationException("Total must be greater than zero.");
+        }
+    }
+
+    private sealed class InMemorySink : ILogEventSink
+    {
+        private readonly List<LogEventRecord> _events = [];
+
+        public IReadOnlyList<LogEventRecord> Events => _events;
+
+        public void Emit(LogEvent logEvent)
+        {
+            var props = logEvent.Properties
+                .ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => ConvertScalar(kvp.Value));
+
+            _events.Add(new LogEventRecord(
+                logEvent.Level.ToString().ToUpperInvariant(),
+                logEvent.MessageTemplate.Render(logEvent.Properties),
+                props,
+                logEvent.Exception));
+        }
+
+        private static object? ConvertScalar(LogEventPropertyValue value)
+            => value switch
+            {
+                ScalarValue scalar => scalar.Value,
+                SequenceValue seq => seq.Elements.Select(ConvertScalar).ToArray(),
+                _ => value.ToString()
+            };
+    }
+}

--- a/examples/migrations/serilog-nlog-bidirectional/diagnostics.md
+++ b/examples/migrations/serilog-nlog-bidirectional/diagnostics.md
@@ -1,0 +1,32 @@
+# Diagnostics and Manual Migration Guidance
+
+The following patterns should be flagged as **review/manual** during automated migration.
+
+## Unsupported or risky sink/target semantics
+
+1. **Custom Serilog sinks with side effects**
+   - Example: sink writes to external service with custom batching logic
+   - NLog equivalent may require custom target implementation
+   - Recommendation: emit diagnostic `WG3XXX` (manual target port required)
+
+2. **NLog target wrappers (Buffering/Fallback/Async)**
+   - Wrapper stacks can alter delivery guarantees and retry behavior
+   - Serilog pipeline composition is similar but not identical
+   - Recommendation: emit diagnostic `WG3XXX` (delivery semantics review)
+
+3. **Template/rendering assumptions in dashboards**
+   - Serilog message-template rendering differs from NLog layout rendering
+   - Potential drift in structured fields and search queries
+   - Recommendation: emit diagnostic `WG3XXX` (dashboard query update required)
+
+4. **Scope/context propagation across async boundaries**
+   - Serilog `LogContext` and NLog `ScopeContext` can diverge by host integration
+   - Recommendation: emit diagnostic `WG3XXX` (trace correlation validation required)
+
+## Manual path checklist
+
+- Build inventory of existing sinks/targets and wrapper stacks
+- Migrate baseline level + template APIs first
+- Preserve structured property keys used by alerting dashboards
+- Add parity tests over representative log scenarios (happy + failure paths)
+- Validate throughput/flush behavior under load before production rollout

--- a/examples/migrations/serilog-nlog-bidirectional/mapping-matrix.md
+++ b/examples/migrations/serilog-nlog-bidirectional/mapping-matrix.md
@@ -1,0 +1,14 @@
+# Serilog <-> NLog Mapping Matrix
+
+| Concern | Serilog API | NLog API | Direction | Safety | Notes |
+|---|---|---|---|---|---|
+| Logger acquisition | `new LoggerConfiguration().CreateLogger()` | `LogManager.GetLogger(name)` | both | safe | Prefer explicit logger name in NLog |
+| Information event | `logger.Information(template, args)` | `logger.Info(template, args)` | both | safe | Template interpolation semantics differ slightly |
+| Debug event | `logger.Debug(template, args)` | `logger.Debug(template, args)` | both | safe | Equivalent intent |
+| Error with exception | `logger.Error(ex, template, args)` | `logger.Error(ex, template, args)` | both | safe | Preserve exception as first-class field |
+| Global enrichment/context | `.Enrich.WithProperty(key, value)` | `LogEventInfo.Properties[key]=value`/`ScopeContext` | both | review | NLog context propagation APIs vary by integration |
+| Structured arguments | `{OrderId}` / `{Total}` tokens | message template + `LogEventInfo.Parameters` | both | review | Positional vs named fidelity can vary by renderer |
+| Sink/target registration | `.WriteTo.Sink(...)` | `LoggingConfiguration.AddRuleForAllLevels(target)` | both | review | Routing/filter semantics are not 1:1 |
+| Minimum level | `.MinimumLevel.Debug()` | `LoggingRule` + `LogLevel` | both | safe | Keep threshold behavior explicit |
+| Async pipeline wrappers | `WriteTo.Async(...)` | `AsyncTargetWrapper` | both | manual | Buffering and flush semantics differ |
+| JSON rendering | `RenderedCompactJsonFormatter` | `JsonLayout` | both | manual | Property naming/order and exception schema differ |


### PR DESCRIPTION
## Summary\n- add xamples/migrations/serilog-nlog-bidirectional with Serilog and NLog sample apps\n- add parity test project validating equivalent happy-path and error-path log events\n- add mapping matrix + diagnostics/manual migration guidance\n- wire the new projects into xamples/WrapGod.Examples.slnx and cross-link from examples README\n\n## Validation\n- dotnet test examples/migrations/serilog-nlog-bidirectional/ParityTests/ParityTests.csproj\n- dotnet build examples/WrapGod.Examples.slnx -c Release\n\nCloses #158