### PR TITLE
docs: restructure docfx TOC with proper nesting

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -31,7 +31,11 @@
         ],
         "exclude": [
           "_site/**",
-          "api/.manifest"
+          "api/.manifest",
+          "active/**",
+          "ops/**",
+          "PLAN.md",
+          "WORK-BREAKDOWN.md"
         ]
       },
       {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,33 @@
-# WrapGod documentation
+# WrapGod Documentation
 
-WrapGod helps you extract API manifests and generate wrappers to keep consumers decoupled from third-party dependency churn.
+WrapGod generates type-safe wrapper interfaces over third-party .NET APIs so your application code never touches vendor types directly. Upgrade, swap, or support multiple versions — without refactoring a single line.
 
-## Guides
+## Getting Started
 
-- [Quickstart](QUICKSTART.md)
-- [Configuration](CONFIGURATION.md)
-- [Manifest](MANIFEST.md)
-- [Manifest schema](MANIFEST-SCHEMA.md)
-- [Migration playbook](MIGRATION-PLAYBOOK.md)
-- [Compatibility](COMPATIBILITY.md)
-- [Analyzers](ANALYZERS.md)
-- [Architecture](ARCHITECTURE.md)
-- [Engineering](ENGINEERING.md)
-- [Plan](PLAN.md)
-- [Work breakdown](WORK-BREAKDOWN.md)
-- [Quality matrix](QUALITY-MATRIX.md)
+- [Quick Start](QUICKSTART.md) — zero to generated wrappers in 5 minutes
+- [CLI Reference](CLI.md) — all 9 commands with options and examples
+- [Configuration](CONFIGURATION.md) — JSON, attributes, fluent DSL, merge precedence
+- [MSBuild Integration](MSBUILD-INTEGRATION.md) — zero-touch build pipeline with WrapGod.Targets
 
-## References
+## Core Concepts
 
-- [API reference](api/index.md)
-- [RFCs](rfc/0051-extractor-incremental-cache-strategy.md)
-- [Ops notes](ops/workflow-parity-matrix.md)
+- [Architecture](ARCHITECTURE.md) — pipeline overview: Extract → Configure → Generate → Analyze
+- [Manifest Format](MANIFEST.md) — API surface schema, type and member nodes
+- [Manifest Schema](MANIFEST-SCHEMA.md) — JSON schema reference
+- [Compatibility Modes](COMPATIBILITY.md) — LCD, Targeted, and Adaptive strategies
+- [Analyzers & Code Fixes](ANALYZERS.md) — WG2001, WG2002 diagnostics and auto-migration
+
+## Migration
+
+- [Migration Playbook](MIGRATION-PLAYBOOK.md) — strategy selection, safety model, validation checklist
+- [Automation Guide](AUTOMATION.md) — end-to-end automation for eliminating library tech debt
+
+## API Reference
+
+- [API Documentation](api/index.md) — generated API reference for all WrapGod packages
+
+## Engineering
+
+- [Engineering Guide](ENGINEERING.md) — SDK, build conventions, project structure
+- [Coverage Policy](COVERAGE-POLICY.md) — 90% per-package line coverage gate
+- [Quality Matrix](QUALITY-MATRIX.md) — quality metrics and standards

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,47 +1,56 @@
 - name: Home
   href: index.md
-- name: Guides
+
+- name: Getting Started
   items:
-    - name: Quickstart
+    - name: Quick Start
       href: QUICKSTART.md
+    - name: CLI Reference
+      href: CLI.md
     - name: Configuration
       href: CONFIGURATION.md
-    - name: Manifest
-      href: MANIFEST.md
-    - name: Manifest schema
-      href: MANIFEST-SCHEMA.md
-    - name: Migration playbook
-      href: MIGRATION-PLAYBOOK.md
-    - name: Compatibility
-      href: COMPATIBILITY.md
-    - name: Analyzers
-      href: ANALYZERS.md
+    - name: MSBuild Integration
+      href: MSBUILD-INTEGRATION.md
+
+- name: Core Concepts
+  items:
     - name: Architecture
       href: ARCHITECTURE.md
-    - name: Engineering
-      href: ENGINEERING.md
-    - name: Plan
-      href: PLAN.md
-    - name: Work breakdown
-      href: WORK-BREAKDOWN.md
-    - name: Quality matrix
-      href: QUALITY-MATRIX.md
-- name: API reference
+    - name: Manifest Format
+      href: MANIFEST.md
+    - name: Manifest Schema
+      href: MANIFEST-SCHEMA.md
+    - name: Compatibility Modes
+      href: COMPATIBILITY.md
+    - name: Analyzers & Code Fixes
+      href: ANALYZERS.md
+
+- name: Migration
+  items:
+    - name: Migration Playbook
+      href: MIGRATION-PLAYBOOK.md
+    - name: Automation Guide
+      href: AUTOMATION.md
+
+- name: API Reference
   href: api/index.md
   homepage: api/index.md
-- name: Active work
+
+- name: Engineering
   items:
-    - name: Issue #6 - Config ingestion
-      href: active/issue-6-config-ingestion.md
-    - name: Issue #163 - NuGet matrix orchestration
-      href: active/issue-163-orchestration-hygiene-update-path.md
-- name: Operations
-  href: ops/workflow-parity-matrix.md
-- name: RFCs
-  items:
-    - name: RFC 0051 - Extractor incremental cache strategy
-      href: rfc/0051-extractor-incremental-cache-strategy.md
-    - name: RFC 0052 - Performance benchmarks and SLOs
-      href: rfc/RFC-0052-performance-benchmarks-and-slos.md
-    - name: RFC 0054 - Structured diagnostics contract and reporting
-      href: rfc/0054-structured-diagnostics-contract-and-reporting.md
+    - name: Engineering Guide
+      href: ENGINEERING.md
+    - name: Coverage Policy
+      href: COVERAGE-POLICY.md
+    - name: Flake Policy
+      href: FLAKE-POLICY.md
+    - name: Quality Matrix
+      href: QUALITY-MATRIX.md
+    - name: RFCs
+      items:
+        - name: "RFC 0051: Incremental Cache Strategy"
+          href: rfc/0051-extractor-incremental-cache-strategy.md
+        - name: "RFC 0052: Performance Benchmarks & SLOs"
+          href: rfc/RFC-0052-performance-benchmarks-and-slos.md
+        - name: "RFC 0054: Structured Diagnostics"
+          href: rfc/0054-structured-diagnostics-contract-and-reporting.md


### PR DESCRIPTION
## Summary
Restructures the documentation site navigation from a flat list to a properly nested hierarchy.

### Before
- 12 guides dumped at one level alongside internal engineering docs
- Missing pages: CLI.md, AUTOMATION.md, MSBUILD-INTEGRATION.md
- Internal tracking docs (Plan, Work Breakdown, active issues) in public nav

### After
| Section | Contents |
|---------|----------|
| **Getting Started** | Quick Start, CLI Reference, Configuration, MSBuild Integration |
| **Core Concepts** | Architecture, Manifest, Schema, Compatibility, Analyzers |
| **Migration** | Playbook, Automation Guide |
| **API Reference** | Generated API docs |
| **Engineering** | Policies, Quality Matrix, RFCs (nested) |

### Changes
- `docs/toc.yml` — reorganized with 5 top-level sections, proper nesting
- `docs/index.md` — updated to match new structure
- `docs/docfx.json` — excludes internal docs (active/, ops/, Plan, Work Breakdown) from build

🤖 Generated with [Claude Code](https://claude.com/claude-code)