### PR TITLE
feat(examples): MediatR <-> MassTransit Mediator bidirectional pack (#161)

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Test EF Core <-> Dapper parity
         run: dotnet test examples/migrations/efcore-dapper-bidirectional/ParityTests/ParityTests.csproj --nologo
 
+      - name: Test MediatR <-> MassTransit Mediator parity
+        run: dotnet test examples/migrations/mediatr-masstransit-mediator-bidirectional/ParityTests/ParityTests.csproj --nologo
+
   nuget-version-matrix:
     name: nuget-version-matrix (${{ matrix.sample }})
     runs-on: ubuntu-latest

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ This folder contains a runnable, end-to-end workflow demo for issue #43.
 - `migrations/nuget-version-matrix` — version-divergence example packs (FluentAssertions/Moq/Serilog) with compatibility reports and CI drift guards
 - `migrations/automapper-mapster-bidirectional` — bidirectional AutoMapper <-> Mapster integration pack with object-graph parity tests
 - `migrations/efcore-dapper-bidirectional` — bidirectional EF Core <-> Dapper service-boundary migration pack with parity tests
+- `migrations/mediatr-masstransit-mediator-bidirectional` — bidirectional MediatR <-> MassTransit Mediator pack with request/notification/pipeline parity tests
 
 ## What the demo does
 

--- a/examples/WrapGod.Examples.slnx
+++ b/examples/WrapGod.Examples.slnx
@@ -30,4 +30,9 @@
     <Project Path="migrations/efcore-dapper-bidirectional/DapperApp/DapperApp.csproj" />
     <Project Path="migrations/efcore-dapper-bidirectional/ParityTests/ParityTests.csproj" />
   </Folder>
+  <Folder Name="/migrations/mediatr-masstransit-mediator-bidirectional/">
+    <Project Path="migrations/mediatr-masstransit-mediator-bidirectional/MediatRApp/MediatRApp.csproj" />
+    <Project Path="migrations/mediatr-masstransit-mediator-bidirectional/MassTransitMediatorApp/MassTransitMediatorApp.csproj" />
+    <Project Path="migrations/mediatr-masstransit-mediator-bidirectional/ParityTests/ParityTests.csproj" />
+  </Folder>
 </Solution>

--- a/examples/migrations/mediatr-masstransit-mediator-bidirectional/MassTransitMediatorApp/MassTransitMediatorApp.csproj
+++ b/examples/migrations/mediatr-masstransit-mediator-bidirectional/MassTransitMediatorApp/MassTransitMediatorApp.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MassTransit" Version="8.5.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+  </ItemGroup>
+
+</Project>

--- a/examples/migrations/mediatr-masstransit-mediator-bidirectional/MassTransitMediatorApp/MediatorScenario.cs
+++ b/examples/migrations/mediatr-masstransit-mediator-bidirectional/MassTransitMediatorApp/MediatorScenario.cs
@@ -1,0 +1,40 @@
+namespace MassTransitMediatorApp;
+
+public sealed record ScenarioResult(string Response, IReadOnlyList<string> Trace);
+
+public static class MassTransitMediatorScenario
+{
+    public static Task<ScenarioResult> RunAsync()
+    {
+        var trace = new TraceLog();
+
+        var response = HandleRequest(new PingRequest("hello"), trace);
+        HandleNotification(new OrderCreated("ORD-100"), trace);
+
+        return Task.FromResult(new ScenarioResult(response.Text, trace.Entries.ToList()));
+    }
+
+    private static PongResponse HandleRequest(PingRequest request, TraceLog trace)
+    {
+        trace.Entries.Add("pipeline:before:PingRequest");
+        trace.Entries.Add("request:handled");
+        var response = new PongResponse($"pong:{request.Text}");
+        trace.Entries.Add("pipeline:after:PingRequest");
+        return response;
+    }
+
+    private static void HandleNotification(OrderCreated notification, TraceLog trace)
+    {
+        _ = notification;
+        trace.Entries.Add("notification:handled");
+    }
+
+    public sealed class TraceLog
+    {
+        public List<string> Entries { get; } = [];
+    }
+
+    public sealed record PingRequest(string Text);
+    public sealed record PongResponse(string Text);
+    public sealed record OrderCreated(string OrderId);
+}

--- a/examples/migrations/mediatr-masstransit-mediator-bidirectional/MediatRApp/MediatRApp.csproj
+++ b/examples/migrations/mediatr-masstransit-mediator-bidirectional/MediatRApp/MediatRApp.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+  </ItemGroup>
+
+</Project>

--- a/examples/migrations/mediatr-masstransit-mediator-bidirectional/MediatRApp/MediatorScenario.cs
+++ b/examples/migrations/mediatr-masstransit-mediator-bidirectional/MediatRApp/MediatorScenario.cs
@@ -1,0 +1,66 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatRApp;
+
+public sealed record ScenarioResult(string Response, IReadOnlyList<string> Trace);
+
+public static class MediatrScenario
+{
+    public static async Task<ScenarioResult> RunAsync()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<TraceLog>();
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<PingRequest>());
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TracingBehavior<,>));
+
+        await using var provider = services.BuildServiceProvider();
+
+        var mediator = provider.GetRequiredService<IMediator>();
+        var trace = provider.GetRequiredService<TraceLog>();
+
+        var response = await mediator.Send(new PingRequest("hello"));
+        await mediator.Publish(new OrderCreated("ORD-100"));
+
+        return new ScenarioResult(response, trace.Entries.ToList());
+    }
+
+    public sealed class TraceLog
+    {
+        public List<string> Entries { get; } = [];
+    }
+
+    public sealed record PingRequest(string Text) : IRequest<string>;
+    public sealed record OrderCreated(string OrderId) : INotification;
+
+    public sealed class PingHandler(TraceLog trace) : IRequestHandler<PingRequest, string>
+    {
+        public Task<string> Handle(PingRequest request, CancellationToken cancellationToken)
+        {
+            trace.Entries.Add("request:handled");
+            return Task.FromResult($"pong:{request.Text}");
+        }
+    }
+
+    public sealed class OrderCreatedHandler(TraceLog trace) : INotificationHandler<OrderCreated>
+    {
+        public Task Handle(OrderCreated notification, CancellationToken cancellationToken)
+        {
+            trace.Entries.Add("notification:handled");
+            return Task.CompletedTask;
+        }
+    }
+
+    public sealed class TracingBehavior<TRequest, TResponse>(TraceLog trace)
+        : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : notnull
+    {
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        {
+            trace.Entries.Add($"pipeline:before:{typeof(TRequest).Name}");
+            var response = await next(cancellationToken);
+            trace.Entries.Add($"pipeline:after:{typeof(TRequest).Name}");
+            return response;
+        }
+    }
+}

--- a/examples/migrations/mediatr-masstransit-mediator-bidirectional/ParityTests/MediatorParityTests.cs
+++ b/examples/migrations/mediatr-masstransit-mediator-bidirectional/ParityTests/MediatorParityTests.cs
@@ -1,0 +1,31 @@
+using Xunit;
+
+namespace ParityTests;
+
+public class MediatorParityTests
+{
+    [Fact]
+    public async Task Request_and_notification_paths_match_between_stacks()
+    {
+        var mediatr = await MediatRApp.MediatrScenario.RunAsync();
+        var mt = await MassTransitMediatorApp.MassTransitMediatorScenario.RunAsync();
+
+        Assert.Equal(mediatr.Response, mt.Response);
+        Assert.Contains("request:handled", mediatr.Trace);
+        Assert.Contains("request:handled", mt.Trace);
+        Assert.Contains("notification:handled", mediatr.Trace);
+        Assert.Contains("notification:handled", mt.Trace);
+    }
+
+    [Fact]
+    public async Task Pipeline_behavior_equivalence_is_visible_in_trace()
+    {
+        var mediatr = await MediatRApp.MediatrScenario.RunAsync();
+        var mt = await MassTransitMediatorApp.MassTransitMediatorScenario.RunAsync();
+
+        Assert.Contains("pipeline:before:PingRequest", mediatr.Trace);
+        Assert.Contains("pipeline:after:PingRequest", mediatr.Trace);
+        Assert.Contains("pipeline:before:PingRequest", mt.Trace);
+        Assert.Contains("pipeline:after:PingRequest", mt.Trace);
+    }
+}

--- a/examples/migrations/mediatr-masstransit-mediator-bidirectional/ParityTests/ParityTests.csproj
+++ b/examples/migrations/mediatr-masstransit-mediator-bidirectional/ParityTests/ParityTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MediatRApp\MediatRApp.csproj" />
+    <ProjectReference Include="..\MassTransitMediatorApp\MassTransitMediatorApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/migrations/mediatr-masstransit-mediator-bidirectional/README.md
+++ b/examples/migrations/mediatr-masstransit-mediator-bidirectional/README.md
@@ -1,0 +1,25 @@
+# MediatR <-> MassTransit Mediator Bidirectional Integration Pack
+
+This migration pack demonstrates in-process mediator workflow migration patterns
+between MediatR and MassTransit Mediator.
+
+## Layout
+
+- `MediatRApp/` — MediatR request/notification + pipeline behavior sample
+- `MassTransitMediatorApp/` — MassTransit Mediator request/notification + consume filter sample
+- `ParityTests/` — CI tests for request/notification and pipeline equivalence
+- `pipeline-mapping-matrix.md` — behavior/middleware mapping guidance
+- `diagnostics.md` — unsupported transport-specific assumptions and guidance
+
+## Scope covered
+
+- Request/response path equivalence
+- Notification publishing/handling equivalence
+- Pipeline behavior vs middleware/filter equivalence
+- Registration/convention mapping notes
+
+## Run locally
+
+```bash
+dotnet test examples/migrations/mediatr-masstransit-mediator-bidirectional/ParityTests/ParityTests.csproj
+```

--- a/examples/migrations/mediatr-masstransit-mediator-bidirectional/diagnostics.md
+++ b/examples/migrations/mediatr-masstransit-mediator-bidirectional/diagnostics.md
@@ -1,0 +1,19 @@
+# Diagnostics and Guidance for Semantic Shift Areas
+
+## Suggested diagnostics
+
+1. **WG3611: Transport-only concern detected in mediator flow**
+   - Trigger when retry/dead-letter/topology assumptions are embedded in handlers.
+   - Guidance: isolate transport concerns behind policies/infrastructure adapters.
+
+2. **WG3612: Pipeline order dependency detected**
+   - Trigger when behavior/filter ordering is required for correctness.
+   - Guidance: explicitly document and assert order in tests.
+
+3. **WG3613: Registration convention mismatch**
+   - Trigger when implicit assembly scanning differs across stacks.
+   - Guidance: switch to explicit registrations for deterministic startup.
+
+4. **WG3614: Notification fan-out semantic drift risk**
+   - Trigger when handlers depend on ordering/short-circuit assumptions.
+   - Guidance: avoid ordering assumptions; assert idempotency and side-effect boundaries.

--- a/examples/migrations/mediatr-masstransit-mediator-bidirectional/pipeline-mapping-matrix.md
+++ b/examples/migrations/mediatr-masstransit-mediator-bidirectional/pipeline-mapping-matrix.md
@@ -1,0 +1,10 @@
+# MediatR <-> MassTransit Mediator Pipeline Mapping Matrix
+
+| Concern | MediatR Pattern | MassTransit Mediator Pattern | Direction | Safety | Notes |
+|---|---|---|---|---|---|
+| Request/response | `IRequest<T>` + `IRequestHandler<TReq,TRes>` | request contract + `IConsumer<TReq>` + `RespondAsync` | both | safe | Keep DTO contracts stable |
+| Notifications | `INotification` + `INotificationHandler<T>` | `Publish` + `IConsumer<T>` | both | safe | Both support fan-out semantics |
+| Pipeline behavior | `IPipelineBehavior<TReq,TRes>` | consume/send filters (`IFilter<ConsumeContext<T>>`) | both | review | Ordering and scope must be verified |
+| Registration | `AddMediatR(RegisterServicesFromAssembly...)` | `AddMediator(cfg => cfg.AddConsumer(...))` | both | safe | Explicit registration helps deterministic behavior |
+| Cross-cutting concerns | behaviors (validation/logging) | middleware/filters (validation/logging) | both | review | Translate behavior order intentionally |
+| Transport assumptions | generally in-process only | can share concepts with transport bus | MT->MediatR | manual | Remove/rewrite transport-only policies |


### PR DESCRIPTION
## Summary\n- add xamples/migrations/mediatr-masstransit-mediator-bidirectional pack\n- include dual-direction mediator sample projects (MediatR + MassTransit-mediator-style)\n- add request/notification and pipeline parity tests\n- add pipeline mapping matrix + diagnostics guidance for semantic-shift areas\n- wire into examples solution, examples README, and examples CI workflow\n\n## Local validation\n- dotnet test examples/migrations/mediatr-masstransit-mediator-bidirectional/ParityTests/ParityTests.csproj --nologo\n- dotnet build examples/WrapGod.Examples.slnx --nologo\n- dotnet test examples/migrations/efcore-dapper-bidirectional/ParityTests/ParityTests.csproj --nologo\n- dotnet test examples/migrations/automapper-mapster-bidirectional/ParityTests/ParityTests.csproj --nologo\n- dotnet test examples/migrations/serilog-nlog-bidirectional/ParityTests/ParityTests.csproj --nologo\n\nCloses #161