### PR TITLE
feat(migration-engine): #194 WrapGod.Migration.Engine scaffold + IRuleRewriter

### DIFF
--- a/WrapGod.Migration.Engine/AppliedRewrite.cs
+++ b/WrapGod.Migration.Engine/AppliedRewrite.cs
@@ -1,0 +1,16 @@
+namespace WrapGod.Migration.Engine;
+
+/// <summary>
+/// Represents a rewrite that was successfully applied to a source file.
+/// </summary>
+/// <param name="RuleId">The identifier of the <see cref="WrapGod.Migration.MigrationRule"/> that was applied.</param>
+/// <param name="File">Path to the source file that was modified.</param>
+/// <param name="Line">1-based line number of the rewrite site.</param>
+/// <param name="OriginalText">The original source text that was replaced.</param>
+/// <param name="ReplacedWith">The replacement source text.</param>
+public sealed record AppliedRewrite(
+    string RuleId,
+    string File,
+    int Line,
+    string OriginalText,
+    string ReplacedWith);

--- a/WrapGod.Migration.Engine/IRuleRewriter.cs
+++ b/WrapGod.Migration.Engine/IRuleRewriter.cs
@@ -1,0 +1,45 @@
+using Microsoft.CodeAnalysis;
+using WrapGod.Migration;
+
+namespace WrapGod.Migration.Engine;
+
+/// <summary>
+/// A rule rewriter transforms a single <see cref="SyntaxNode"/> according to a
+/// <see cref="MigrationRule"/>, producing a rewritten node or returning <see langword="null"/>
+/// when the rule does not apply to that node.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Trivia contract:</strong> every replacement node MUST preserve leading and trailing
+/// trivia from the original node by calling <c>newNode.WithTriviaFrom(originalNode)</c>
+/// (or the token-level equivalent). Failure to do so will corrupt whitespace and comments
+/// in the output file.
+/// </para>
+/// <para>
+/// <strong>No-match contract:</strong> return <see langword="null"/> when the rule does not
+/// match the current node. Never throw; never return a partially-modified node that is
+/// semantically incorrect. If the match is ambiguous, record a <see cref="SkippedRewrite"/>
+/// via <see cref="RewriteContext"/> and return <see langword="null"/>.
+/// </para>
+/// </remarks>
+public interface IRuleRewriter
+{
+    /// <summary>
+    /// The <see cref="MigrationRuleKind"/> name (camelCase, matches the JSON schema
+    /// discriminator) that this rewriter handles, e.g. <c>"renameType"</c>.
+    /// </summary>
+    string Kind { get; }
+
+    /// <summary>
+    /// Attempts to rewrite <paramref name="node"/> according to <paramref name="rule"/>.
+    /// </summary>
+    /// <param name="node">The syntax node to potentially rewrite.</param>
+    /// <param name="rule">The migration rule to apply.</param>
+    /// <param name="ctx">The rewrite context for recording applied/skipped results.</param>
+    /// <returns>
+    /// A replacement <see cref="SyntaxNode"/> with trivia preserved via
+    /// <c>WithTriviaFrom</c>, or <see langword="null"/> if this rule does not match
+    /// <paramref name="node"/>.
+    /// </returns>
+    SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx);
+}

--- a/WrapGod.Migration.Engine/ManualRewrite.cs
+++ b/WrapGod.Migration.Engine/ManualRewrite.cs
@@ -1,0 +1,16 @@
+namespace WrapGod.Migration.Engine;
+
+/// <summary>
+/// Represents a migration rule with <see cref="WrapGod.Migration.RuleConfidence.Manual"/>
+/// confidence that was identified as potentially applicable but not automatically applied.
+/// </summary>
+/// <param name="RuleId">The identifier of the <see cref="WrapGod.Migration.MigrationRule"/>.</param>
+/// <param name="Note">Human-readable guidance for the manual migration step.</param>
+/// <param name="MatchedFiles">
+/// Files where this rule's pattern was syntactically detected.
+/// May be empty if no syntactic match was found.
+/// </param>
+public sealed record ManualRewrite(
+    string RuleId,
+    string Note,
+    IReadOnlyList<string> MatchedFiles);

--- a/WrapGod.Migration.Engine/MigrationResult.cs
+++ b/WrapGod.Migration.Engine/MigrationResult.cs
@@ -1,0 +1,83 @@
+namespace WrapGod.Migration.Engine;
+
+/// <summary>
+/// Aggregates the results of a migration run across all processed files.
+/// </summary>
+public sealed class MigrationResult
+{
+    /// <summary>All rewrites that were successfully applied.</summary>
+    public IReadOnlyList<AppliedRewrite> Applied { get; }
+
+    /// <summary>All rewrites that were evaluated but not applied.</summary>
+    public IReadOnlyList<SkippedRewrite> Skipped { get; }
+
+    /// <summary>
+    /// Rules with <see cref="WrapGod.Migration.RuleConfidence.Manual"/> confidence that
+    /// require human intervention.
+    /// </summary>
+    public IReadOnlyList<ManualRewrite> Manual { get; }
+
+    /// <summary>
+    /// Per-file rewritten source text (path → new text).
+    /// Populated even during a dry run so callers can inspect the would-be output.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> RewrittenFiles { get; }
+
+    /// <summary>
+    /// <see langword="true"/> if this result was produced by a dry-run pass that did not
+    /// write files to disk.
+    /// </summary>
+    public bool DryRun { get; }
+
+    /// <summary>Total number of rewrites applied across all files.</summary>
+    public int AppliedCount => Applied.Count;
+
+    /// <summary>Total number of rewrites skipped across all files.</summary>
+    public int SkippedCount => Skipped.Count;
+
+    /// <summary>Total number of manual rules identified across all files.</summary>
+    public int ManualCount => Manual.Count;
+
+    /// <summary>
+    /// Initializes a new <see cref="MigrationResult"/>.
+    /// </summary>
+    /// <param name="applied">Applied rewrites. Must not be <see langword="null"/>.</param>
+    /// <param name="skipped">Skipped rewrites. Must not be <see langword="null"/>.</param>
+    /// <param name="manual">Manual rewrites. Must not be <see langword="null"/>.</param>
+    /// <param name="rewrittenFiles">Per-file rewritten text. Must not be <see langword="null"/>.</param>
+    /// <param name="dryRun">Whether this was a dry-run pass.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when any of <paramref name="applied"/>, <paramref name="skipped"/>,
+    /// <paramref name="manual"/>, or <paramref name="rewrittenFiles"/> is
+    /// <see langword="null"/>.
+    /// </exception>
+    public MigrationResult(
+        IReadOnlyList<AppliedRewrite> applied,
+        IReadOnlyList<SkippedRewrite> skipped,
+        IReadOnlyList<ManualRewrite> manual,
+        IReadOnlyDictionary<string, string> rewrittenFiles,
+        bool dryRun)
+    {
+        ArgumentNullException.ThrowIfNull(applied);
+        ArgumentNullException.ThrowIfNull(skipped);
+        ArgumentNullException.ThrowIfNull(manual);
+        ArgumentNullException.ThrowIfNull(rewrittenFiles);
+
+        Applied = applied;
+        Skipped = skipped;
+        Manual = manual;
+        RewrittenFiles = rewrittenFiles;
+        DryRun = dryRun;
+    }
+
+    /// <summary>
+    /// Returns an empty <see cref="MigrationResult"/> with no applied, skipped, or manual
+    /// rewrites and <see cref="DryRun"/> set to <see langword="false"/>.
+    /// </summary>
+    public static MigrationResult Empty { get; } = new(
+        applied: [],
+        skipped: [],
+        manual: [],
+        rewrittenFiles: new Dictionary<string, string>(),
+        dryRun: false);
+}

--- a/WrapGod.Migration.Engine/RewriteContext.cs
+++ b/WrapGod.Migration.Engine/RewriteContext.cs
@@ -1,0 +1,90 @@
+using System.Collections.ObjectModel;
+using Microsoft.CodeAnalysis.Text;
+using WrapGod.Migration;
+
+namespace WrapGod.Migration.Engine;
+
+/// <summary>
+/// Carries per-file context for a rewrite pass and accumulates the audit trail of
+/// applied and skipped rewrites.
+/// </summary>
+public sealed class RewriteContext
+{
+    private readonly List<AppliedRewrite> _applied = [];
+    private readonly List<SkippedRewrite> _skipped = [];
+    private readonly ReadOnlyCollection<AppliedRewrite> _appliedView;
+    private readonly ReadOnlyCollection<SkippedRewrite> _skippedView;
+
+    /// <summary>Absolute or relative path to the source file being rewritten.</summary>
+    public string FilePath { get; }
+
+    /// <summary>
+    /// Read-only view of rewrites that were successfully applied.
+    /// The returned collection cannot be cast to a mutable type.
+    /// </summary>
+    public IReadOnlyList<AppliedRewrite> Applied => _appliedView;
+
+    /// <summary>
+    /// Read-only view of rewrites that were skipped (ambiguous, no-match, etc.).
+    /// The returned collection cannot be cast to a mutable type.
+    /// </summary>
+    public IReadOnlyList<SkippedRewrite> Skipped => _skippedView;
+
+    /// <summary>Initializes a new <see cref="RewriteContext"/> for the given file.</summary>
+    /// <param name="filePath">Absolute or relative path to the source file.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="filePath"/> is <see langword="null"/>.
+    /// </exception>
+    public RewriteContext(string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        FilePath = filePath;
+        _appliedView = _applied.AsReadOnly();
+        _skippedView = _skipped.AsReadOnly();
+    }
+
+    /// <summary>Records a successfully applied rewrite.</summary>
+    /// <param name="rule">The rule that was applied.</param>
+    /// <param name="original">The text span of the original code.</param>
+    /// <param name="originalText">The original source text.</param>
+    /// <param name="replacementText">The replacement source text.</param>
+    /// <param name="line">1-based line number of the rewrite site.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="rule"/>, <paramref name="originalText"/>,
+    /// or <paramref name="replacementText"/> is <see langword="null"/>.
+    /// </exception>
+    public void RecordApplied(
+        MigrationRule rule,
+        TextSpan original,
+        string originalText,
+        string replacementText,
+        int line)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        ArgumentNullException.ThrowIfNull(originalText);
+        ArgumentNullException.ThrowIfNull(replacementText);
+
+        _applied.Add(new AppliedRewrite(rule.Id, FilePath, line, originalText, replacementText));
+    }
+
+    /// <summary>Records a rewrite that was skipped.</summary>
+    /// <param name="rule">The rule that was evaluated.</param>
+    /// <param name="location">The text span of the potential rewrite site.</param>
+    /// <param name="line">1-based line number of the potential rewrite site.</param>
+    /// <param name="reason">Human-readable explanation of why the rewrite was skipped.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="rule"/> or <paramref name="reason"/> is
+    /// <see langword="null"/>.
+    /// </exception>
+    public void RecordSkipped(
+        MigrationRule rule,
+        TextSpan location,
+        int line,
+        string reason)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        ArgumentNullException.ThrowIfNull(reason);
+
+        _skipped.Add(new SkippedRewrite(rule.Id, FilePath, line, reason));
+    }
+}

--- a/WrapGod.Migration.Engine/SkippedRewrite.cs
+++ b/WrapGod.Migration.Engine/SkippedRewrite.cs
@@ -1,0 +1,14 @@
+namespace WrapGod.Migration.Engine;
+
+/// <summary>
+/// Represents a rewrite that was evaluated but not applied.
+/// </summary>
+/// <param name="RuleId">The identifier of the <see cref="WrapGod.Migration.MigrationRule"/> that was evaluated.</param>
+/// <param name="File">Path to the source file where the potential rewrite site was found.</param>
+/// <param name="Line">1-based line number of the potential rewrite site.</param>
+/// <param name="Reason">Human-readable explanation of why the rewrite was not applied.</param>
+public sealed record SkippedRewrite(
+    string RuleId,
+    string File,
+    int Line,
+    string Reason);

--- a/WrapGod.Migration.Engine/TriviaPreservation.cs
+++ b/WrapGod.Migration.Engine/TriviaPreservation.cs
@@ -1,0 +1,33 @@
+using Microsoft.CodeAnalysis;
+
+namespace WrapGod.Migration.Engine;
+
+/// <summary>
+/// Convenience extensions for preserving Roslyn syntax trivia (whitespace, comments,
+/// directives) when rewriting syntax nodes and tokens.
+/// </summary>
+public static class TriviaPreservation
+{
+    /// <summary>
+    /// Replaces <paramref name="oldToken"/> with <paramref name="newToken"/> inside
+    /// <paramref name="node"/>, copying the leading and trailing trivia from
+    /// <paramref name="oldToken"/> to <paramref name="newToken"/> so that surrounding
+    /// whitespace and comments are preserved.
+    /// </summary>
+    /// <typeparam name="T">The concrete <see cref="SyntaxNode"/> type.</typeparam>
+    /// <param name="node">The node that contains <paramref name="oldToken"/>.</param>
+    /// <param name="oldToken">The token to replace.</param>
+    /// <param name="newToken">The replacement token (trivia will be overwritten).</param>
+    /// <returns>
+    /// A new <typeparamref name="T"/> with the token replaced and trivia preserved.
+    /// </returns>
+    public static T WithReplacedToken<T>(this T node, SyntaxToken oldToken, SyntaxToken newToken)
+        where T : SyntaxNode
+    {
+        var triviaPreservedToken = newToken
+            .WithLeadingTrivia(oldToken.LeadingTrivia)
+            .WithTrailingTrivia(oldToken.TrailingTrivia);
+
+        return node.ReplaceToken(oldToken, triviaPreservedToken);
+    }
+}

--- a/WrapGod.Migration.Engine/WrapGod.Migration.Engine.csproj
+++ b/WrapGod.Migration.Engine/WrapGod.Migration.Engine.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WrapGod.Migration\WrapGod.Migration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WrapGod.Tests/Migration/Engine/EngineScaffoldTests.cs
+++ b/WrapGod.Tests/Migration/Engine/EngineScaffoldTests.cs
@@ -1,0 +1,250 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine;
+
+[Feature("WrapGod.Migration.Engine scaffold: contract shape, equality, and immutability")]
+public sealed class EngineScaffoldTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Test double ──────────────────────────────────────────────────────────
+
+    /// <summary>No-op rewriter used as a test double for IRuleRewriter.</summary>
+    private sealed class NullRewriter : IRuleRewriter
+    {
+        public string Kind => "renameType";
+
+        public SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx) => null;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static RenameTypeRule MakeRule(string id = "R-001") =>
+        new RenameTypeRule { Id = id, OldName = "Foo", NewName = "Bar" };
+
+    private static TextSpan AnySpan() => new(0, 4);
+
+    // ── happy ────────────────────────────────────────────────────────────────
+
+    [Scenario("NullRewriter implements IRuleRewriter and is reachable")]
+    [Fact]
+    public Task NullRewriter_ImplementsInterface_IsReachable() =>
+        Given("a NullRewriter instance", () => new NullRewriter())
+        .Then("it implements IRuleRewriter", r => r is IRuleRewriter)
+        .And("Kind is renameType", r => r.Kind == "renameType")
+        .And("TryRewrite returns null for any node", r =>
+        {
+            var tree = CSharpSyntaxTree.ParseText("class C {}");
+            var root = tree.GetRoot();
+            var ctx = new RewriteContext("file.cs");
+            var rule = MakeRule();
+            return r.TryRewrite(root, rule, ctx) is null;
+        })
+        .AssertPassed();
+
+    [Scenario("RewriteContext carries all expected fields after RecordApplied")]
+    [Fact]
+    public Task RewriteContext_RecordApplied_AppendsEntry() =>
+        Given("a fresh RewriteContext and one RecordApplied call", () =>
+        {
+            var ctx = new RewriteContext("foo.cs");
+            ctx.RecordApplied(MakeRule("R-001"), AnySpan(), "old", "new", 12);
+            return ctx;
+        })
+        .Then("Applied has one entry", ctx => ctx.Applied.Count == 1)
+        .And("RuleId is preserved", ctx => ctx.Applied[0].RuleId == "R-001")
+        .And("File is preserved", ctx => ctx.Applied[0].File == "foo.cs")
+        .And("Line is preserved", ctx => ctx.Applied[0].Line == 12)
+        .And("OriginalText is preserved", ctx => ctx.Applied[0].OriginalText == "old")
+        .And("ReplacedWith is preserved", ctx => ctx.Applied[0].ReplacedWith == "new")
+        .AssertPassed();
+
+    [Scenario("RewriteContext accumulates multiple Skipped entries in order")]
+    [Fact]
+    public Task RewriteContext_RecordSkipped_AppendsEntries() =>
+        Given("a RewriteContext with three RecordSkipped calls", () =>
+        {
+            var ctx = new RewriteContext("bar.cs");
+            ctx.RecordSkipped(MakeRule("R-001"), AnySpan(), 1, "reason A");
+            ctx.RecordSkipped(MakeRule("R-002"), AnySpan(), 2, "reason B");
+            ctx.RecordSkipped(MakeRule("R-003"), AnySpan(), 3, "reason C");
+            return ctx;
+        })
+        .Then("Skipped count is 3", ctx => ctx.Skipped.Count == 3)
+        .And("first reason is reason A", ctx => ctx.Skipped[0].Reason == "reason A")
+        .And("second reason is reason B", ctx => ctx.Skipped[1].Reason == "reason B")
+        .And("third reason is reason C", ctx => ctx.Skipped[2].Reason == "reason C")
+        .AssertPassed();
+
+    [Scenario("MigrationResult.Empty has zero counts and DryRun false")]
+    [Fact]
+    public Task MigrationResult_Empty_HasZeroCounts() =>
+        Given("MigrationResult.Empty", () => MigrationResult.Empty)
+        .Then("Applied is empty", r => r.Applied.Count == 0)
+        .And("Skipped is empty", r => r.Skipped.Count == 0)
+        .And("Manual is empty", r => r.Manual.Count == 0)
+        .And("RewrittenFiles is empty", r => r.RewrittenFiles.Count == 0)
+        .And("DryRun is false", r => !r.DryRun)
+        .And("AppliedCount is 0", r => r.AppliedCount == 0)
+        .And("SkippedCount is 0", r => r.SkippedCount == 0)
+        .And("ManualCount is 0", r => r.ManualCount == 0)
+        .AssertPassed();
+
+    [Scenario("AppliedRewrite value-equals when all fields are equal")]
+    [Fact]
+    public Task AppliedRewrite_RecordEquality_Holds() =>
+        Given("two AppliedRewrite records with identical fields", () =>
+        (
+            A: new AppliedRewrite("R-001", "foo.cs", 10, "old", "new"),
+            B: new AppliedRewrite("R-001", "foo.cs", 10, "old", "new")
+        ))
+        .Then("they are equal", t => t.A == t.B)
+        .And("hash codes match", t => t.A.GetHashCode() == t.B.GetHashCode())
+        .AssertPassed();
+
+    [Scenario("SkippedRewrite value-equals when all fields are equal")]
+    [Fact]
+    public Task SkippedRewrite_RecordEquality_Holds() =>
+        Given("two SkippedRewrite records with identical fields", () =>
+        (
+            A: new SkippedRewrite("R-001", "foo.cs", 5, "reason"),
+            B: new SkippedRewrite("R-001", "foo.cs", 5, "reason")
+        ))
+        .Then("they are equal", t => t.A == t.B)
+        .And("hash codes match", t => t.A.GetHashCode() == t.B.GetHashCode())
+        .AssertPassed();
+
+    [Scenario("ManualRewrite value-equals when all fields are equal")]
+    [Fact]
+    public Task ManualRewrite_RecordEquality_Holds() =>
+        Given("two ManualRewrite records with identical fields", () =>
+        {
+            IReadOnlyList<string> files = ["a.cs", "b.cs"];
+            return (
+                A: new ManualRewrite("R-001", "note", files),
+                B: new ManualRewrite("R-001", "note", files)
+            );
+        })
+        .Then("they are equal", t => t.A == t.B)
+        .AssertPassed();
+
+    // ── sad ─────────────────────────────────────────────────────────────────
+
+    [Scenario("RewriteContext throws when filePath is null")]
+    [Fact]
+    public Task RewriteContext_NullFilePath_Throws() =>
+        Given("a null file path", () => (string?)null)
+        .Then("constructing RewriteContext throws ArgumentNullException", path =>
+        {
+            try { _ = new RewriteContext(path!); return false; }
+            catch (ArgumentNullException) { return true; }
+        })
+        .AssertPassed();
+
+    [Scenario("RecordApplied throws when rule is null")]
+    [Fact]
+    public Task RewriteContext_NullRule_Throws() =>
+        Given("a RewriteContext and a null rule", () => new RewriteContext("file.cs"))
+        .Then("RecordApplied throws ArgumentNullException", ctx =>
+        {
+            try { ctx.RecordApplied(null!, AnySpan(), "old", "new", 1); return false; }
+            catch (ArgumentNullException) { return true; }
+        })
+        .AssertPassed();
+
+    [Scenario("RecordSkipped throws when reason is null")]
+    [Fact]
+    public Task RewriteContext_NullReason_Throws() =>
+        Given("a RewriteContext and a null reason", () => new RewriteContext("file.cs"))
+        .Then("RecordSkipped throws ArgumentNullException", ctx =>
+        {
+            try { ctx.RecordSkipped(MakeRule(), AnySpan(), 1, null!); return false; }
+            catch (ArgumentNullException) { return true; }
+        })
+        .AssertPassed();
+
+    [Scenario("MigrationResult constructor throws when applied list is null")]
+    [Fact]
+    public Task MigrationResult_NullList_Throws() =>
+        Given("a null applied list", () => (IReadOnlyList<AppliedRewrite>?)null)
+        .Then("constructing MigrationResult throws ArgumentNullException", applied =>
+        {
+            try
+            {
+                _ = new MigrationResult(
+                    applied: applied!,
+                    skipped: [],
+                    manual: [],
+                    rewrittenFiles: new Dictionary<string, string>(),
+                    dryRun: false);
+                return false;
+            }
+            catch (ArgumentNullException) { return true; }
+        })
+        .AssertPassed();
+
+    // ── edge ────────────────────────────────────────────────────────────────
+
+    [Scenario("WithReplacedToken preserves leading and trailing trivia")]
+    [Fact]
+    public Task WithReplacedToken_PreservesTrivia() =>
+        Given("a syntax tree with a class that has leading and trailing whitespace", () =>
+        {
+            var tree = CSharpSyntaxTree.ParseText("  class  OldName  {  }  ");
+            var root = tree.GetRoot();
+            // Find the identifier token for OldName
+            var classDecl = root.DescendantNodes()
+                .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax>()
+                .First();
+            var oldIdentifier = classDecl.Identifier;
+            var newIdentifier = SyntaxFactory.Identifier("NewName");
+            var rewritten = classDecl.WithReplacedToken(oldIdentifier, newIdentifier);
+            return (Old: oldIdentifier, New: rewritten.Identifier);
+        })
+        .Then("leading trivia is preserved", t => t.New.LeadingTrivia.ToFullString() == t.Old.LeadingTrivia.ToFullString())
+        .And("trailing trivia is preserved", t => t.New.TrailingTrivia.ToFullString() == t.Old.TrailingTrivia.ToFullString())
+        .And("new identifier text is NewName", t => t.New.ValueText == "NewName")
+        .AssertPassed();
+
+    [Scenario("NullRewriter TryRewrite returns null leaving tree unchanged")]
+    [Fact]
+    public Task IRuleRewriter_NoOp_LeavesTreeUnchanged() =>
+        Given("a NullRewriter, a parsed syntax tree, and a rule", () =>
+        {
+            var tree = CSharpSyntaxTree.ParseText("class C { int X; }");
+            var root = tree.GetRoot();
+            var ctx = new RewriteContext("test.cs");
+            var rule = MakeRule();
+            var rewriter = new NullRewriter();
+            var result = rewriter.TryRewrite(root, rule, ctx);
+            return (Root: root, Result: result);
+        })
+        .Then("result is null", t => t.Result is null)
+        .And("Applied is empty", t =>
+        {
+            // null result means no mutation was applied
+            return true; // NullRewriter never calls RecordApplied
+        })
+        .AssertPassed();
+
+    [Scenario("Applied collection is not externally castable to mutable List")]
+    [Fact]
+    public Task RewriteContext_ExternalCast_Fails() =>
+        Given("a RewriteContext with one applied entry", () =>
+        {
+            var ctx = new RewriteContext("file.cs");
+            ctx.RecordApplied(MakeRule(), AnySpan(), "x", "y", 1);
+            return ctx.Applied;
+        })
+        .Then("cast to List<AppliedRewrite> throws InvalidCastException", applied =>
+        {
+            try { _ = (List<AppliedRewrite>)applied; return false; }
+            catch (InvalidCastException) { return true; }
+        })
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/EngineScaffoldTests.cs
+++ b/WrapGod.Tests/Migration/Engine/EngineScaffoldTests.cs
@@ -222,14 +222,11 @@ public sealed class EngineScaffoldTests(ITestOutputHelper output) : TinyBddXunit
             var rule = MakeRule();
             var rewriter = new NullRewriter();
             var result = rewriter.TryRewrite(root, rule, ctx);
-            return (Root: root, Result: result);
+            return (Root: root, Result: result, Ctx: ctx);
         })
-        .Then("result is null", t => t.Result is null)
-        .And("Applied is empty", t =>
-        {
-            // null result means no mutation was applied
-            return true; // NullRewriter never calls RecordApplied
-        })
+        .Then("rewrite returned null", t => t.Result is null)
+        .And("ctx.Applied count is 0", t => t.Ctx.Applied.Count == 0)
+        .And("ctx.Skipped count is 0", t => t.Ctx.Skipped.Count == 0)
         .AssertPassed();
 
     [Scenario("Applied collection is not externally castable to mutable List")]

--- a/WrapGod.Tests/WrapGod.Tests.csproj
+++ b/WrapGod.Tests/WrapGod.Tests.csproj
@@ -62,6 +62,7 @@
     <ProjectReference Include="..\WrapGod.Runtime\WrapGod.Runtime.csproj" />
     <ProjectReference Include="..\WrapGod.Cli\WrapGod.Cli.csproj" />
     <ProjectReference Include="..\WrapGod.Migration\WrapGod.Migration.csproj" />
+    <ProjectReference Include="..\WrapGod.Migration.Engine\WrapGod.Migration.Engine.csproj" />
   </ItemGroup>
 
 </Project>

--- a/WrapGod.slnx
+++ b/WrapGod.slnx
@@ -12,4 +12,5 @@
   <Project Path="WrapGod.Benchmarks/WrapGod.Benchmarks.csproj" />
   <Project Path="WrapGod.Targets/WrapGod.Targets.csproj" />
   <Project Path="WrapGod.Migration/WrapGod.Migration.csproj" />
+  <Project Path="WrapGod.Migration.Engine/WrapGod.Migration.Engine.csproj" />
 </Solution>

--- a/docs/migration/engine.md
+++ b/docs/migration/engine.md
@@ -1,0 +1,107 @@
+# Migration Engine
+
+`WrapGod.Migration.Engine` is the Roslyn-backed rewrite pipeline that consumes a
+`MigrationSchema` (authored or generated via `WrapGod.Migration`) and applies its rules
+against C# source files. This page documents the scaffold contracts that ship in
+issue #194; the concrete rewriters and the orchestrator that wire everything together
+arrive in later issues (see "What's next" below).
+
+## Public contracts
+
+The project (`net10.0`, depends on `Microsoft.CodeAnalysis.CSharp`) exposes the following
+types under the `WrapGod.Migration.Engine` namespace:
+
+- **`IRuleRewriter`** — interface implemented by every concrete rewriter. `Kind`
+  identifies the `MigrationRuleKind` (camelCase) the rewriter handles; `TryRewrite`
+  returns a rewritten `SyntaxNode` with trivia preserved, or `null` when the rule does
+  not match.
+- **`RewriteContext`** — per-file context that records the audit trail. Exposes the
+  source `FilePath`, accumulates `Applied` and `Skipped` collections (externally
+  immutable via `ReadOnlyCollection<T>`), and offers `RecordApplied`/`RecordSkipped`
+  for rewriters to log outcomes.
+- **`AppliedRewrite`** — sealed positional record describing a successful rewrite
+  (`RuleId`, `File`, `Line`, `OriginalText`, `ReplacedWith`); value-equal across
+  instances.
+- **`SkippedRewrite`** — sealed positional record describing a rewrite that was
+  evaluated but not applied (`RuleId`, `File`, `Line`, `Reason`).
+- **`ManualRewrite`** — sealed positional record for `Manual`-confidence rules that
+  require human intervention (`RuleId`, `Note`, `MatchedFiles`).
+- **`MigrationResult`** — sealed aggregator class with `Applied`, `Skipped`, `Manual`,
+  `RewrittenFiles`, and `DryRun` properties. Provides aggregate `*Count` properties
+  and a static `Empty` factory.
+- **`TriviaPreservation`** — extension helper exposing `WithReplacedToken<T>`, which
+  replaces a `SyntaxToken` while copying the leading and trailing trivia from the
+  original token onto the replacement.
+
+## The `IRuleRewriter` contract
+
+```csharp
+using Microsoft.CodeAnalysis;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+
+public interface IRuleRewriter
+{
+    /// <summary>The MigrationRuleKind discriminator this rewriter handles (camelCase).</summary>
+    string Kind { get; }
+
+    /// <summary>
+    /// Returns a rewritten node (with trivia preserved via WithTriviaFrom) when the rule
+    /// applies, or null to leave the node unchanged.
+    /// </summary>
+    SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx);
+}
+```
+
+### Example implementation skeleton
+
+```csharp
+public sealed class MyRenameRewriter : IRuleRewriter
+{
+    public string Kind => "renameType";
+
+    public SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx)
+    {
+        if (rule is not RenameTypeRule typed)
+            return null;
+
+        if (node is not IdentifierNameSyntax id || id.Identifier.ValueText != typed.OldName)
+            return null;
+
+        var replacement = SyntaxFactory.IdentifierName(typed.NewName);
+        // Trivia contract — every replacement MUST preserve leading/trailing trivia.
+        var rewritten = replacement.WithTriviaFrom(id);
+
+        ctx.RecordApplied(
+            rule,
+            id.Span,
+            originalText: id.ToString(),
+            replacementText: rewritten.ToString(),
+            line: id.GetLocation().GetLineSpan().StartLinePosition.Line + 1);
+
+        return rewritten;
+    }
+}
+```
+
+### Contract rules
+
+- **Trivia must be preserved.** Every rewritten node MUST copy trivia from the
+  original via `WithTriviaFrom` (or the token-level `TriviaPreservation.WithReplacedToken`).
+  Skipping this corrupts whitespace and comments in the output.
+- **Return `null` when the rule does not match.** Never throw, never return a
+  partially-modified node. Ambiguous matches should record a `SkippedRewrite` and
+  return `null`.
+- **No semantic lookup.** The engine works on syntax only so it can operate on
+  broken code; rewriters must not require a `SemanticModel`.
+
+## What's next
+
+This issue (#194) ships only the contracts. Concrete pieces follow:
+
+- **#195** — A-level syntax rewriters (`RenameType`, `RenameNamespace`,
+  `RenameMember`, `ChangeParameter`, `RemoveMember`, `AddRequiredParameter`,
+  `ChangeTypeReference`).
+- **#196** — `MigrationEngine` orchestrator with `Apply` and `DryRun` entry points.
+- **#202** — B-level structural rewriters (`SplitMethod`,
+  `ExtractParameterObject`, `PropertyToMethod`, `MoveMember`).

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -5,3 +5,4 @@ Strategies and automation for migrating codebases between library versions and a
 - [Migration Playbook](playbook.md) — strategy selection, safety model, validation checklist
 - [Automation Guide](automation.md) — end-to-end automation for eliminating library tech debt
 - [Migration Schema](schema.md) — `WrapGod.Migration` schema model and rule kinds reference
+- [Migration Engine](engine.md) — `WrapGod.Migration.Engine` rewrite pipeline contracts (`IRuleRewriter`, `RewriteContext`, `MigrationResult`)

--- a/docs/migration/toc.yml
+++ b/docs/migration/toc.yml
@@ -9,3 +9,6 @@
 
 - name: Migration Schema
   href: schema.md
+
+- name: Migration Engine
+  href: engine.md


### PR DESCRIPTION
Implements #194. New `WrapGod.Migration.Engine` project with `IRuleRewriter`, `RewriteContext`, `AppliedRewrite`, `SkippedRewrite`, `ManualRewrite`, `MigrationResult`, and `TriviaPreservation`. Roslyn dependency (`Microsoft.CodeAnalysis.CSharp` 4.14.0). 14 TinyBDD scenarios validate contract shape and value-equality semantics.

## Summary

- New project `WrapGod.Migration.Engine` targeting `net10.0`
- `IRuleRewriter` interface with XML-doc trivia contract and null-on-no-match contract
- `RewriteContext`: accumulates `Applied`/`Skipped` via `ReadOnlyCollection` (immutable externally, castability blocked)
- `AppliedRewrite`, `SkippedRewrite`, `ManualRewrite`: sealed positional records with value equality
- `MigrationResult`: immutable aggregator with `static Empty` factory, `DryRun` flag, aggregate counts
- `TriviaPreservation.WithReplacedToken<T>`: extension preserving leading/trailing trivia on token replacement
- Added to `WrapGod.slnx`; `WrapGod.Tests` references the new project

## Test plan

- [x] 14 TinyBDD scenarios in `WrapGod.Tests/Migration/Engine/EngineScaffoldTests.cs`
- [x] Happy: NullRewriter implements interface, RecordApplied fields, RecordSkipped order, MigrationResult.Empty, record equality (Applied/Skipped/Manual)
- [x] Sad: null filePath throws, null rule throws, null reason throws, null applied list throws
- [x] Edge: WithReplacedToken trivia preservation, NullRewriter leaves tree unchanged, Applied is not externally castable to List
- [x] Full solution build: 0 warnings, 0 errors (-warnaserror)
- [x] Full test run: 585 passed (0 failures)

Closes #194.

Generated with Claude Code