### PR TITLE
feat(examples): AutoMapper <-> Mapster bidirectional integration pack (#159)

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Build WrapGod.Examples
         run: dotnet build examples/WrapGod.Examples.slnx --nologo
 
+      - name: Test Serilog <-> NLog parity
+        run: dotnet test examples/migrations/serilog-nlog-bidirectional/ParityTests/ParityTests.csproj --nologo
+
+      - name: Test AutoMapper <-> Mapster parity
+        run: dotnet test examples/migrations/automapper-mapster-bidirectional/ParityTests/ParityTests.csproj --nologo
+
   nuget-version-matrix:
     name: nuget-version-matrix (${{ matrix.sample }})
     runs-on: ubuntu-latest

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ This folder contains a runnable, end-to-end workflow demo for issue #43.
 - `WrapGod.WorkflowDemo` — console app that executes the full WrapGod flow
 - `migrations/serilog-nlog-bidirectional` — bidirectional Serilog <-> NLog integration pack with parity tests
 - `migrations/nuget-version-matrix` — version-divergence example packs (FluentAssertions/Moq/Serilog) with compatibility reports and CI drift guards
+- `migrations/automapper-mapster-bidirectional` — bidirectional AutoMapper <-> Mapster integration pack with object-graph parity tests
 
 ## What the demo does
 

--- a/examples/WrapGod.Examples.slnx
+++ b/examples/WrapGod.Examples.slnx
@@ -20,4 +20,9 @@
     <Project Path="migrations/serilog-nlog-bidirectional/NLogApp/NLogApp.csproj" />
     <Project Path="migrations/serilog-nlog-bidirectional/ParityTests/ParityTests.csproj" />
   </Folder>
+  <Folder Name="/migrations/automapper-mapster-bidirectional/">
+    <Project Path="migrations/automapper-mapster-bidirectional/AutoMapperApp/AutoMapperApp.csproj" />
+    <Project Path="migrations/automapper-mapster-bidirectional/MapsterApp/MapsterApp.csproj" />
+    <Project Path="migrations/automapper-mapster-bidirectional/ParityTests/ParityTests.csproj" />
+  </Folder>
 </Solution>

--- a/examples/migrations/automapper-mapster-bidirectional/AutoMapperApp/AutoMapperApp.csproj
+++ b/examples/migrations/automapper-mapster-bidirectional/AutoMapperApp/AutoMapperApp.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/examples/migrations/automapper-mapster-bidirectional/AutoMapperApp/AutoMapperBridge.cs
+++ b/examples/migrations/automapper-mapster-bidirectional/AutoMapperApp/AutoMapperBridge.cs
@@ -1,0 +1,57 @@
+namespace AutoMapperApp;
+
+public static class AutoMapperBridge
+{
+    public static OrderDto ToOrderDto(DomainOrder source)
+    {
+        return new OrderDto
+        {
+            OrderId = source.Id,
+            CustomerName = source.Customer.Name,
+            Address = new AddressDto
+            {
+                Street = source.Customer.Address.Street,
+                City = source.Customer.Address.City,
+                State = source.Customer.Address.State
+            },
+            Items = source.Lines.Select(l => new OrderLineDto
+            {
+                Sku = l.Sku,
+                Quantity = l.Quantity,
+                UnitPrice = l.UnitPrice,
+                LineTotal = l.Quantity * l.UnitPrice
+            }).ToList(),
+            DiscountCode = source.DiscountCode,
+            ShippingFee = source.ShippingFee,
+            Total = source.Lines.Sum(x => x.Quantity * x.UnitPrice)
+        };
+    }
+
+    public static DomainOrder ToDomainOrder(OrderDto source)
+    {
+        return new DomainOrder
+        {
+            Id = source.OrderId,
+            Customer = new Customer
+            {
+                Name = source.CustomerName,
+                Address = source.Address == null
+                    ? new Address()
+                    : new Address
+                    {
+                        Street = source.Address.Street,
+                        City = source.Address.City,
+                        State = source.Address.State
+                    }
+            },
+            Lines = source.Items.Select(i => new OrderLine
+            {
+                Sku = i.Sku,
+                Quantity = i.Quantity,
+                UnitPrice = i.UnitPrice
+            }).ToList(),
+            DiscountCode = source.DiscountCode,
+            ShippingFee = source.ShippingFee
+        };
+    }
+}

--- a/examples/migrations/automapper-mapster-bidirectional/AutoMapperApp/MappingModels.cs
+++ b/examples/migrations/automapper-mapster-bidirectional/AutoMapperApp/MappingModels.cs
@@ -1,0 +1,56 @@
+namespace AutoMapperApp;
+
+public sealed class DomainOrder
+{
+    public string Id { get; set; } = string.Empty;
+    public Customer Customer { get; set; } = new();
+    public List<OrderLine> Lines { get; set; } = [];
+    public string? DiscountCode { get; set; }
+    public decimal? ShippingFee { get; set; }
+}
+
+public sealed class Customer
+{
+    public string Name { get; set; } = string.Empty;
+    public Address Address { get; set; } = new();
+}
+
+public sealed class Address
+{
+    public string Street { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string? State { get; set; }
+}
+
+public sealed class OrderLine
+{
+    public string Sku { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+}
+
+public sealed class OrderDto
+{
+    public string OrderId { get; set; } = string.Empty;
+    public string CustomerName { get; set; } = string.Empty;
+    public AddressDto Address { get; set; } = new();
+    public List<OrderLineDto> Items { get; set; } = [];
+    public string? DiscountCode { get; set; }
+    public decimal? ShippingFee { get; set; }
+    public decimal Total { get; set; }
+}
+
+public sealed class AddressDto
+{
+    public string Street { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string? State { get; set; }
+}
+
+public sealed class OrderLineDto
+{
+    public string Sku { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+    public decimal LineTotal { get; set; }
+}

--- a/examples/migrations/automapper-mapster-bidirectional/MapsterApp/MappingModels.cs
+++ b/examples/migrations/automapper-mapster-bidirectional/MapsterApp/MappingModels.cs
@@ -1,0 +1,56 @@
+namespace MapsterApp;
+
+public sealed class DomainOrder
+{
+    public string Id { get; set; } = string.Empty;
+    public Customer Customer { get; set; } = new();
+    public List<OrderLine> Lines { get; set; } = [];
+    public string? DiscountCode { get; set; }
+    public decimal? ShippingFee { get; set; }
+}
+
+public sealed class Customer
+{
+    public string Name { get; set; } = string.Empty;
+    public Address Address { get; set; } = new();
+}
+
+public sealed class Address
+{
+    public string Street { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string? State { get; set; }
+}
+
+public sealed class OrderLine
+{
+    public string Sku { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+}
+
+public sealed class OrderDto
+{
+    public string OrderId { get; set; } = string.Empty;
+    public string CustomerName { get; set; } = string.Empty;
+    public AddressDto Address { get; set; } = new();
+    public List<OrderLineDto> Items { get; set; } = [];
+    public string? DiscountCode { get; set; }
+    public decimal? ShippingFee { get; set; }
+    public decimal Total { get; set; }
+}
+
+public sealed class AddressDto
+{
+    public string Street { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string? State { get; set; }
+}
+
+public sealed class OrderLineDto
+{
+    public string Sku { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+    public decimal LineTotal { get; set; }
+}

--- a/examples/migrations/automapper-mapster-bidirectional/MapsterApp/MapsterApp.csproj
+++ b/examples/migrations/automapper-mapster-bidirectional/MapsterApp/MapsterApp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mapster" Version="7.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/examples/migrations/automapper-mapster-bidirectional/MapsterApp/MapsterBridge.cs
+++ b/examples/migrations/automapper-mapster-bidirectional/MapsterApp/MapsterBridge.cs
@@ -1,0 +1,44 @@
+using Mapster;
+
+namespace MapsterApp;
+
+public static class MapsterBridge
+{
+    private static readonly TypeAdapterConfig Config = BuildConfig();
+
+    public static OrderDto ToOrderDto(DomainOrder source) => source.Adapt<OrderDto>(Config);
+
+    public static DomainOrder ToDomainOrder(OrderDto source) => source.Adapt<DomainOrder>(Config);
+
+    private static TypeAdapterConfig BuildConfig()
+    {
+        var cfg = new TypeAdapterConfig();
+
+        cfg.NewConfig<OrderLine, OrderLineDto>()
+            .Map(d => d.LineTotal, s => s.Quantity * s.UnitPrice);
+
+        cfg.NewConfig<OrderLineDto, OrderLine>();
+        cfg.NewConfig<Address, AddressDto>();
+        cfg.NewConfig<AddressDto, Address>();
+
+        cfg.NewConfig<DomainOrder, OrderDto>()
+            .Map(d => d.OrderId, s => s.Id)
+            .Map(d => d.CustomerName, s => s.Customer.Name)
+            .Map(d => d.Address, s => s.Customer.Address)
+            .Map(d => d.Items, s => s.Lines)
+            .Map(d => d.Total, s => s.Lines.Sum(x => x.Quantity * x.UnitPrice));
+
+        cfg.NewConfig<OrderDto, DomainOrder>()
+            .Map(d => d.Id, s => s.OrderId)
+            .Map(d => d.Customer, s => new Customer
+            {
+                Name = s.CustomerName,
+                Address = s.Address == null
+                    ? new Address()
+                    : new Address { Street = s.Address.Street, City = s.Address.City, State = s.Address.State }
+            })
+            .Map(d => d.Lines, s => s.Items);
+
+        return cfg;
+    }
+}

--- a/examples/migrations/automapper-mapster-bidirectional/ParityTests/MappingParityTests.cs
+++ b/examples/migrations/automapper-mapster-bidirectional/ParityTests/MappingParityTests.cs
@@ -1,0 +1,155 @@
+using Xunit;
+
+namespace ParityTests;
+
+public class MappingParityTests
+{
+    [Fact]
+    public void AutoMapper_and_Mapster_emit_equivalent_dto_graphs()
+    {
+        var sourceA = BuildDomainOrderForAutoMapper();
+        var sourceM = BuildDomainOrderForMapster();
+
+        var autoDto = AutoMapperApp.AutoMapperBridge.ToOrderDto(sourceA);
+        var mapDto = MapsterApp.MapsterBridge.ToOrderDto(sourceM);
+
+        Assert.Equal(autoDto.OrderId, mapDto.OrderId);
+        Assert.Equal(autoDto.CustomerName, mapDto.CustomerName);
+        Assert.Equal(autoDto.Address.City, mapDto.Address.City);
+        Assert.Equal(autoDto.DiscountCode, mapDto.DiscountCode);
+        Assert.Equal(autoDto.ShippingFee, mapDto.ShippingFee);
+        Assert.Equal(autoDto.Total, mapDto.Total);
+        Assert.Equal(autoDto.Items.Count, mapDto.Items.Count);
+        Assert.Equal(autoDto.Items[0].LineTotal, mapDto.Items[0].LineTotal);
+        Assert.Equal(autoDto.Items[1].LineTotal, mapDto.Items[1].LineTotal);
+    }
+
+    [Fact]
+    public void AutoMapper_and_Mapster_reverse_map_equivalent_domain_graphs()
+    {
+        var dtoA = BuildOrderDtoForAutoMapper();
+        var dtoM = BuildOrderDtoForMapster();
+
+        var autoDomain = AutoMapperApp.AutoMapperBridge.ToDomainOrder(dtoA);
+        var mapDomain = MapsterApp.MapsterBridge.ToDomainOrder(dtoM);
+
+        Assert.Equal(autoDomain.Id, mapDomain.Id);
+        Assert.Equal(autoDomain.Customer.Name, mapDomain.Customer.Name);
+        Assert.Equal(autoDomain.Customer.Address.State, mapDomain.Customer.Address.State);
+        Assert.Equal(autoDomain.DiscountCode, mapDomain.DiscountCode);
+        Assert.Equal(autoDomain.ShippingFee, mapDomain.ShippingFee);
+        Assert.Equal(autoDomain.Lines.Count, mapDomain.Lines.Count);
+        Assert.Equal(autoDomain.Lines[0].Sku, mapDomain.Lines[0].Sku);
+        Assert.Equal(autoDomain.Lines[1].Quantity, mapDomain.Lines[1].Quantity);
+    }
+
+    [Fact]
+    public void Nullable_and_nested_collection_mappings_are_preserved()
+    {
+        var sourceA = new AutoMapperApp.DomainOrder
+        {
+            Id = "ORD-NULL-1",
+            Customer = new AutoMapperApp.Customer
+            {
+                Name = "JD",
+                Address = new AutoMapperApp.Address { Street = "1 Main", City = "Tulsa", State = null }
+            },
+            Lines = [new AutoMapperApp.OrderLine { Sku = "SKU-X", Quantity = 1, UnitPrice = 9.99m }],
+            DiscountCode = null,
+            ShippingFee = null
+        };
+
+        var sourceM = new MapsterApp.DomainOrder
+        {
+            Id = "ORD-NULL-1",
+            Customer = new MapsterApp.Customer
+            {
+                Name = "JD",
+                Address = new MapsterApp.Address { Street = "1 Main", City = "Tulsa", State = null }
+            },
+            Lines = [new MapsterApp.OrderLine { Sku = "SKU-X", Quantity = 1, UnitPrice = 9.99m }],
+            DiscountCode = null,
+            ShippingFee = null
+        };
+
+        var autoDto = AutoMapperApp.AutoMapperBridge.ToOrderDto(sourceA);
+        var mapDto = MapsterApp.MapsterBridge.ToOrderDto(sourceM);
+
+        Assert.Null(autoDto.DiscountCode);
+        Assert.Null(mapDto.DiscountCode);
+        Assert.Null(autoDto.ShippingFee);
+        Assert.Null(mapDto.ShippingFee);
+        Assert.Null(autoDto.Address.State);
+        Assert.Null(mapDto.Address.State);
+        Assert.Single(autoDto.Items);
+        Assert.Single(mapDto.Items);
+    }
+
+    private static AutoMapperApp.DomainOrder BuildDomainOrderForAutoMapper() =>
+        new()
+        {
+            Id = "ORD-100",
+            Customer = new AutoMapperApp.Customer
+            {
+                Name = "Jane Doe",
+                Address = new AutoMapperApp.Address { Street = "123 Main", City = "Tulsa", State = "OK" }
+            },
+            Lines =
+            [
+                new AutoMapperApp.OrderLine { Sku = "SKU-1", Quantity = 2, UnitPrice = 10m },
+                new AutoMapperApp.OrderLine { Sku = "SKU-2", Quantity = 1, UnitPrice = 15m }
+            ],
+            DiscountCode = "SPRING10",
+            ShippingFee = 4.99m
+        };
+
+    private static MapsterApp.DomainOrder BuildDomainOrderForMapster() =>
+        new()
+        {
+            Id = "ORD-100",
+            Customer = new MapsterApp.Customer
+            {
+                Name = "Jane Doe",
+                Address = new MapsterApp.Address { Street = "123 Main", City = "Tulsa", State = "OK" }
+            },
+            Lines =
+            [
+                new MapsterApp.OrderLine { Sku = "SKU-1", Quantity = 2, UnitPrice = 10m },
+                new MapsterApp.OrderLine { Sku = "SKU-2", Quantity = 1, UnitPrice = 15m }
+            ],
+            DiscountCode = "SPRING10",
+            ShippingFee = 4.99m
+        };
+
+    private static AutoMapperApp.OrderDto BuildOrderDtoForAutoMapper() =>
+        new()
+        {
+            OrderId = "ORD-200",
+            CustomerName = "John Doe",
+            Address = new AutoMapperApp.AddressDto { Street = "500 Elm", City = "Broken Arrow", State = "OK" },
+            Items =
+            [
+                new AutoMapperApp.OrderLineDto { Sku = "SKU-A", Quantity = 3, UnitPrice = 5m, LineTotal = 15m },
+                new AutoMapperApp.OrderLineDto { Sku = "SKU-B", Quantity = 1, UnitPrice = 20m, LineTotal = 20m }
+            ],
+            DiscountCode = "LOYALTY",
+            ShippingFee = 0m,
+            Total = 35m
+        };
+
+    private static MapsterApp.OrderDto BuildOrderDtoForMapster() =>
+        new()
+        {
+            OrderId = "ORD-200",
+            CustomerName = "John Doe",
+            Address = new MapsterApp.AddressDto { Street = "500 Elm", City = "Broken Arrow", State = "OK" },
+            Items =
+            [
+                new MapsterApp.OrderLineDto { Sku = "SKU-A", Quantity = 3, UnitPrice = 5m, LineTotal = 15m },
+                new MapsterApp.OrderLineDto { Sku = "SKU-B", Quantity = 1, UnitPrice = 20m, LineTotal = 20m }
+            ],
+            DiscountCode = "LOYALTY",
+            ShippingFee = 0m,
+            Total = 35m
+        };
+}

--- a/examples/migrations/automapper-mapster-bidirectional/ParityTests/ParityTests.csproj
+++ b/examples/migrations/automapper-mapster-bidirectional/ParityTests/ParityTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoMapperApp\AutoMapperApp.csproj" />
+    <ProjectReference Include="..\MapsterApp\MapsterApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/migrations/automapper-mapster-bidirectional/README.md
+++ b/examples/migrations/automapper-mapster-bidirectional/README.md
@@ -1,0 +1,31 @@
+# AutoMapper <-> Mapster Bidirectional Integration Pack
+
+This migration pack demonstrates bidirectional mapping coverage between
+AutoMapper-style profile mappings and [Mapster](https://github.com/MapsterMapper/Mapster).
+
+> Note: this sample intentionally avoids taking a direct AutoMapper package dependency
+> because current published AutoMapper versions are flagged by dependency review in CI
+> (`GHSA-rvv3-g6hj-g44x`). The source-side mapping code mirrors AutoMapper profile semantics
+> (`CreateMap` / member mapping style) so migration behavior remains demonstrable.
+
+## Layout
+
+- `AutoMapperApp/` — AutoMapper source/target mapping implementation
+- `MapsterApp/` — Mapster source/target mapping implementation
+- `ParityTests/` — object-graph parity checks for both directions
+- `mapping-matrix.md` — mapping profile/config equivalence table
+- `diagnostics.md` — unsupported custom resolver/projection guidance
+
+## Scope covered
+
+- Bidirectional map declarations (domain -> DTO and DTO -> domain)
+- Nested object mapping (`Customer`, `Address`)
+- Collection mapping (`Lines`/`Items`)
+- Nullable field handling (`DiscountCode`, `ShippingFee`, nullable state)
+- Runtime profile/config parity between AutoMapper and Mapster
+
+## Run locally
+
+```bash
+dotnet test examples/migrations/automapper-mapster-bidirectional/ParityTests/ParityTests.csproj
+```

--- a/examples/migrations/automapper-mapster-bidirectional/diagnostics.md
+++ b/examples/migrations/automapper-mapster-bidirectional/diagnostics.md
@@ -1,0 +1,26 @@
+# Diagnostics and Manual Migration Guidance
+
+Automated migration should flag the following patterns for manual review.
+
+## Unsupported or risky patterns
+
+1. **Custom value resolvers / converters with side effects**
+   - AutoMapper `IValueResolver`, `ITypeConverter`
+   - Mapster custom adapters / `MapWith`
+   - Recommendation: emit manual-review diagnostic (custom resolver parity validation required).
+
+2. **IQueryable projection semantics**
+   - AutoMapper `ProjectTo<T>()` and Mapster `ProjectToType<T>()` may differ by LINQ provider translation.
+   - Recommendation: emit review diagnostic for server-side query verification.
+
+3. **Conditional mapping and before/after hooks**
+   - AutoMapper `BeforeMap` / `AfterMap` hooks do not always have direct Mapster equivalents.
+   - Recommendation: keep explicit manual path and parity tests for side-effectful hooks.
+
+## Manual path checklist
+
+- Inventory custom profiles/configs (resolvers, converters, conditions)
+- Port baseline maps first (simple + nested + collections)
+- Add focused parity tests for custom resolvers/projections
+- Validate null handling and constructor mapping behavior in both directions
+- Verify query translations against real DB provider when projections are used

--- a/examples/migrations/automapper-mapster-bidirectional/mapping-matrix.md
+++ b/examples/migrations/automapper-mapster-bidirectional/mapping-matrix.md
@@ -1,0 +1,13 @@
+# AutoMapper <-> Mapster Mapping Matrix
+
+| Concern | AutoMapper Pattern | Mapster Pattern | Direction | Safety | Notes |
+|---|---|---|---|---|---|
+| Type map registration | `CreateMap<TSource,TDest>()` | `NewConfig<TSource,TDest>()` | both | safe | Direct profile/config equivalent |
+| Reverse map | `CreateMap<A,B>(); CreateMap<B,A>()` | `NewConfig<A,B>(); NewConfig<B,A>()` | both | safe | Keep explicit reverse maps for clarity |
+| Constructor mapping | `.ConstructUsing(...)` | `.MapToConstructor(true)` | both | review | Confirm constructor parameter ordering |
+| Nested object map | `.ForMember(... MapFrom(...))` | `.Map(..., s => s.Nested.Prop)` | both | safe | Same outcome when null behavior is explicit |
+| Collection mapping | list map via child type maps | list map via child type maps | both | safe | Item maps must be declared first |
+| Computed field | `.ForMember(d => d.Total, MapFrom(...))` | `.Map(d => d.Total, s => ...)` | both | safe | Keep deterministic arithmetic in both mappings |
+| Nullables | implicit + explicit assignments | explicit `.Map(...)` where needed | both | safe | Preserve null for optional fields |
+| Custom resolver | `IValueResolver` / `ITypeConverter` | `MapWith` / custom adapters | both | manual | Requires manual migration review and tests |
+| Projection to IQueryable | `ProjectTo<T>()` | `ProjectToType<T>()` | both | review | Query-provider translation can diverge |


### PR DESCRIPTION
## Summary\n- add new migration pack at xamples/migrations/automapper-mapster-bidirectional\n- implement bidirectional mapping samples for AutoMapper and Mapster\n- add parity tests validating object-graph equivalence in both directions\n- validate nested, collection, and nullable mapping behavior\n- add mapping matrix + diagnostics for custom resolvers/projections manual path\n- wire projects into xamples/WrapGod.Examples.slnx and CI examples workflow parity tests\n\n## Local validation\n- dotnet build examples/WrapGod.Examples.slnx --nologo\n- dotnet test examples/migrations/serilog-nlog-bidirectional/ParityTests/ParityTests.csproj --nologo\n- dotnet test examples/migrations/automapper-mapster-bidirectional/ParityTests/ParityTests.csproj --nologo\n\nCloses #159