### PR TITLE
ci(examples): add NuGet version-matrix CI + artifact publication (#169)

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -5,10 +5,16 @@ on:
     branches: [ main ]
     paths:
       - 'examples/**'
+      - 'schemas/**'
+      - '.github/workflows/examples.yml'
+      - 'WrapGod.Tests/**'
   pull_request:
     branches: [ main ]
     paths:
       - 'examples/**'
+      - 'schemas/**'
+      - '.github/workflows/examples.yml'
+      - 'WrapGod.Tests/**'
 
 jobs:
   build-examples:
@@ -46,3 +52,80 @@ jobs:
 
       - name: Build WrapGod.Examples
         run: dotnet build examples/WrapGod.Examples.slnx --nologo
+
+  nuget-version-matrix:
+    name: nuget-version-matrix (${{ matrix.sample }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sample: fluent-assertions
+            versions: "v5 v6 v8"
+          - sample: moq
+            versions: "v4.10 v4.16 v4.20"
+          - sample: serilog
+            versions: "v2 v3 v4"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Validate sample structure + report consistency
+        shell: pwsh
+        run: |
+          $sample = "${{ matrix.sample }}"
+          $versions = "${{ matrix.versions }}".Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)
+          $root = "examples/migrations/nuget-version-matrix/$sample"
+
+          if (!(Test-Path $root)) { throw "Missing sample root: $root" }
+          foreach ($v in $versions) {
+            $manifest = Join-Path $root "$v/manifest.wrapgod.json"
+            if (!(Test-Path $manifest)) { throw "Missing manifest: $manifest" }
+          }
+
+          $jsonPath = Join-Path $root "compatibility-report.json"
+          $mdPath = Join-Path $root "compatibility-report.md"
+          $diffPath = Join-Path $root "diff-report.md"
+          foreach ($f in @($jsonPath,$mdPath,$diffPath)) {
+            if (!(Test-Path $f)) { throw "Missing required report artifact: $f" }
+          }
+
+          $report = Get-Content $jsonPath -Raw | ConvertFrom-Json
+          if ($null -eq $report.package -or [string]::IsNullOrWhiteSpace($report.package.name)) {
+            throw "compatibility-report.json is missing package.name for $sample"
+          }
+
+          $md = Get-Content $mdPath -Raw
+          if ($md -notmatch [Regex]::Escape($report.package.name)) {
+            throw "compatibility-report.md does not mention package '$($report.package.name)' for $sample"
+          }
+
+          foreach ($v in $report.package.versions) {
+            if ($md -notmatch [Regex]::Escape($v)) {
+              throw "compatibility-report.md missing version '$v' for $sample"
+            }
+          }
+
+          $diffLength = (Get-Content $diffPath -Raw).Trim().Length
+          if ($diffLength -lt 100) { throw "diff-report.md appears too small/non-deterministic for $sample" }
+
+      - name: Validate JSON schema tests
+        run: dotnet test WrapGod.Tests/WrapGod.Tests.csproj --filter "CompatibilityReportSchemaTests|ManifestSchemaTests" --nologo
+
+      - name: Upload compatibility artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-version-matrix-${{ matrix.sample }}
+          path: |
+            examples/migrations/nuget-version-matrix/${{ matrix.sample }}/compatibility-report.json
+            examples/migrations/nuget-version-matrix/${{ matrix.sample }}/compatibility-report.md
+            examples/migrations/nuget-version-matrix/${{ matrix.sample }}/diff-report.md
+            examples/migrations/nuget-version-matrix/${{ matrix.sample }}/strategies/
+            examples/migrations/nuget-version-matrix/${{ matrix.sample }}/v*/manifest.wrapgod.json
+          if-no-files-found: error

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ This folder contains a runnable, end-to-end workflow demo for issue #43.
 - `Acme.Lib` — tiny third-party library we will wrap
 - `WrapGod.WorkflowDemo` — console app that executes the full WrapGod flow
 - `migrations/serilog-nlog-bidirectional` — bidirectional Serilog <-> NLog integration pack with parity tests
+- `migrations/nuget-version-matrix` — version-divergence example packs (FluentAssertions/Moq/Serilog) with compatibility reports and CI drift guards
 
 ## What the demo does
 

--- a/examples/migrations/nuget-version-matrix/ci-behavior.md
+++ b/examples/migrations/nuget-version-matrix/ci-behavior.md
@@ -1,0 +1,39 @@
+# NuGet Version-Matrix CI Behavior
+
+This document describes deterministic pass/fail behavior for the `nuget-version-matrix` CI job.
+
+## Coverage
+
+The workflow validates all tracked version-divergence examples:
+
+- `fluent-assertions` (`v5`, `v6`, `v8`)
+- `moq` (`v4.10`, `v4.16`, `v4.20`)
+- `serilog` (`v2`, `v3`, `v4`)
+
+## Deterministic validation gates
+
+For each sample, CI must pass all gates below:
+
+1. **Structure gate**
+   - Sample folder exists.
+   - Each expected version folder includes `manifest.wrapgod.json`.
+
+2. **Report artifact gate**
+   - `compatibility-report.json`, `compatibility-report.md`, and `diff-report.md` must exist.
+
+3. **Schema + content gate**
+   - `CompatibilityReportSchemaTests` and `ManifestSchemaTests` pass.
+   - `compatibility-report.md` must include package name and all declared versions from `compatibility-report.json`.
+
+4. **Drift guard gate**
+   - `diff-report.md` must be non-trivial (length threshold check) to avoid accidentally-empty reports.
+
+5. **Artifact publication gate**
+   - CI uploads compatibility report artifacts and manifests for each sample.
+   - Missing artifact files fail the run.
+
+## Failure behavior
+
+A run fails immediately for a sample if any required file is missing, schema validation fails, markdown and JSON drift, or artifacts are not publishable.
+
+This ensures repeatable pass/fail behavior and reduces silent regressions in version-matrix examples.


### PR DESCRIPTION
## Summary\n- add a dedicated 
uget-version-matrix CI matrix job for fluent-assertions, moq, and serilog samples\n- validate required version manifests and compatibility report artifacts per sample\n- run schema-focused tests (CompatibilityReportSchemaTests|ManifestSchemaTests) to fail on schema/report drift\n- upload compatibility report + strategy + manifest artifacts per sample\n- document deterministic pass/fail behavior in xamples/migrations/nuget-version-matrix/ci-behavior.md\n\nCloses #169