### PR TITLE
feat(migration-engine): #195 A-level syntax rewriters

### DIFF
--- a/WrapGod.Migration.Engine/Rewriters/AddRequiredParameterRewriter.cs
+++ b/WrapGod.Migration.Engine/Rewriters/AddRequiredParameterRewriter.cs
@@ -1,0 +1,95 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using WrapGod.Migration;
+
+namespace WrapGod.Migration.Engine.Rewriters;
+
+/// <summary>
+/// Handles <see cref="AddRequiredParameterRule"/>. Inserts a <c>default</c> keyword
+/// (or <c>null</c> for reference types) at the specified position in the argument list
+/// of every matching invocation, annotated with a TODO comment so developers know to
+/// supply the correct value. Records each insertion as an <see cref="AppliedRewrite"/>.
+/// </summary>
+internal sealed class AddRequiredParameterRewriter : IRuleRewriter
+{
+    /// <inheritdoc/>
+    public string Kind => "addRequiredParameter";
+
+    /// <inheritdoc/>
+    public SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx)
+    {
+        if (rule is not AddRequiredParameterRule typed)
+            return null;
+
+        var walker = new AddRequiredParameterWalker(typed, ctx);
+        var result = walker.Visit(node);
+        return walker.Changed ? result : null;
+    }
+
+    // ── Inner CSharpSyntaxRewriter ────────────────────────────────────────────
+
+    private sealed class AddRequiredParameterWalker : CSharpSyntaxRewriter
+    {
+        private readonly AddRequiredParameterRule _rule;
+        private readonly RewriteContext _ctx;
+        internal bool Changed;
+
+        internal AddRequiredParameterWalker(AddRequiredParameterRule rule, RewriteContext ctx)
+        {
+            _rule = rule;
+            _ctx = ctx;
+        }
+
+        public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            if (!IsTargetMethodCall(node))
+                return base.VisitInvocationExpression(node);
+
+            var argList = node.ArgumentList;
+            var args = argList.Arguments;
+            var position = _rule.Position;
+
+            // Build the default argument with a TODO comment
+            var todoComment = SyntaxFactory.Comment(
+                $"/* TODO MIGRATION: {_rule.Id} required arg '{_rule.ParameterName}' ({_rule.ParameterType}) added */");
+
+            var defaultExpression = SyntaxFactory
+                .LiteralExpression(SyntaxKind.DefaultLiteralExpression)
+                .WithLeadingTrivia(SyntaxFactory.Space)
+                .WithTrailingTrivia(SyntaxFactory.Space, todoComment);
+
+            var newArg = SyntaxFactory.Argument(defaultExpression);
+
+            // Clamp position to valid range
+            var insertAt = Math.Clamp(position, 0, args.Count);
+
+            var newArgsList = args.Insert(insertAt, newArg);
+            // Rebuild separators: take existing separators and add one for the new arg
+            // The simplest approach: use SeparatedList which handles separators automatically
+            var newArgList = argList.WithArguments(newArgsList);
+
+            _ctx.RecordApplied(
+                _rule,
+                argList.Span,
+                originalText: argList.ToString(),
+                replacementText: newArgList.ToString(),
+                line: RewriterHelpers.LineOf(argList));
+
+            Changed = true;
+            return node.WithArgumentList(newArgList);
+        }
+
+        private bool IsTargetMethodCall(InvocationExpressionSyntax node)
+        {
+            return node.Expression switch
+            {
+                MemberAccessExpressionSyntax mae =>
+                    mae.Name.Identifier.ValueText == _rule.MethodName,
+                IdentifierNameSyntax id =>
+                    id.Identifier.ValueText == _rule.MethodName,
+                _ => false,
+            };
+        }
+    }
+}

--- a/WrapGod.Migration.Engine/Rewriters/AddRequiredParameterRewriter.cs
+++ b/WrapGod.Migration.Engine/Rewriters/AddRequiredParameterRewriter.cs
@@ -50,16 +50,22 @@ internal sealed class AddRequiredParameterRewriter : IRuleRewriter
             var args = argList.Arguments;
             var position = _rule.Position;
 
-            // Build the default argument with a TODO comment
+            // Build the default argument with a TODO comment. Use 'null' when the
+            // parameter type is clearly a reference type (nullable, string, array, common
+            // interfaces) so the rewritten code is more likely to compile under recent
+            // C# nullable-aware analyzers.
             var todoComment = SyntaxFactory.Comment(
                 $"/* TODO MIGRATION: {_rule.Id} required arg '{_rule.ParameterName}' ({_rule.ParameterType}) added */");
 
-            var defaultExpression = SyntaxFactory
-                .LiteralExpression(SyntaxKind.DefaultLiteralExpression)
+            ExpressionSyntax placeholderExpression = IsLikelyReferenceType(_rule.ParameterType)
+                ? SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)
+                : SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression);
+
+            placeholderExpression = placeholderExpression
                 .WithLeadingTrivia(SyntaxFactory.Space)
                 .WithTrailingTrivia(SyntaxFactory.Space, todoComment);
 
-            var newArg = SyntaxFactory.Argument(defaultExpression);
+            var newArg = SyntaxFactory.Argument(placeholderExpression);
 
             // Clamp position to valid range
             var insertAt = Math.Clamp(position, 0, args.Count);
@@ -90,6 +96,34 @@ internal sealed class AddRequiredParameterRewriter : IRuleRewriter
                     id.Identifier.ValueText == _rule.MethodName,
                 _ => false,
             };
+        }
+
+        /// <summary>
+        /// Heuristic — returns <see langword="true"/> when <paramref name="parameterType"/>
+        /// is clearly a reference type by syntactic shape: nullable annotation, string,
+        /// object, array, or an interface name (prefix <c>I</c> + uppercase next char).
+        /// </summary>
+        private static bool IsLikelyReferenceType(string parameterType)
+        {
+            if (string.IsNullOrEmpty(parameterType))
+                return false;
+
+            if (parameterType.EndsWith('?'))
+                return true;
+
+            if (parameterType.EndsWith("[]", StringComparison.Ordinal))
+                return true;
+
+            var shortName = RewriterHelpers.ShortName(parameterType);
+
+            if (shortName is "string" or "String" or "object" or "Object")
+                return true;
+
+            // Interface convention: starts with capital I followed by another capital
+            if (shortName.Length >= 2 && shortName[0] == 'I' && char.IsUpper(shortName[1]))
+                return true;
+
+            return false;
         }
     }
 }

--- a/WrapGod.Migration.Engine/Rewriters/ChangeParameterRewriter.cs
+++ b/WrapGod.Migration.Engine/Rewriters/ChangeParameterRewriter.cs
@@ -1,0 +1,123 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using WrapGod.Migration;
+
+namespace WrapGod.Migration.Engine.Rewriters;
+
+/// <summary>
+/// Handles <see cref="ChangeParameterRule"/>. For parameter-name-only changes, rewrites
+/// the named-argument label in invocations of the target method. For type-change rules
+/// (when positional arguments are used), records a <see cref="SkippedRewrite"/> because
+/// a syntax-only rewriter cannot safely cast or convert argument values.
+/// </summary>
+internal sealed class ChangeParameterRewriter : IRuleRewriter
+{
+    /// <inheritdoc/>
+    public string Kind => "changeParameter";
+
+    /// <inheritdoc/>
+    public SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx)
+    {
+        if (rule is not ChangeParameterRule typed)
+            return null;
+
+        var walker = new ChangeParameterWalker(typed, ctx);
+        var result = walker.Visit(node);
+        return walker.Changed ? result : null;
+    }
+
+    // ── Inner CSharpSyntaxRewriter ────────────────────────────────────────────
+
+    private sealed class ChangeParameterWalker : CSharpSyntaxRewriter
+    {
+        private readonly ChangeParameterRule _rule;
+        private readonly RewriteContext _ctx;
+        internal bool Changed;
+
+        internal ChangeParameterWalker(ChangeParameterRule rule, RewriteContext ctx)
+        {
+            _rule = rule;
+            _ctx = ctx;
+        }
+
+        public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            // Check if this invocation is a call to the target method on the target type.
+            // We require that the method name matches; receiver type is best-effort only.
+            if (!IsTargetMethodCall(node))
+                return base.VisitInvocationExpression(node);
+
+            var argList = node.ArgumentList;
+            var newArgs = new List<ArgumentSyntax>(argList.Arguments.Count);
+            var anyChanged = false;
+
+            foreach (var arg in argList.Arguments)
+            {
+                if (arg.NameColon is not null &&
+                    arg.NameColon.Name.Identifier.ValueText == _rule.OldParameterName)
+                {
+                    // Named argument with matching label — rewrite the label if name changed
+                    if (_rule.NewParameterName is not null &&
+                        _rule.NewParameterName != _rule.OldParameterName)
+                    {
+                        var oldToken = arg.NameColon.Name.Identifier;
+                        var newToken = RewriterHelpers.IdentifierWithTrivia(
+                            oldToken, _rule.NewParameterName);
+                        var newNameColon = arg.NameColon.WithName(
+                            arg.NameColon.Name.WithIdentifier(newToken));
+                        var newArg = arg.WithNameColon(newNameColon);
+
+                        _ctx.RecordApplied(
+                            _rule,
+                            arg.NameColon.Span,
+                            originalText: _rule.OldParameterName + ":",
+                            replacementText: _rule.NewParameterName + ":",
+                            line: RewriterHelpers.LineOf(arg));
+
+                        newArgs.Add(newArg);
+                        anyChanged = true;
+                        continue;
+                    }
+                }
+                else if (arg.NameColon is null &&
+                         _rule.OldParameterType is not null &&
+                         _rule.NewParameterType is not null)
+                {
+                    // Positional argument with a type change — cannot safely rewrite
+                    _ctx.RecordSkipped(
+                        _rule,
+                        arg.Span,
+                        line: RewriterHelpers.LineOf(arg),
+                        reason: $"type change from '{_rule.OldParameterType}' to " +
+                                $"'{_rule.NewParameterType}' requires semantic conversion — " +
+                                "manual review required");
+                }
+
+                newArgs.Add(arg);
+            }
+
+            if (!anyChanged)
+                return base.VisitInvocationExpression(node);
+
+            Changed = true;
+            var newArgList = argList.WithArguments(
+                SyntaxFactory.SeparatedList(newArgs, argList.Arguments.GetSeparators()));
+            return node.WithArgumentList(newArgList);
+        }
+
+        private bool IsTargetMethodCall(InvocationExpressionSyntax node)
+        {
+            // Simple heuristic: check the method name matches regardless of receiver type
+            // (syntax-only; we cannot resolve the declaring type without SemanticModel)
+            return node.Expression switch
+            {
+                MemberAccessExpressionSyntax mae =>
+                    mae.Name.Identifier.ValueText == _rule.MethodName,
+                IdentifierNameSyntax id =>
+                    id.Identifier.ValueText == _rule.MethodName,
+                _ => false,
+            };
+        }
+    }
+}

--- a/WrapGod.Migration.Engine/Rewriters/ChangeParameterRewriter.cs
+++ b/WrapGod.Migration.Engine/Rewriters/ChangeParameterRewriter.cs
@@ -22,7 +22,7 @@ internal sealed class ChangeParameterRewriter : IRuleRewriter
         if (rule is not ChangeParameterRule typed)
             return null;
 
-        var walker = new ChangeParameterWalker(typed, ctx);
+        var walker = new ChangeParameterWalker(typed, ctx, node);
         var result = walker.Visit(node);
         return walker.Changed ? result : null;
     }
@@ -33,20 +33,46 @@ internal sealed class ChangeParameterRewriter : IRuleRewriter
     {
         private readonly ChangeParameterRule _rule;
         private readonly RewriteContext _ctx;
+        private readonly SyntaxNode _root;
+        private readonly string _declTypeShort;
         internal bool Changed;
 
-        internal ChangeParameterWalker(ChangeParameterRule rule, RewriteContext ctx)
+        internal ChangeParameterWalker(
+            ChangeParameterRule rule,
+            RewriteContext ctx,
+            SyntaxNode root)
         {
             _rule = rule;
             _ctx = ctx;
+            _root = root;
+            _declTypeShort = RewriterHelpers.ShortName(rule.TypeName);
         }
 
         public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
         {
             // Check if this invocation is a call to the target method on the target type.
-            // We require that the method name matches; receiver type is best-effort only.
             if (!IsTargetMethodCall(node))
                 return base.VisitInvocationExpression(node);
+
+            // Receiver-type disambiguation: if the receiver is a member access whose receiver
+            // type can be inferred and does NOT match the declaring type, record a Skipped
+            // and leave the invocation alone. This prevents wrong rewrites on unrelated
+            // methods that share a name.
+            if (node.Expression is MemberAccessExpressionSyntax mae)
+            {
+                var inferred = RewriterHelpers.TryInferReceiverTypeName(mae, _root);
+                if (inferred is not null &&
+                    !string.Equals(inferred, _declTypeShort, StringComparison.Ordinal))
+                {
+                    _ctx.RecordSkipped(
+                        _rule,
+                        node.Span,
+                        line: RewriterHelpers.LineOf(node),
+                        reason: $"ambiguous: receiver type '{inferred}' does not match " +
+                                $"declaring type '{_declTypeShort}'");
+                    return base.VisitInvocationExpression(node);
+                }
+            }
 
             var argList = node.ArgumentList;
             var newArgs = new List<ArgumentSyntax>(argList.Arguments.Count);

--- a/WrapGod.Migration.Engine/Rewriters/ChangeTypeReferenceRewriter.cs
+++ b/WrapGod.Migration.Engine/Rewriters/ChangeTypeReferenceRewriter.cs
@@ -1,0 +1,152 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using WrapGod.Migration;
+
+namespace WrapGod.Migration.Engine.Rewriters;
+
+/// <summary>
+/// Handles <see cref="ChangeTypeReferenceRule"/>. Replaces all occurrences of
+/// <see cref="ChangeTypeReferenceRule.OldType"/> (by short name) in type positions
+/// (field declarations, local variable declarations, casts, <c>typeof</c>, generic
+/// type arguments, base lists) with <see cref="ChangeTypeReferenceRule.NewType"/>.
+/// </summary>
+internal sealed class ChangeTypeReferenceRewriter : IRuleRewriter
+{
+    /// <inheritdoc/>
+    public string Kind => "changeTypeReference";
+
+    /// <inheritdoc/>
+    public SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx)
+    {
+        if (rule is not ChangeTypeReferenceRule typed)
+            return null;
+
+        var walker = new ChangeTypeReferenceWalker(typed, ctx);
+        var result = walker.Visit(node);
+        return walker.Changed ? result : null;
+    }
+
+    // ── Inner CSharpSyntaxRewriter ────────────────────────────────────────────
+
+    private sealed class ChangeTypeReferenceWalker : CSharpSyntaxRewriter
+    {
+        private readonly ChangeTypeReferenceRule _rule;
+        private readonly RewriteContext _ctx;
+        private readonly string _oldShort;
+        private readonly string _newShort;
+        internal bool Changed;
+
+        internal ChangeTypeReferenceWalker(ChangeTypeReferenceRule rule, RewriteContext ctx)
+        {
+            _rule = rule;
+            _ctx = ctx;
+            _oldShort = RewriterHelpers.ShortName(rule.OldType);
+            _newShort = RewriterHelpers.ShortName(rule.NewType);
+        }
+
+        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            if (node.Identifier.ValueText != _oldShort)
+                return base.VisitIdentifierName(node);
+
+            // Only rewrite nodes that appear in a type-context position
+            if (!IsInTypeContext(node))
+                return base.VisitIdentifierName(node);
+
+            var newToken = RewriterHelpers.IdentifierWithTrivia(node.Identifier, _newShort);
+            var replacement = node.WithIdentifier(newToken);
+
+            _ctx.RecordApplied(
+                _rule,
+                node.Span,
+                originalText: node.ToString(),
+                replacementText: replacement.ToString(),
+                line: RewriterHelpers.LineOf(node));
+
+            Changed = true;
+            return replacement;
+        }
+
+        public override SyntaxNode? VisitGenericName(GenericNameSyntax node)
+        {
+            // Handle generic type references like IList<string> where the identifier
+            // is the generic name's identifier, e.g. "IList" in IList<string>
+            if (node.Identifier.ValueText != _oldShort)
+                return base.VisitGenericName(node);
+
+            if (!IsInTypeContext(node))
+                return base.VisitGenericName(node);
+
+            var newToken = RewriterHelpers.IdentifierWithTrivia(node.Identifier, _newShort);
+            var replacement = node.WithIdentifier(newToken);
+
+            _ctx.RecordApplied(
+                _rule,
+                node.Span,
+                originalText: node.ToString(),
+                replacementText: replacement.ToString(),
+                line: RewriterHelpers.LineOf(node));
+
+            Changed = true;
+            return replacement;
+        }
+
+        public override SyntaxNode? VisitQualifiedName(QualifiedNameSyntax node)
+        {
+            // Handle fully-qualified references
+            var nodeText = node.ToString();
+            if (nodeText != _rule.OldType)
+                return base.VisitQualifiedName(node);
+
+            if (!IsInTypeContext(node))
+                return base.VisitQualifiedName(node);
+
+            var replacement = SyntaxFactory.ParseName(_rule.NewType)
+                .WithTriviaFrom(node);
+
+            _ctx.RecordApplied(
+                _rule,
+                node.Span,
+                originalText: nodeText,
+                replacementText: replacement.ToString(),
+                line: RewriterHelpers.LineOf(node));
+
+            Changed = true;
+            return replacement;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> when <paramref name="node"/> appears in a
+        /// syntactic position that is unambiguously a type reference (not an identifier
+        /// used as a variable name or method name).
+        /// </summary>
+        private static bool IsInTypeContext(SyntaxNode node)
+        {
+            var parent = node.Parent;
+            return parent is
+                // Variable / field declaration: int foo (type is direct child of VariableDeclarationSyntax)
+                VariableDeclarationSyntax or
+                // Method return type (type is direct child of MethodDeclarationSyntax)
+                MethodDeclarationSyntax or
+                // Parameter type
+                ParameterSyntax or
+                // Cast expression: (TypeName)x
+                CastExpressionSyntax or
+                // typeof(TypeName)
+                TypeOfExpressionSyntax or
+                // Generic type argument (e.g. T in List<T>)
+                TypeArgumentListSyntax or
+                // Base list: class Foo : Bar
+                SimpleBaseTypeSyntax or
+                // Object creation: new TypeName()
+                ObjectCreationExpressionSyntax or
+                // Array type: TypeName[]
+                ArrayTypeSyntax or
+                // Nullable type: TypeName?
+                NullableTypeSyntax or
+                // Property type
+                PropertyDeclarationSyntax;
+        }
+    }
+}

--- a/WrapGod.Migration.Engine/Rewriters/RemoveMemberRewriter.cs
+++ b/WrapGod.Migration.Engine/Rewriters/RemoveMemberRewriter.cs
@@ -7,9 +7,10 @@ namespace WrapGod.Migration.Engine.Rewriters;
 
 /// <summary>
 /// Handles <see cref="RemoveMemberRule"/>. At every call site for the removed member,
-/// the entire expression statement is replaced with a leading trivia comment that
-/// preserves the original text so developers can see what was there and manually restore
-/// or remove the call. Records each replacement as an <see cref="AppliedRewrite"/>.
+/// the expression statement is removed entirely and its location is annotated with a
+/// migration comment attached as TRIVIA to a sibling token. This avoids leaving an
+/// orphan <c>;</c> in the rewritten code and is safe against formatters. Records each
+/// removal as an <see cref="AppliedRewrite"/>.
 /// </summary>
 internal sealed class RemoveMemberRewriter : IRuleRewriter
 {
@@ -41,44 +42,94 @@ internal sealed class RemoveMemberRewriter : IRuleRewriter
             _ctx = ctx;
         }
 
-        public override SyntaxNode? VisitExpressionStatement(ExpressionStatementSyntax node)
+        public override SyntaxNode? VisitBlock(BlockSyntax node)
         {
-            if (!IsTargetCall(node.Expression))
-                return base.VisitExpressionStatement(node);
+            // First recurse so nested blocks are processed bottom-up.
+            var visitedBlock = (BlockSyntax)base.VisitBlock(node)!;
 
-            var originalText = node.ToString().Trim();
+            // Walk statements; if a statement matches the target call, remove it and attach
+            // the migration comment as trivia to the next sibling (or the closing brace).
+            var newStatements = new List<StatementSyntax>(visitedBlock.Statements.Count);
+            // Pending comments to be prepended to the next emitted token.
+            var pendingTrivia = SyntaxTriviaList.Empty;
+
+            foreach (var stmt in visitedBlock.Statements)
+            {
+                if (TryMatchTargetStatement(stmt, out var commentText, out var originalText))
+                {
+                    // Record this as an applied rewrite — the line is the original statement's line.
+                    _ctx.RecordApplied(
+                        _rule,
+                        stmt.Span,
+                        originalText: originalText,
+                        replacementText: commentText,
+                        line: RewriterHelpers.LineOf(stmt));
+
+                    Changed = true;
+
+                    // Build the trivia: preserve the statement's leading trivia (indentation,
+                    // blank lines) then insert the comment then a newline.
+                    var commentTrivia = SyntaxFactory.Comment(commentText);
+                    var newline = SyntaxFactory.CarriageReturnLineFeed;
+
+                    pendingTrivia = pendingTrivia
+                        .AddRange(stmt.GetLeadingTrivia())
+                        .Add(commentTrivia)
+                        .Add(newline);
+
+                    // Drop the statement (do not add to newStatements).
+                    continue;
+                }
+
+                // Not a target — attach any pending trivia as leading trivia to this stmt.
+                if (pendingTrivia.Count > 0)
+                {
+                    var combined = pendingTrivia.AddRange(stmt.GetLeadingTrivia());
+                    newStatements.Add(stmt.WithLeadingTrivia(combined));
+                    pendingTrivia = SyntaxTriviaList.Empty;
+                }
+                else
+                {
+                    newStatements.Add(stmt);
+                }
+            }
+
+            // If we still have pending trivia after iterating all statements, attach it as
+            // leading trivia to the closing brace token. This handles the case where the
+            // removed call was the last (or only) statement in the block.
+            var closeBrace = visitedBlock.CloseBraceToken;
+            if (pendingTrivia.Count > 0)
+            {
+                var combined = pendingTrivia.AddRange(closeBrace.LeadingTrivia);
+                closeBrace = closeBrace.WithLeadingTrivia(combined);
+            }
+
+            if (!Changed)
+                return visitedBlock;
+
+            return visitedBlock
+                .WithStatements(SyntaxFactory.List(newStatements))
+                .WithCloseBraceToken(closeBrace);
+        }
+
+        private bool TryMatchTargetStatement(
+            StatementSyntax stmt,
+            out string commentText,
+            out string originalText)
+        {
+            commentText = string.Empty;
+            originalText = string.Empty;
+
+            if (stmt is not ExpressionStatementSyntax exprStmt)
+                return false;
+
+            if (!IsTargetCall(exprStmt.Expression))
+                return false;
+
+            originalText = exprStmt.ToString().Trim();
             var noteText = string.IsNullOrEmpty(_rule.Note) ? string.Empty : $" — {_rule.Note}";
-
-            // Build a comment that replaces the statement
-            var commentText = $"// MIGRATION: {_rule.Id} removed{noteText}: {originalText}";
-
-            // Preserve the leading trivia (indentation, blank lines) from the original node
-            var leadingTrivia = node.GetLeadingTrivia();
-            var trailingTrivia = node.GetTrailingTrivia();
-
-            var commentTrivia = SyntaxFactory.Comment(commentText);
-            var newTrivia = leadingTrivia
-                .Add(commentTrivia)
-                .AddRange(trailingTrivia);
-
-            // Replace the statement with an empty statement that carries the comment as
-            // leading trivia, then is itself invisible (just a semicolon with no real effect).
-            // Alternatively, produce a comment-only trivia on an empty statement.
-            // We emit a single-line comment on a trivial empty statement node.
-            var placeholder = SyntaxFactory.EmptyStatement(
-                    SyntaxFactory.Token(SyntaxKind.SemicolonToken))
-                .WithLeadingTrivia(newTrivia)
-                .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);
-
-            _ctx.RecordApplied(
-                _rule,
-                node.Span,
-                originalText: originalText,
-                replacementText: commentText,
-                line: RewriterHelpers.LineOf(node));
-
-            Changed = true;
-            return placeholder;
+            commentText = $"// MIGRATION: {_rule.Id} removed{noteText}: {originalText}";
+            return true;
         }
 
         private bool IsTargetCall(ExpressionSyntax expr)

--- a/WrapGod.Migration.Engine/Rewriters/RemoveMemberRewriter.cs
+++ b/WrapGod.Migration.Engine/Rewriters/RemoveMemberRewriter.cs
@@ -1,0 +1,96 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using WrapGod.Migration;
+
+namespace WrapGod.Migration.Engine.Rewriters;
+
+/// <summary>
+/// Handles <see cref="RemoveMemberRule"/>. At every call site for the removed member,
+/// the entire expression statement is replaced with a leading trivia comment that
+/// preserves the original text so developers can see what was there and manually restore
+/// or remove the call. Records each replacement as an <see cref="AppliedRewrite"/>.
+/// </summary>
+internal sealed class RemoveMemberRewriter : IRuleRewriter
+{
+    /// <inheritdoc/>
+    public string Kind => "removeMember";
+
+    /// <inheritdoc/>
+    public SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx)
+    {
+        if (rule is not RemoveMemberRule typed)
+            return null;
+
+        var walker = new RemoveMemberWalker(typed, ctx);
+        var result = walker.Visit(node);
+        return walker.Changed ? result : null;
+    }
+
+    // ── Inner CSharpSyntaxRewriter ────────────────────────────────────────────
+
+    private sealed class RemoveMemberWalker : CSharpSyntaxRewriter
+    {
+        private readonly RemoveMemberRule _rule;
+        private readonly RewriteContext _ctx;
+        internal bool Changed;
+
+        internal RemoveMemberWalker(RemoveMemberRule rule, RewriteContext ctx)
+        {
+            _rule = rule;
+            _ctx = ctx;
+        }
+
+        public override SyntaxNode? VisitExpressionStatement(ExpressionStatementSyntax node)
+        {
+            if (!IsTargetCall(node.Expression))
+                return base.VisitExpressionStatement(node);
+
+            var originalText = node.ToString().Trim();
+            var noteText = string.IsNullOrEmpty(_rule.Note) ? string.Empty : $" — {_rule.Note}";
+
+            // Build a comment that replaces the statement
+            var commentText = $"// MIGRATION: {_rule.Id} removed{noteText}: {originalText}";
+
+            // Preserve the leading trivia (indentation, blank lines) from the original node
+            var leadingTrivia = node.GetLeadingTrivia();
+            var trailingTrivia = node.GetTrailingTrivia();
+
+            var commentTrivia = SyntaxFactory.Comment(commentText);
+            var newTrivia = leadingTrivia
+                .Add(commentTrivia)
+                .AddRange(trailingTrivia);
+
+            // Replace the statement with an empty statement that carries the comment as
+            // leading trivia, then is itself invisible (just a semicolon with no real effect).
+            // Alternatively, produce a comment-only trivia on an empty statement.
+            // We emit a single-line comment on a trivial empty statement node.
+            var placeholder = SyntaxFactory.EmptyStatement(
+                    SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .WithLeadingTrivia(newTrivia)
+                .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);
+
+            _ctx.RecordApplied(
+                _rule,
+                node.Span,
+                originalText: originalText,
+                replacementText: commentText,
+                line: RewriterHelpers.LineOf(node));
+
+            Changed = true;
+            return placeholder;
+        }
+
+        private bool IsTargetCall(ExpressionSyntax expr)
+        {
+            // Match: receiver.MemberName(...)
+            if (expr is InvocationExpressionSyntax inv &&
+                inv.Expression is MemberAccessExpressionSyntax mae)
+            {
+                return mae.Name.Identifier.ValueText == _rule.MemberName;
+            }
+
+            return false;
+        }
+    }
+}

--- a/WrapGod.Migration.Engine/Rewriters/RenameMemberRewriter.cs
+++ b/WrapGod.Migration.Engine/Rewriters/RenameMemberRewriter.cs
@@ -1,0 +1,107 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using WrapGod.Migration;
+
+namespace WrapGod.Migration.Engine.Rewriters;
+
+/// <summary>
+/// Rewrites member accesses where the member name matches
+/// <see cref="RenameMemberRule.OldMemberName"/> and the receiver can be heuristically
+/// resolved to the declaring <see cref="RenameMemberRule.TypeName"/>. When the receiver
+/// type cannot be determined, records a <see cref="SkippedRewrite"/> and leaves the node
+/// unchanged.
+/// </summary>
+internal sealed class RenameMemberRewriter : IRuleRewriter
+{
+    /// <inheritdoc/>
+    public string Kind => "renameMember";
+
+    /// <inheritdoc/>
+    public SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx)
+    {
+        if (rule is not RenameMemberRule typed)
+            return null;
+
+        var walker = new RenameMemberWalker(typed, ctx, node);
+        var result = walker.Visit(node);
+
+        // Return the rewritten tree only if at least one successful rewrite happened.
+        // (Skips-only still return null for the tree — the context already records the skips.)
+        return walker.AppliedCount > 0 ? result : null;
+    }
+
+    // ── Inner CSharpSyntaxRewriter ────────────────────────────────────────────
+
+    private sealed class RenameMemberWalker : CSharpSyntaxRewriter
+    {
+        private readonly RenameMemberRule _rule;
+        private readonly RewriteContext _ctx;
+        private readonly SyntaxNode _root;
+        private readonly string _declTypeShort;
+        internal int AppliedCount;
+
+        internal RenameMemberWalker(
+            RenameMemberRule rule,
+            RewriteContext ctx,
+            SyntaxNode root)
+        {
+            _rule = rule;
+            _ctx = ctx;
+            _root = root;
+            _declTypeShort = RewriterHelpers.ShortName(rule.TypeName);
+        }
+
+        public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+        {
+            // Recurse first so that nested member accesses are handled bottom-up
+            var visited = (MemberAccessExpressionSyntax)base.VisitMemberAccessExpression(node)!;
+
+            if (visited.Name.Identifier.ValueText != _rule.OldMemberName)
+                return visited;
+
+            // Attempt to infer the receiver type using syntax-only heuristics
+            var inferredType = RewriterHelpers.TryInferReceiverTypeName(visited, _root);
+
+            if (inferredType is null)
+            {
+                // Cannot determine whether the receiver is the declaring type — skip
+                _ctx.RecordSkipped(
+                    _rule,
+                    visited.Span,
+                    line: RewriterHelpers.LineOf(visited),
+                    reason: $"ambiguous: cannot determine receiver type for '{visited.Expression}' " +
+                            $"(expected '{_declTypeShort}') — manual review required");
+                return visited;
+            }
+
+            if (!string.Equals(inferredType, _declTypeShort, StringComparison.Ordinal))
+            {
+                // Receiver type is known but does NOT match the declaring type — skip
+                _ctx.RecordSkipped(
+                    _rule,
+                    visited.Span,
+                    line: RewriterHelpers.LineOf(visited),
+                    reason: $"ambiguous: receiver type '{inferredType}' does not match " +
+                            $"declaring type '{_declTypeShort}'");
+                return visited;
+            }
+
+            // Replace the member name while preserving trivia
+            var oldNameToken = visited.Name.Identifier;
+            var newNameToken = RewriterHelpers.IdentifierWithTrivia(oldNameToken, _rule.NewMemberName);
+            var newName = visited.Name.WithIdentifier(newNameToken);
+            var replacement = visited.WithName(newName);
+
+            _ctx.RecordApplied(
+                _rule,
+                visited.Name.Span,
+                originalText: _rule.OldMemberName,
+                replacementText: _rule.NewMemberName,
+                line: RewriterHelpers.LineOf(visited.Name));
+
+            AppliedCount++;
+            return replacement;
+        }
+    }
+}

--- a/WrapGod.Migration.Engine/Rewriters/RenameNamespaceRewriter.cs
+++ b/WrapGod.Migration.Engine/Rewriters/RenameNamespaceRewriter.cs
@@ -1,0 +1,98 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using WrapGod.Migration;
+
+namespace WrapGod.Migration.Engine.Rewriters;
+
+/// <summary>
+/// Rewrites <c>using</c> directives and qualified names when a namespace is renamed.
+/// Only the prefix matching <see cref="RenameNamespaceRule.OldNamespace"/> is changed;
+/// no other identifiers are touched.
+/// </summary>
+internal sealed class RenameNamespaceRewriter : IRuleRewriter
+{
+    /// <inheritdoc/>
+    public string Kind => "renameNamespace";
+
+    /// <inheritdoc/>
+    public SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx)
+    {
+        if (rule is not RenameNamespaceRule typed)
+            return null;
+
+        var walker = new RenameNamespaceWalker(typed, ctx);
+        var result = walker.Visit(node);
+        return walker.Changed ? result : null;
+    }
+
+    // ── Inner CSharpSyntaxRewriter ────────────────────────────────────────────
+
+    private sealed class RenameNamespaceWalker : CSharpSyntaxRewriter
+    {
+        private readonly RenameNamespaceRule _rule;
+        private readonly RewriteContext _ctx;
+        internal bool Changed;
+
+        internal RenameNamespaceWalker(RenameNamespaceRule rule, RewriteContext ctx)
+        {
+            _rule = rule;
+            _ctx = ctx;
+        }
+
+        public override SyntaxNode? VisitUsingDirective(UsingDirectiveSyntax node)
+        {
+            var usingText = node.Name?.ToString() ?? string.Empty;
+
+            if (!StartsWithNamespace(usingText, _rule.OldNamespace))
+                return base.VisitUsingDirective(node);
+
+            var newText = _rule.NewNamespace + usingText[_rule.OldNamespace.Length..];
+            var newName = SyntaxFactory.ParseName(newText)
+                .WithTriviaFrom(node.Name!);
+
+            var replacement = node.WithName(newName);
+
+            _ctx.RecordApplied(
+                _rule,
+                node.Span,
+                originalText: usingText,
+                replacementText: newText,
+                line: RewriterHelpers.LineOf(node));
+
+            Changed = true;
+            return replacement;
+        }
+
+        public override SyntaxNode? VisitQualifiedName(QualifiedNameSyntax node)
+        {
+            var nodeText = node.ToString();
+
+            if (!StartsWithNamespace(nodeText, _rule.OldNamespace))
+                return base.VisitQualifiedName(node);
+
+            var newText = _rule.NewNamespace + nodeText[_rule.OldNamespace.Length..];
+            var replacement = SyntaxFactory.ParseName(newText)
+                .WithTriviaFrom(node);
+
+            _ctx.RecordApplied(
+                _rule,
+                node.Span,
+                originalText: nodeText,
+                replacementText: newText,
+                line: RewriterHelpers.LineOf(node));
+
+            Changed = true;
+            return replacement;
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="nameText"/> equals or starts with
+        /// <paramref name="ns"/> followed by a dot (to avoid matching a prefix of a
+        /// longer namespace accidentally).
+        /// </summary>
+        private static bool StartsWithNamespace(string nameText, string ns) =>
+            nameText == ns ||
+            nameText.StartsWith(ns + ".", StringComparison.Ordinal);
+    }
+}

--- a/WrapGod.Migration.Engine/Rewriters/RenameTypeRewriter.cs
+++ b/WrapGod.Migration.Engine/Rewriters/RenameTypeRewriter.cs
@@ -1,0 +1,110 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using WrapGod.Migration;
+
+namespace WrapGod.Migration.Engine.Rewriters;
+
+/// <summary>
+/// Rewrites occurrences of a renamed type's short name (identifier nodes, qualified names,
+/// generic type arguments) using syntax-only heuristics. Fully-qualified references are
+/// updated in-place; unresolvable ambiguities are recorded as <see cref="SkippedRewrite"/>.
+/// </summary>
+internal sealed class RenameTypeRewriter : IRuleRewriter
+{
+    /// <inheritdoc/>
+    public string Kind => "renameType";
+
+    /// <inheritdoc/>
+    public SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx)
+    {
+        if (rule is not RenameTypeRule typed)
+            return null;
+
+        var oldShort = RewriterHelpers.ShortName(typed.OldName);
+        var newShort = RewriterHelpers.ShortName(typed.NewName);
+
+        var walker = new RenameTypeWalker(typed, oldShort, newShort, ctx);
+        var result = walker.Visit(node);
+        return walker.Changed ? result : null;
+    }
+
+    // ── Inner CSharpSyntaxRewriter ────────────────────────────────────────────
+
+    private sealed class RenameTypeWalker : CSharpSyntaxRewriter
+    {
+        private readonly RenameTypeRule _rule;
+        private readonly string _oldShort;
+        private readonly string _newShort;
+        private readonly RewriteContext _ctx;
+        internal bool Changed;
+
+        internal RenameTypeWalker(
+            RenameTypeRule rule,
+            string oldShort,
+            string newShort,
+            RewriteContext ctx)
+        {
+            _rule = rule;
+            _oldShort = oldShort;
+            _newShort = newShort;
+            _ctx = ctx;
+        }
+
+        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            // Only rewrite when the identifier text exactly equals the short name
+            if (node.Identifier.ValueText != _oldShort)
+                return base.VisitIdentifierName(node);
+
+            // Avoid renaming identifiers that are clearly not type references:
+            // member names on the right side of a MemberAccessExpression are handled
+            // by their parent; attribute names ending in "Attribute" keep the original
+            // (we rely on the parent QualifiedName visitor when fully-qualified).
+            var parent = node.Parent;
+            if (parent is MemberAccessExpressionSyntax mae && mae.Name == node)
+                return base.VisitIdentifierName(node);
+
+            var newIdentifier = RewriterHelpers.IdentifierWithTrivia(node.Identifier, _newShort);
+            var replacement = node.WithIdentifier(newIdentifier);
+
+            _ctx.RecordApplied(
+                _rule,
+                node.Span,
+                originalText: node.ToString(),
+                replacementText: replacement.ToString(),
+                line: RewriterHelpers.LineOf(node));
+
+            Changed = true;
+            return replacement;
+        }
+
+        public override SyntaxNode? VisitQualifiedName(QualifiedNameSyntax node)
+        {
+            // Handle fully-qualified reference: check that the right part matches
+            // and left part matches the old namespace.
+            var nodeText = node.ToString();
+            var oldFq = _rule.OldName;
+            var newFq = _rule.NewName;
+
+            if (nodeText == oldFq)
+            {
+                // Replace the entire qualified name
+                var replacement = SyntaxFactory.ParseName(newFq)
+                    .WithTriviaFrom(node);
+
+                _ctx.RecordApplied(
+                    _rule,
+                    node.Span,
+                    originalText: nodeText,
+                    replacementText: replacement.ToString(),
+                    line: RewriterHelpers.LineOf(node));
+
+                Changed = true;
+                return replacement;
+            }
+
+            return base.VisitQualifiedName(node);
+        }
+    }
+}

--- a/WrapGod.Migration.Engine/Rewriters/RewriterHelpers.cs
+++ b/WrapGod.Migration.Engine/Rewriters/RewriterHelpers.cs
@@ -1,0 +1,142 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace WrapGod.Migration.Engine.Rewriters;
+
+/// <summary>
+/// Shared syntax-only utilities used by the A-level rewriters.
+/// </summary>
+internal static class RewriterHelpers
+{
+    /// <summary>
+    /// Returns the short (unqualified) name from a fully-qualified type name.
+    /// e.g. <c>"Foo.Bar.Baz"</c> → <c>"Baz"</c>.
+    /// </summary>
+    internal static string ShortName(string fullyQualified)
+    {
+        var dot = fullyQualified.LastIndexOf('.');
+        return dot < 0 ? fullyQualified : fullyQualified[(dot + 1)..];
+    }
+
+    /// <summary>
+    /// Returns the namespace portion from a fully-qualified type name.
+    /// e.g. <c>"Foo.Bar.Baz"</c> → <c>"Foo.Bar"</c>. Returns empty string when
+    /// there is no namespace (bare name).
+    /// </summary>
+    internal static string Namespace(string fullyQualified)
+    {
+        var dot = fullyQualified.LastIndexOf('.');
+        return dot < 0 ? string.Empty : fullyQualified[..dot];
+    }
+
+    /// <summary>
+    /// Attempts to infer the declared type name of the receiver expression in a
+    /// <see cref="MemberAccessExpressionSyntax"/> using syntax-only heuristics.
+    /// Returns the simple identifier text if the receiver is a simple name for which
+    /// a local/field declaration with an explicit type is visible in the same method
+    /// body, otherwise returns <see langword="null"/>.
+    /// </summary>
+    internal static string? TryInferReceiverTypeName(
+        MemberAccessExpressionSyntax memberAccess,
+        SyntaxNode root)
+    {
+        // Only handle the simplest case: receiver is a plain identifier
+        if (memberAccess.Expression is not IdentifierNameSyntax receiverIdentifier)
+            return null;
+
+        var receiverName = receiverIdentifier.Identifier.ValueText;
+
+        // Walk upward to the nearest method or property body to find local variable declarations
+        var enclosingBody = memberAccess
+            .Ancestors()
+            .FirstOrDefault(a =>
+                a is MethodDeclarationSyntax or
+                PropertyDeclarationSyntax or
+                ConstructorDeclarationSyntax or
+                AccessorDeclarationSyntax);
+
+        if (enclosingBody is null)
+            return null;
+
+        // Scan local variable declarations: look for "TypeName varName =" or "TypeName varName;"
+        foreach (var local in enclosingBody.DescendantNodes().OfType<VariableDeclarationSyntax>())
+        {
+            foreach (var variable in local.Variables)
+            {
+                if (variable.Identifier.ValueText != receiverName)
+                    continue;
+
+                // Extract the declared type text (e.g., "MyService", "MyService?", etc.)
+                var typeSyntax = local.Type;
+                if (typeSyntax is NullableTypeSyntax nullable)
+                    typeSyntax = nullable.ElementType;
+
+                if (typeSyntax is IdentifierNameSyntax idType)
+                    return idType.Identifier.ValueText;
+
+                if (typeSyntax is QualifiedNameSyntax qn)
+                    return qn.Right.Identifier.ValueText;
+
+                if (typeSyntax is GenericNameSyntax gn)
+                    return gn.Identifier.ValueText;
+            }
+        }
+
+        // Also check method / constructor parameters
+        var paramLists = enclosingBody
+            .ChildNodes()
+            .OfType<ParameterListSyntax>()
+            .Concat(enclosingBody.AncestorsAndSelf()
+                .OfType<MethodDeclarationSyntax>()
+                .Select(m => m.ParameterList))
+            .Concat(enclosingBody.AncestorsAndSelf()
+                .OfType<ConstructorDeclarationSyntax>()
+                .Select(c => c.ParameterList));
+
+        foreach (var paramList in paramLists)
+        {
+            foreach (var param in paramList.Parameters)
+            {
+                if (param.Identifier.ValueText != receiverName)
+                    continue;
+
+                if (param.Type is null)
+                    continue;
+
+                var pType = param.Type;
+                if (pType is NullableTypeSyntax npt)
+                    pType = npt.ElementType;
+
+                if (pType is IdentifierNameSyntax pid)
+                    return pid.Identifier.ValueText;
+
+                if (pType is QualifiedNameSyntax pqn)
+                    return pqn.Right.Identifier.ValueText;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the 1-based line number for a <see cref="SyntaxNode"/>.
+    /// </summary>
+    internal static int LineOf(SyntaxNode node) =>
+        node.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+    /// <summary>
+    /// Returns the 1-based line number for a <see cref="SyntaxToken"/>.
+    /// </summary>
+    internal static int LineOf(SyntaxToken token) =>
+        token.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+    /// <summary>
+    /// Creates an identifier token with the given text, suitable for use as a
+    /// replacement identifier while preserving trivia from the original token.
+    /// </summary>
+    internal static SyntaxToken IdentifierWithTrivia(SyntaxToken original, string newText) =>
+        SyntaxFactory.Identifier(newText)
+            .WithLeadingTrivia(original.LeadingTrivia)
+            .WithTrailingTrivia(original.TrailingTrivia);
+}

--- a/WrapGod.Migration.Engine/Rewriters/RewriterHelpers.cs
+++ b/WrapGod.Migration.Engine/Rewriters/RewriterHelpers.cs
@@ -33,9 +33,11 @@ internal static class RewriterHelpers
     /// <summary>
     /// Attempts to infer the declared type name of the receiver expression in a
     /// <see cref="MemberAccessExpressionSyntax"/> using syntax-only heuristics.
-    /// Returns the simple identifier text if the receiver is a simple name for which
-    /// a local/field declaration with an explicit type is visible in the same method
-    /// body, otherwise returns <see langword="null"/>.
+    /// Searches, in order:
+    /// (1) local variable declarations and parameters in the enclosing method body,
+    /// (2) field and property declarations on the enclosing type,
+    /// (3) the receiver identifier itself as a static type name (uppercase-start).
+    /// Returns the short type name when found, otherwise <see langword="null"/>.
     /// </summary>
     internal static string? TryInferReceiverTypeName(
         MemberAccessExpressionSyntax memberAccess,
@@ -56,67 +58,117 @@ internal static class RewriterHelpers
                 ConstructorDeclarationSyntax or
                 AccessorDeclarationSyntax);
 
-        if (enclosingBody is null)
-            return null;
-
-        // Scan local variable declarations: look for "TypeName varName =" or "TypeName varName;"
-        foreach (var local in enclosingBody.DescendantNodes().OfType<VariableDeclarationSyntax>())
+        if (enclosingBody is not null)
         {
-            foreach (var variable in local.Variables)
+            // Scan local variable declarations: skip fields (those are scanned separately
+            // below). Only inspect locals declared inside the method body.
+            foreach (var local in enclosingBody.DescendantNodes().OfType<VariableDeclarationSyntax>())
             {
-                if (variable.Identifier.ValueText != receiverName)
+                if (local.Parent is FieldDeclarationSyntax)
                     continue;
 
-                // Extract the declared type text (e.g., "MyService", "MyService?", etc.)
-                var typeSyntax = local.Type;
-                if (typeSyntax is NullableTypeSyntax nullable)
-                    typeSyntax = nullable.ElementType;
+                foreach (var variable in local.Variables)
+                {
+                    if (variable.Identifier.ValueText != receiverName)
+                        continue;
 
-                if (typeSyntax is IdentifierNameSyntax idType)
-                    return idType.Identifier.ValueText;
+                    var inferred = ExtractShortTypeName(local.Type);
+                    if (inferred is not null)
+                        return inferred;
+                }
+            }
 
-                if (typeSyntax is QualifiedNameSyntax qn)
-                    return qn.Right.Identifier.ValueText;
+            // Also check method / constructor parameters
+            var paramLists = enclosingBody
+                .ChildNodes()
+                .OfType<ParameterListSyntax>()
+                .Concat(enclosingBody.AncestorsAndSelf()
+                    .OfType<MethodDeclarationSyntax>()
+                    .Select(m => m.ParameterList))
+                .Concat(enclosingBody.AncestorsAndSelf()
+                    .OfType<ConstructorDeclarationSyntax>()
+                    .Select(c => c.ParameterList));
 
-                if (typeSyntax is GenericNameSyntax gn)
-                    return gn.Identifier.ValueText;
+            foreach (var paramList in paramLists)
+            {
+                foreach (var param in paramList.Parameters)
+                {
+                    if (param.Identifier.ValueText != receiverName)
+                        continue;
+
+                    if (param.Type is null)
+                        continue;
+
+                    var inferred = ExtractShortTypeName(param.Type);
+                    if (inferred is not null)
+                        return inferred;
+                }
             }
         }
 
-        // Also check method / constructor parameters
-        var paramLists = enclosingBody
-            .ChildNodes()
-            .OfType<ParameterListSyntax>()
-            .Concat(enclosingBody.AncestorsAndSelf()
-                .OfType<MethodDeclarationSyntax>()
-                .Select(m => m.ParameterList))
-            .Concat(enclosingBody.AncestorsAndSelf()
-                .OfType<ConstructorDeclarationSyntax>()
-                .Select(c => c.ParameterList));
+        // Walk up to the enclosing type declaration to scan fields and properties.
+        var enclosingType = memberAccess
+            .Ancestors()
+            .OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault();
 
-        foreach (var paramList in paramLists)
+        if (enclosingType is not null)
         {
-            foreach (var param in paramList.Parameters)
+            // Fields: e.g. `private readonly MyService _service;`
+            foreach (var field in enclosingType.Members.OfType<FieldDeclarationSyntax>())
             {
-                if (param.Identifier.ValueText != receiverName)
+                foreach (var variable in field.Declaration.Variables)
+                {
+                    if (variable.Identifier.ValueText != receiverName)
+                        continue;
+
+                    var inferred = ExtractShortTypeName(field.Declaration.Type);
+                    if (inferred is not null)
+                        return inferred;
+                }
+            }
+
+            // Properties: e.g. `public MyService Service { get; }`
+            foreach (var prop in enclosingType.Members.OfType<PropertyDeclarationSyntax>())
+            {
+                if (prop.Identifier.ValueText != receiverName)
                     continue;
 
-                if (param.Type is null)
-                    continue;
-
-                var pType = param.Type;
-                if (pType is NullableTypeSyntax npt)
-                    pType = npt.ElementType;
-
-                if (pType is IdentifierNameSyntax pid)
-                    return pid.Identifier.ValueText;
-
-                if (pType is QualifiedNameSyntax pqn)
-                    return pqn.Right.Identifier.ValueText;
+                var inferred = ExtractShortTypeName(prop.Type);
+                if (inferred is not null)
+                    return inferred;
             }
         }
+
+        // Static-style receiver: if the receiver identifier text starts with an uppercase
+        // letter and no locals/fields/properties/parameters with that name were found, treat
+        // it as a type-of-name reference (e.g. `MyStatic.OldMethod()` calls a static member).
+        if (!string.IsNullOrEmpty(receiverName) && char.IsUpper(receiverName[0]))
+            return receiverName;
 
         return null;
+    }
+
+    /// <summary>
+    /// Extracts the short (unqualified) type name from a <see cref="TypeSyntax"/>,
+    /// peeling off nullable annotations and arrays. Returns <see langword="null"/> when
+    /// the type cannot be reduced to a simple short name.
+    /// </summary>
+    private static string? ExtractShortTypeName(TypeSyntax typeSyntax)
+    {
+        if (typeSyntax is NullableTypeSyntax nullable)
+            typeSyntax = nullable.ElementType;
+
+        if (typeSyntax is ArrayTypeSyntax array)
+            typeSyntax = array.ElementType;
+
+        return typeSyntax switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            QualifiedNameSyntax qn => qn.Right.Identifier.ValueText,
+            GenericNameSyntax gn => gn.Identifier.ValueText,
+            _ => null,
+        };
     }
 
     /// <summary>

--- a/WrapGod.Migration.Engine/WrapGod.Migration.Engine.csproj
+++ b/WrapGod.Migration.Engine/WrapGod.Migration.Engine.csproj
@@ -12,4 +12,10 @@
     <ProjectReference Include="..\WrapGod.Migration\WrapGod.Migration.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>WrapGod.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/WrapGod.Tests/Fixtures/Migration/SyntheticAfter.cs.txt
+++ b/WrapGod.Tests/Fixtures/Migration/SyntheticAfter.cs.txt
@@ -1,0 +1,26 @@
+using Acme.Modern.Widgets;
+
+namespace TestApp;
+
+// Service consumer demonstrating multiple migration rule kinds simultaneously.
+public class WidgetService
+{
+    // Field receiver — used by RenameMemberRewriter via field-receiver inference.
+    private readonly Widget _widget;
+
+    public WidgetService(Widget widget)
+    {
+        _widget = widget;
+    }
+
+    public IReadOnlyList<string> GetItems()
+    {
+        // RenameMember target: _widget.Render() becomes _widget.Draw()
+        _widget.Draw();
+
+        // ChangeTypeReference: IList<string> stays in the return-type line above; this
+        // local declaration line is also rewritten.
+        IReadOnlyList<string> items = new List<string>();
+        return items;
+    }
+}

--- a/WrapGod.Tests/Fixtures/Migration/SyntheticBefore.cs.txt
+++ b/WrapGod.Tests/Fixtures/Migration/SyntheticBefore.cs.txt
@@ -1,0 +1,26 @@
+using Acme.Legacy.Widgets;
+
+namespace TestApp;
+
+// Service consumer demonstrating multiple migration rule kinds simultaneously.
+public class WidgetService
+{
+    // Field receiver — used by RenameMemberRewriter via field-receiver inference.
+    private readonly Widget _widget;
+
+    public WidgetService(Widget widget)
+    {
+        _widget = widget;
+    }
+
+    public IList<string> GetItems()
+    {
+        // RenameMember target: _widget.Render() becomes _widget.Draw()
+        _widget.Render();
+
+        // ChangeTypeReference: IList<string> stays in the return-type line above; this
+        // local declaration line is also rewritten.
+        IList<string> items = new List<string>();
+        return items;
+    }
+}

--- a/WrapGod.Tests/Fixtures/Migration/SyntheticRules.json
+++ b/WrapGod.Tests/Fixtures/Migration/SyntheticRules.json
@@ -1,0 +1,31 @@
+{
+  "schema": "wrapgod-migration/1.0",
+  "library": "TestApp.Widgets",
+  "from": "1.0.0",
+  "to": "2.0.0",
+  "generatedFrom": "manual",
+  "rules": [
+    {
+      "kind": "renameNamespace",
+      "id": "RNS-001",
+      "confidence": "auto",
+      "oldNamespace": "Acme.Legacy",
+      "newNamespace": "Acme.Modern"
+    },
+    {
+      "kind": "renameMember",
+      "id": "RM-001",
+      "confidence": "auto",
+      "typeName": "Widget",
+      "oldMemberName": "Render",
+      "newMemberName": "Draw"
+    },
+    {
+      "kind": "changeTypeReference",
+      "id": "CTR-001",
+      "confidence": "auto",
+      "oldType": "IList",
+      "newType": "IReadOnlyList"
+    }
+  ]
+}

--- a/WrapGod.Tests/Migration/Engine/Rewriters/AddRequiredParameterRewriterTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/AddRequiredParameterRewriterTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.Rewriters;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.Rewriters;
+
+[Feature("AddRequiredParameterRewriter: insert default argument at required position in matching invocations")]
+public sealed class AddRequiredParameterRewriterTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static AddRequiredParameterRewriter Make() => new();
+
+    private static AddRequiredParameterRule RuleAt(int position = 0, string paramType = "MudTheme") =>
+        new()
+        {
+            Id = "ARP-001",
+            TypeName = "ThemeProvider",
+            MethodName = "Apply",
+            ParameterName = "theme",
+            ParameterType = paramType,
+            Position = position,
+        };
+
+    private static (SyntaxNode Root, RewriteContext Ctx) Parse(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        return (tree.GetRoot(), new RewriteContext("test.cs"));
+    }
+
+    // ── happy ────────────────────────────────────────────────────────────────
+
+    [Scenario("default argument is inserted at position 0 for an empty argument list")]
+    [Fact]
+    public Task AddRequiredParameter_Position0_EmptyArgList_InsertsDefault() =>
+        Given("source calling provider.Apply() with no args and rule adding at position 0", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(ThemeProvider provider) { provider.Apply(); } }");
+            var result = Make().TryRewrite(root, RuleAt(0), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null", t => t.Result is not null)
+        .And("result contains default", t => t.Result!.ToString().Contains("default"))
+        .And("result contains TODO MIGRATION comment", t => t.Result!.ToString().Contains("TODO MIGRATION", StringComparison.Ordinal))
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("default argument is inserted at position 1 after existing argument")]
+    [Fact]
+    public Task AddRequiredParameter_Position1_ExistingArgs_InsertsAtRight() =>
+        Given("source calling provider.Apply(x) and rule adding at position 1", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(ThemeProvider provider) { provider.Apply(x); } }");
+            var result = Make().TryRewrite(root, RuleAt(1), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result contains x, default", t =>
+        {
+            var s = t.Result!.ToString();
+            return s.Contains('x') && s.Contains("default", StringComparison.Ordinal);
+        })
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("Multiple matching invocations each get the default argument")]
+    [Fact]
+    public Task AddRequiredParameter_MultipleInvocations_AllGetDefault() =>
+        Given("source with two calls to Apply()", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { void M(ThemeProvider p) { p.Apply(); p.Apply(); } }");
+            var result = Make().TryRewrite(root, RuleAt(0), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count is 2", t => t.Ctx.Applied.Count == 2)
+        .AssertPassed();
+
+    [Scenario("Wrong rule kind returns null")]
+    [Fact]
+    public Task AddRequiredParameter_WrongRuleKind_ReturnsNull() =>
+        Given("a RemoveMemberRule passed to AddRequiredParameterRewriter", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(ThemeProvider p) { p.Apply(); } }");
+            var wrongRule = new RemoveMemberRule { Id = "X", TypeName = "T", MemberName = "M" };
+            var result = Make().TryRewrite(root, wrongRule, ctx);
+            return result;
+        })
+        .Then("result is null", r => r is null)
+        .AssertPassed();
+
+    [Scenario("No matching invocation returns null")]
+    [Fact]
+    public Task AddRequiredParameter_NoMatch_ReturnsNull() =>
+        Given("source with no Apply() calls", () =>
+        {
+            var (root, ctx) = Parse("class C { void M() { } }");
+            var result = Make().TryRewrite(root, RuleAt(0), ctx);
+            return result;
+        })
+        .Then("result is null", r => r is null)
+        .AssertPassed();
+
+    [Scenario("Trivia is preserved around the modified argument list")]
+    [Fact]
+    public Task AddRequiredParameter_Trivia_IsPreserved() =>
+        Given("source with whitespace around the call", () =>
+        {
+            var src = "class C { void M(ThemeProvider p) {\n    p.Apply();\n} }";
+            var (root, ctx) = Parse(src);
+            var result = Make().TryRewrite(root, RuleAt(0), ctx);
+            return result!.ToString();
+        })
+        .Then("default is in the result", s => s.Contains("default"))
+        .AssertPassed();
+
+    [Scenario("Kind property returns addRequiredParameter")]
+    [Fact]
+    public Task AddRequiredParameterRewriter_Kind_IsAddRequiredParameter() =>
+        Given("an AddRequiredParameterRewriter instance", () => Make())
+        .Then("Kind is addRequiredParameter", r => r.Kind == "addRequiredParameter")
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/Rewriters/ChangeParameterRewriterTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/ChangeParameterRewriterTests.cs
@@ -1,0 +1,138 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.Rewriters;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.Rewriters;
+
+[Feature("ChangeParameterRewriter: rename named arguments; skip positional when type changes")]
+public sealed class ChangeParameterRewriterTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static ChangeParameterRewriter Make() => new();
+
+    private static ChangeParameterRule NameRenameRule() =>
+        new()
+        {
+            Id = "CP-001",
+            TypeName = "Builder",
+            MethodName = "Build",
+            OldParameterName = "size",
+            NewParameterName = "buttonSize",
+            OldParameterType = null,
+            NewParameterType = null,
+        };
+
+    private static ChangeParameterRule TypeChangeRule() =>
+        new()
+        {
+            Id = "CP-002",
+            TypeName = "Builder",
+            MethodName = "Build",
+            OldParameterName = "size",
+            NewParameterName = null,
+            OldParameterType = "int",
+            NewParameterType = "MudSize",
+        };
+
+    private static (SyntaxNode Root, RewriteContext Ctx) Parse(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        return (tree.GetRoot(), new RewriteContext("test.cs"));
+    }
+
+    // ── happy ────────────────────────────────────────────────────────────────
+
+    [Scenario("Named argument label is renamed when parameter name changed")]
+    [Fact]
+    public Task ChangeParameter_NamedArg_Renamed() =>
+        Given("source with Build(size: 12) and rule renaming size->buttonSize", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(Builder b) { b.Build(size: 12); } }");
+            var result = Make().TryRewrite(root, NameRenameRule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null", t => t.Result is not null)
+        .And("result contains buttonSize:", t => t.Result!.ToString().Contains("buttonSize:"))
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("Positional argument with type change records SkippedRewrite")]
+    [Fact]
+    public Task ChangeParameter_PositionalWithTypeChange_RecordsSkipped() =>
+        Given("source with Build(12) and rule changing type int->MudSize", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(Builder b) { b.Build(12); } }");
+            var result = Make().TryRewrite(root, TypeChangeRule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Skipped count >= 1", t => t.Ctx.Skipped.Count >= 1)
+        .And("Skipped reason mentions type change", t =>
+            t.Ctx.Skipped[0].Reason.Contains("type", StringComparison.OrdinalIgnoreCase))
+        .AssertPassed();
+
+    [Scenario("Wrong rule kind returns null")]
+    [Fact]
+    public Task ChangeParameter_WrongRuleKind_ReturnsNull() =>
+        Given("a RemoveMemberRule passed to ChangeParameterRewriter", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(Builder b) { b.Build(size: 12); } }");
+            var wrongRule = new RemoveMemberRule { Id = "X", TypeName = "T", MemberName = "M" };
+            var result = Make().TryRewrite(root, wrongRule, ctx);
+            return result;
+        })
+        .Then("result is null", r => r is null)
+        .AssertPassed();
+
+    [Scenario("No matching invocation returns null")]
+    [Fact]
+    public Task ChangeParameter_NoMatch_ReturnsNull() =>
+        Given("source with no Build invocation", () =>
+        {
+            var (root, ctx) = Parse("class C { void M() { } }");
+            var result = Make().TryRewrite(root, NameRenameRule(), ctx);
+            return result;
+        })
+        .Then("result is null", r => r is null)
+        .AssertPassed();
+
+    [Scenario("Trivia is preserved on renamed named argument label")]
+    [Fact]
+    public Task ChangeParameter_Trivia_IsPreserved() =>
+        Given("source with leading whitespace around named argument", () =>
+        {
+            var src = "class C { void M(Builder b) { b.Build(\n    size:  12\n); } }";
+            var (root, ctx) = Parse(src);
+            var result = Make().TryRewrite(root, NameRenameRule(), ctx);
+            return result!.ToString();
+        })
+        .Then("buttonSize: is present", s => s.Contains("buttonSize:"))
+        .And("size: is gone", s => !s.Contains("size:"))
+        .AssertPassed();
+
+    [Scenario("Multiple named argument labels of same name are all renamed")]
+    [Fact]
+    public Task ChangeParameter_MultipleNamedArgs_AllRenamed() =>
+        Given("source with two calls both using size: named argument", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { void M(Builder b) { b.Build(size: 1); b.Build(size: 2); } }");
+            var result = Make().TryRewrite(root, NameRenameRule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count is 2", t => t.Ctx.Applied.Count == 2)
+        .And("no remaining size: labels", t => !t.Result!.ToString().Contains("size:"))
+        .AssertPassed();
+
+    [Scenario("Kind property returns changeParameter")]
+    [Fact]
+    public Task ChangeParameterRewriter_Kind_IsChangeParameter() =>
+        Given("a ChangeParameterRewriter instance", () => Make())
+        .Then("Kind is changeParameter", r => r.Kind == "changeParameter")
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/Rewriters/ChangeTypeReferenceRewriterTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/ChangeTypeReferenceRewriterTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.Rewriters;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.Rewriters;
+
+[Feature("ChangeTypeReferenceRewriter: replace old type references with new type in declarations and expressions")]
+public sealed class ChangeTypeReferenceRewriterTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static ChangeTypeReferenceRewriter Make() => new();
+
+    private static ChangeTypeReferenceRule Rule(string old = "IList", string @new = "IReadOnlyList") =>
+        new() { Id = "CTR-001", OldType = old, NewType = @new };
+
+    private static (SyntaxNode Root, RewriteContext Ctx) Parse(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        return (tree.GetRoot(), new RewriteContext("test.cs"));
+    }
+
+    // ── happy ────────────────────────────────────────────────────────────────
+
+    [Scenario("Field declaration type is replaced")]
+    [Fact]
+    public Task ChangeTypeReference_FieldDeclaration_Replaced() =>
+        Given("source with 'IList<string> items' and rule IList->IReadOnlyList", () =>
+        {
+            var (root, ctx) = Parse("class C { IList<string> items; }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null", t => t.Result is not null)
+        .And("result contains IReadOnlyList", t => t.Result!.ToString().Contains("IReadOnlyList"))
+        .And("result does not contain IList<", t => !t.Result!.ToString().Contains("IList<"))
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("typeof expression type is replaced")]
+    [Fact]
+    public Task ChangeTypeReference_TypeofExpression_Replaced() =>
+        Given("source with typeof(IList<int>) and rule IList->IReadOnlyList", () =>
+        {
+            var (root, ctx) = Parse("class C { void M() { var t = typeof(IList<int>); } }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result contains IReadOnlyList", t => t.Result!.ToString().Contains("IReadOnlyList"))
+        .And("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("Multiple type references in file are all replaced")]
+    [Fact]
+    public Task ChangeTypeReference_MultipleOccurrences_AllReplaced() =>
+        Given("source with three IList<T> references", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { IList<int> a; IList<string> b; void M(IList<bool> p) {} }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count is 3", t => t.Ctx.Applied.Count == 3)
+        .And("no IList< remains", t => !t.Result!.ToString().Contains("IList<"))
+        .AssertPassed();
+
+    [Scenario("Wrong rule kind returns null")]
+    [Fact]
+    public Task ChangeTypeReference_WrongRuleKind_ReturnsNull() =>
+        Given("a RenameTypeRule passed to ChangeTypeReferenceRewriter", () =>
+        {
+            var (root, ctx) = Parse("class C { IList<int> a; }");
+            var wrongRule = new RenameTypeRule { Id = "X", OldName = "A", NewName = "B" };
+            var result = Make().TryRewrite(root, wrongRule, ctx);
+            return result;
+        })
+        .Then("result is null", r => r is null)
+        .AssertPassed();
+
+    [Scenario("No matching type reference returns null")]
+    [Fact]
+    public Task ChangeTypeReference_NoMatch_ReturnsNull() =>
+        Given("source with no IList references", () =>
+        {
+            var (root, ctx) = Parse("class C { int x; }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return result;
+        })
+        .Then("result is null", r => r is null)
+        .AssertPassed();
+
+    [Scenario("Trivia is preserved on replaced type node")]
+    [Fact]
+    public Task ChangeTypeReference_Trivia_IsPreserved() =>
+        Given("source with comments near the type reference", () =>
+        {
+            var src = "class C {\n    // collection field\n    IList<string>  items;\n}";
+            var (root, ctx) = Parse(src);
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            // Use ToFullString() to capture trivia (comments, whitespace) around nodes
+            return result!.ToFullString();
+        })
+        .Then("comment is preserved", s => s.Contains("// collection field"))
+        .And("IReadOnlyList is in result", s => s.Contains("IReadOnlyList"))
+        .AssertPassed();
+
+    [Scenario("Partial name collision: IListExtensions is not replaced")]
+    [Fact]
+    public Task ChangeTypeReference_PartialNameCollision_NotReplaced() =>
+        Given("source with IListExtensions type and rule targeting IList", () =>
+        {
+            var (root, ctx) = Parse("class C { IListExtensions ext; }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is null (no match)", t => t.Result is null)
+        .And("Applied count is 0", t => t.Ctx.Applied.Count == 0)
+        .AssertPassed();
+
+    [Scenario("Kind property returns changeTypeReference")]
+    [Fact]
+    public Task ChangeTypeReferenceRewriter_Kind_IsChangeTypeReference() =>
+        Given("a ChangeTypeReferenceRewriter instance", () => Make())
+        .Then("Kind is changeTypeReference", r => r.Kind == "changeTypeReference")
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/Rewriters/RemoveMemberRewriterTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/RemoveMemberRewriterTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.Rewriters;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.Rewriters;
+
+[Feature("RemoveMemberRewriter: comment-out call sites for removed members and record Applied")]
+public sealed class RemoveMemberRewriterTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static RemoveMemberRewriter Make() => new();
+
+    private static RemoveMemberRule Rule(string typeName = "OldApi", string member = "Deprecated") =>
+        new() { Id = "DEL-001", TypeName = typeName, MemberName = member, Note = "Use NewApi instead." };
+
+    private static (SyntaxNode Root, RewriteContext Ctx) Parse(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        return (tree.GetRoot(), new RewriteContext("test.cs"));
+    }
+
+    // ── happy ────────────────────────────────────────────────────────────────
+
+    [Scenario("Call site is commented out and Applied entry recorded")]
+    [Fact]
+    public Task RemoveMember_CallSite_CommentedOut_AndApplied() =>
+        Given("source calling obj.Deprecated() and rule for OldApi.Deprecated", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(OldApi obj) { obj.Deprecated(); } }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null", t => t.Result is not null)
+        .And("result contains MIGRATION comment", t => t.Result!.ToString().Contains("MIGRATION"))
+        .And("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("MIGRATION comment contains rule id")]
+    [Fact]
+    public Task RemoveMember_Comment_ContainsRuleId() =>
+        Given("source calling obj.Deprecated()", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(OldApi obj) { obj.Deprecated(); } }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return result!.ToString();
+        })
+        .Then("comment contains rule id DEL-001", s => s.Contains("DEL-001"))
+        .AssertPassed();
+
+    [Scenario("Multiple call sites are all commented out")]
+    [Fact]
+    public Task RemoveMember_MultipleCallSites_AllCommentedOut() =>
+        Given("source with two calls to Deprecated()", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { void M(OldApi obj) { obj.Deprecated(); obj.Deprecated(); } }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count is 2", t => t.Ctx.Applied.Count == 2)
+        .AssertPassed();
+
+    [Scenario("Wrong rule kind returns null")]
+    [Fact]
+    public Task RemoveMember_WrongRuleKind_ReturnsNull() =>
+        Given("a RenameTypeRule passed to RemoveMemberRewriter", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(OldApi obj) { obj.Deprecated(); } }");
+            var wrongRule = new RenameTypeRule { Id = "X", OldName = "A", NewName = "B" };
+            var result = Make().TryRewrite(root, wrongRule, ctx);
+            return result;
+        })
+        .Then("result is null", r => r is null)
+        .AssertPassed();
+
+    [Scenario("No matching call site returns null")]
+    [Fact]
+    public Task RemoveMember_NoMatch_ReturnsNull() =>
+        Given("source with no calls to Deprecated", () =>
+        {
+            var (root, ctx) = Parse("class C { void M() { } }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return result;
+        })
+        .Then("result is null", r => r is null)
+        .AssertPassed();
+
+    [Scenario("Trivia around commented-out expression is preserved")]
+    [Fact]
+    public Task RemoveMember_Trivia_IsPreserved() =>
+        Given("source with leading whitespace on the call statement", () =>
+        {
+            var src = "class C { void M(OldApi obj) {\n    obj.Deprecated();\n} }";
+            var (root, ctx) = Parse(src);
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return result!.ToString();
+        })
+        .Then("MIGRATION comment is in the output", s => s.Contains("MIGRATION"))
+        .AssertPassed();
+
+    [Scenario("Kind property returns removeMember")]
+    [Fact]
+    public Task RemoveMemberRewriter_Kind_IsRemoveMember() =>
+        Given("a RemoveMemberRewriter instance", () => Make())
+        .Then("Kind is removeMember", r => r.Kind == "removeMember")
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/Rewriters/RemoveMemberRewriterTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/RemoveMemberRewriterTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using TinyBDD;
@@ -10,8 +11,11 @@ using Xunit.Abstractions;
 namespace WrapGod.Tests.Migration.Engine.Rewriters;
 
 [Feature("RemoveMemberRewriter: comment-out call sites for removed members and record Applied")]
-public sealed class RemoveMemberRewriterTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+public sealed partial class RemoveMemberRewriterTests(ITestOutputHelper output) : TinyBddXunitBase(output)
 {
+    [GeneratedRegex(@"^\s*;\s*$", RegexOptions.Multiline)]
+    private static partial Regex LoneSemicolonLine();
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static RemoveMemberRewriter Make() => new();
@@ -109,5 +113,37 @@ public sealed class RemoveMemberRewriterTests(ITestOutputHelper output) : TinyBd
     public Task RemoveMemberRewriter_Kind_IsRemoveMember() =>
         Given("a RemoveMemberRewriter instance", () => Make())
         .Then("Kind is removeMember", r => r.Kind == "removeMember")
+        .AssertPassed();
+
+    // ── regression ───────────────────────────────────────────────────────────
+
+    [Scenario("Rewritten output does not contain orphaned lone-semicolon lines")]
+    [Fact]
+    public Task RemoveMember_Output_HasNoOrphanSemicolon() =>
+        Given("source with deprecated call followed by another statement", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { void M(OldApi obj) {\n    obj.Deprecated();\n    var x = 1;\n} }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return result!.ToFullString();
+        })
+        .Then("output does NOT contain a lone ';' on its own line", s =>
+            !LoneSemicolonLine().IsMatch(s))
+        .And("output contains the MIGRATION comment", s => s.Contains("MIGRATION"))
+        .And("output contains the surviving statement 'var x = 1'", s => s.Contains("var x = 1"))
+        .AssertPassed();
+
+    [Scenario("Removed call as last statement in block attaches comment to closing brace trivia")]
+    [Fact]
+    public Task RemoveMember_LastStatement_NoOrphanSemicolon() =>
+        Given("source where the removed call is the ONLY statement in the block", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(OldApi obj) {\n    obj.Deprecated();\n} }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return result!.ToFullString();
+        })
+        .Then("output does NOT contain a lone ';' on its own line", s =>
+            !LoneSemicolonLine().IsMatch(s))
+        .And("output contains the MIGRATION comment", s => s.Contains("MIGRATION"))
         .AssertPassed();
 }

--- a/WrapGod.Tests/Migration/Engine/Rewriters/RenameMemberRewriterTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/RenameMemberRewriterTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.Rewriters;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.Rewriters;
+
+[Feature("RenameMemberRewriter: rename a member on a known declaring type, skip ambiguous usages")]
+public sealed class RenameMemberRewriterTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static RenameMemberRewriter Make() => new();
+
+    private static RenameMemberRule Rule(string typeName = "MyService", string old = "OldMethod", string @new = "NewMethod") =>
+        new() { Id = "RM-001", TypeName = typeName, OldMemberName = old, NewMemberName = @new };
+
+    private static (SyntaxNode Root, RewriteContext Ctx) Parse(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        return (tree.GetRoot(), new RewriteContext("test.cs"));
+    }
+
+    // ── happy ────────────────────────────────────────────────────────────────
+
+    [Scenario("Member access where receiver type variable is declared with the declaring type is renamed")]
+    [Fact]
+    public Task RenameMember_VariableDeclaredWithType_Renamed() =>
+        Given("source declaring 'MyService svc' and calling svc.OldMethod()", () =>
+        {
+            var (root, ctx) = Parse("class C { void M() { MyService svc = null; svc.OldMethod(); } }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null", t => t.Result is not null)
+        .And("result contains NewMethod", t => t.Result!.ToString().Contains("NewMethod"))
+        .And("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("Ambiguous receiver records SkippedRewrite and returns non-null tree (no rewrite at that site)")]
+    [Fact]
+    public Task RenameMember_AmbiguousReceiver_RecordsSkipped() =>
+        Given("source with 'obj.OldMethod()' where obj type is unknown", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(object obj) { obj.OldMethod(); } }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Skipped has at least one entry", t => t.Ctx.Skipped.Count >= 1)
+        .And("Skipped reason mentions ambiguous", t => t.Ctx.Skipped[0].Reason.Contains("ambiguous", StringComparison.OrdinalIgnoreCase))
+        .AssertPassed();
+
+    [Scenario("Wrong rule kind returns null")]
+    [Fact]
+    public Task RenameMember_WrongRuleKind_ReturnsNull() =>
+        Given("a RenameTypeRule passed to RenameMemberRewriter", () =>
+        {
+            var (root, ctx) = Parse("class C { void M() { svc.OldMethod(); } }");
+            var wrongRule = new RenameTypeRule { Id = "X", OldName = "A", NewName = "B" };
+            var result = Make().TryRewrite(root, wrongRule, ctx);
+            return result;
+        })
+        .Then("result is null", r => r is null)
+        .AssertPassed();
+
+    [Scenario("No member access of OldMemberName returns null")]
+    [Fact]
+    public Task RenameMember_NoMatch_ReturnsNull() =>
+        Given("source with no OldMethod references", () =>
+        {
+            var (root, ctx) = Parse("class C { void M() { } }");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return result;
+        })
+        .Then("result is null", r => r is null)
+        .AssertPassed();
+
+    [Scenario("Trivia is preserved on renamed member access")]
+    [Fact]
+    public Task RenameMember_Trivia_IsPreserved() =>
+        Given("source with whitespace around member access", () =>
+        {
+            var src = "class C { void M() { MyService  svc = null;\n    svc.OldMethod  (); } }";
+            var (root, ctx) = Parse(src);
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return result!.ToString();
+        })
+        .Then("NewMethod is present", s => s.Contains("NewMethod"))
+        .And("OldMethod is gone", s => !s.Contains("OldMethod"))
+        .AssertPassed();
+
+    [Scenario("Same-named member on unrelated type is skipped, not renamed")]
+    [Fact]
+    public Task RenameMember_UnrelatedType_Skipped() =>
+        Given("source with two types both having OldMethod, only one matches rule", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { void M() { OtherService other = null; other.OldMethod(); } }");
+            var result = Make().TryRewrite(root, Rule("MyService", "OldMethod", "NewMethod"), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Skipped count >= 1 (receiver type does not match)", t => t.Ctx.Skipped.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("Kind property returns renameMember")]
+    [Fact]
+    public Task RenameMemberRewriter_Kind_IsRenameMember() =>
+        Given("a RenameMemberRewriter instance", () => Make())
+        .Then("Kind is renameMember", r => r.Kind == "renameMember")
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/Rewriters/RenameNamespaceRewriterTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/RenameNamespaceRewriterTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.Rewriters;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.Rewriters;
+
+[Feature("RenameNamespaceRewriter: rewrite using directives and qualified names when a namespace changes")]
+public sealed class RenameNamespaceRewriterTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static RenameNamespaceRewriter Make() => new();
+
+    private static RenameNamespaceRule Rule(string old = "OldNs", string @new = "NewNs") =>
+        new() { Id = "RNS-001", OldNamespace = old, NewNamespace = @new };
+
+    private static (SyntaxNode Root, RewriteContext Ctx) Parse(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        return (tree.GetRoot(), new RewriteContext("test.cs"));
+    }
+
+    // ── happy ────────────────────────────────────────────────────────────────
+
+    [Scenario("using directive with exact match is rewritten")]
+    [Fact]
+    public Task RenameNamespace_UsingDirective_ExactMatch_Rewritten() =>
+        Given("source with 'using OldNs;' and rule OldNs->NewNs", () =>
+        {
+            var (root, ctx) = Parse("using OldNs;");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null", t => t.Result is not null)
+        .And("result contains NewNs", t => t.Result!.ToString().Contains("NewNs"))
+        .And("result does not contain OldNs", t => !t.Result!.ToString().Contains("OldNs"))
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("using directive with sub-namespace is rewritten")]
+    [Fact]
+    public Task RenameNamespace_UsingDirective_SubNamespace_Rewritten() =>
+        Given("source with 'using OldNs.Sub;' and rule OldNs->NewNs", () =>
+        {
+            var (root, ctx) = Parse("using OldNs.Sub;");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result contains NewNs.Sub", t => t.Result!.ToString().Contains("NewNs.Sub"))
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("Multiple using directives in same file are all updated")]
+    [Fact]
+    public Task RenameNamespace_MultipleUsings_AllRewritten() =>
+        Given("source with 'using OldNs; using OldNs.A; using OldNs.B;'", () =>
+        {
+            var (root, ctx) = Parse("using OldNs;\nusing OldNs.A;\nusing OldNs.B;");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result has 3 Applied entries", t => t.Ctx.Applied.Count == 3)
+        .And("no OldNs references remain", t => !t.Result!.ToString().Contains("OldNs"))
+        .AssertPassed();
+
+    [Scenario("Wrong rule kind returns null")]
+    [Fact]
+    public Task RenameNamespace_WrongRuleKind_ReturnsNull() =>
+        Given("a RenameTypeRule passed to RenameNamespaceRewriter", () =>
+        {
+            var (root, ctx) = Parse("using OldNs;");
+            var wrongRule = new RenameTypeRule { Id = "X", OldName = "A", NewName = "B" };
+            var result = Make().TryRewrite(root, wrongRule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is null", t => t.Result is null)
+        .And("no Applied entries", t => t.Ctx.Applied.Count == 0)
+        .AssertPassed();
+
+    [Scenario("No matching namespace returns null")]
+    [Fact]
+    public Task RenameNamespace_NoMatch_ReturnsNull() =>
+        Given("source with 'using SomeOtherNs;' and rule OldNs->NewNs", () =>
+        {
+            var (root, ctx) = Parse("using SomeOtherNs;");
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is null", t => t.Result is null)
+        .AssertPassed();
+
+    [Scenario("Trivia is preserved on rewritten using directive")]
+    [Fact]
+    public Task RenameNamespace_Trivia_IsPreserved() =>
+        Given("source with comment before the using", () =>
+        {
+            var src = "// namespace import\nusing OldNs.Tools;";
+            var (root, ctx) = Parse(src);
+            var result = Make().TryRewrite(root, Rule(), ctx);
+            // Use ToFullString() to include leading/trailing trivia (comments, whitespace)
+            return result!.ToFullString();
+        })
+        .Then("comment is preserved", s => s.Contains("// namespace import"))
+        .And("NewNs.Tools is present", s => s.Contains("NewNs.Tools"))
+        .AssertPassed();
+
+    [Scenario("Kind property returns renameNamespace")]
+    [Fact]
+    public Task RenameNamespaceRewriter_Kind_IsRenameNamespace() =>
+        Given("a RenameNamespaceRewriter instance", () => Make())
+        .Then("Kind is renameNamespace", r => r.Kind == "renameNamespace")
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/Rewriters/RenameTypeRewriterTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/RenameTypeRewriterTests.cs
@@ -1,0 +1,136 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.Rewriters;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.Rewriters;
+
+[Feature("RenameTypeRewriter: rename a type's short name across declarations and usages")]
+public sealed class RenameTypeRewriterTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static RenameTypeRewriter Make() => new();
+
+    private static RenameTypeRule SameNsRule(string old = "Foo.Bar", string @new = "Foo.Baz") =>
+        new() { Id = "RT-001", OldName = old, NewName = @new };
+
+    private static RenameTypeRule CrossNsRule() =>
+        new() { Id = "RT-002", OldName = "OldNs.OldType", NewName = "NewNs.NewType" };
+
+    private static (SyntaxNode Root, RewriteContext Ctx) Parse(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var ctx = new RewriteContext("test.cs");
+        return (tree.GetRoot(), ctx);
+    }
+
+    // ── happy ────────────────────────────────────────────────────────────────
+
+    [Scenario("Short name is replaced in a simple variable declaration")]
+    [Fact]
+    public Task RenameType_VariableDeclaration_ReplacesShortName() =>
+        Given("source with 'Bar x = new Bar();' and rule OldName=Foo.Bar NewName=Foo.Baz", () =>
+        {
+            var (root, ctx) = Parse("class C { Foo.Bar x = new Foo.Bar(); }");
+            var rule = SameNsRule();
+            var rewriter = Make();
+            var result = rewriter.TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null", t => t.Result is not null)
+        .And("result contains Baz", t => t.Result!.ToString().Contains("Baz"))
+        .And("result does not contain Bar as type", t => !t.Result!.ToString().Contains("Foo.Bar"))
+        .And("at least one Applied entry recorded", t => t.Ctx.Applied.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("Multiple occurrences of the type name are all replaced")]
+    [Fact]
+    public Task RenameType_MultipleOccurrences_AllReplaced() =>
+        Given("source with three usages of OldType and rule OldName=Foo.OldType NewName=Foo.NewType", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { Foo.OldType a; Foo.OldType b; void M(Foo.OldType p) {} }");
+            var rule = SameNsRule("Foo.OldType", "Foo.NewType");
+            var rewriter = Make();
+            var result = rewriter.TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result has no remaining OldType references", t =>
+            !t.Result!.ToString().Contains("OldType"))
+        .And("Applied count is 3", t => t.Ctx.Applied.Count == 3)
+        .AssertPassed();
+
+    [Scenario("Wrong rule kind returns null without modifying anything")]
+    [Fact]
+    public Task RenameType_WrongRuleKind_ReturnsNull() =>
+        Given("a RenameNamespaceRule passed to RenameTypeRewriter", () =>
+        {
+            var (root, ctx) = Parse("class C { Bar x; }");
+            var wrongRule = new RenameNamespaceRule { Id = "X-001", OldNamespace = "Old", NewNamespace = "New" };
+            var rewriter = Make();
+            var result = rewriter.TryRewrite(root, wrongRule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is null", t => t.Result is null)
+        .And("no Applied entries", t => t.Ctx.Applied.Count == 0)
+        .And("no Skipped entries", t => t.Ctx.Skipped.Count == 0)
+        .AssertPassed();
+
+    [Scenario("No matching type name in source returns null")]
+    [Fact]
+    public Task RenameType_NoMatch_ReturnsNull() =>
+        Given("source with only 'Qux' type and rule targeting 'Bar'", () =>
+        {
+            var (root, ctx) = Parse("class C { Qux x; }");
+            var rule = SameNsRule("Foo.Bar", "Foo.Baz");
+            var rewriter = Make();
+            var result = rewriter.TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is null", t => t.Result is null)
+        .And("no Applied entries", t => t.Ctx.Applied.Count == 0)
+        .AssertPassed();
+
+    [Scenario("Trivia is preserved around replaced type identifier")]
+    [Fact]
+    public Task RenameType_Trivia_IsPreserved() =>
+        Given("source with leading comment and whitespace around the type reference", () =>
+        {
+            var src = "class C {\n    // comment\n    Foo.Bar  x;\n}";
+            var (root, ctx) = Parse(src);
+            var rule = SameNsRule();
+            var rewriter = Make();
+            var result = rewriter.TryRewrite(root, rule, ctx);
+            return result!.ToString();
+        })
+        .Then("leading comment is still present", s => s.Contains("// comment"))
+        .And("replaced name is Baz", s => s.Contains("Baz"))
+        .AssertPassed();
+
+    [Scenario("Partial-name collision: FooBarType is not renamed when rule targets Foo")]
+    [Fact]
+    public Task RenameType_PartialNameCollision_NotRenamed() =>
+        Given("source with 'FooBarType' and rule targeting short name 'Foo'", () =>
+        {
+            var (root, ctx) = Parse("class C { FooBarType x; }");
+            var rule = SameNsRule("Ns.Foo", "Ns.Baz");
+            var rewriter = Make();
+            var result = rewriter.TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is null (no match)", t => t.Result is null)
+        .And("FooBarType is not in Applied", t => t.Ctx.Applied.Count == 0)
+        .AssertPassed();
+
+    [Scenario("Kind property returns renameType")]
+    [Fact]
+    public Task RenameTypeRewriter_Kind_IsRenameType() =>
+        Given("a RenameTypeRewriter instance", () => Make())
+        .Then("Kind is renameType", r => r.Kind == "renameType")
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/Rewriters/RewriterCoverageBoostTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/RewriterCoverageBoostTests.cs
@@ -90,10 +90,10 @@ public sealed class RewriterCoverageBoostTests(ITestOutputHelper output) : TinyB
         .And("result contains NewMethod", t => t.Result!.ToString().Contains("NewMethod"))
         .AssertPassed();
 
-    [Scenario("RenameMember with constructor parameter as receiver is renamed")]
+    [Scenario("RenameMember with constructor parameter as receiver is renamed (deterministic)")]
     [Fact]
     public Task RenameMember_ConstructorParam_ReceiverInferred() =>
-        Given("source with constructor parameter MyService and call to OldMethod", () =>
+        Given("source with constructor parameter MyService and call to OldMethod in body", () =>
         {
             var (root, ctx) = Parse(
                 "class C { C(MyService svc) { svc.OldMethod(); } }");
@@ -107,8 +107,10 @@ public sealed class RewriterCoverageBoostTests(ITestOutputHelper output) : TinyB
             var result = new RenameMemberRewriter().TryRewrite(root, rule, ctx);
             return (Result: result, Ctx: ctx);
         })
-        .Then("Applied count >= 1 OR Skipped (constructor body)", t =>
-            t.Ctx.Applied.Count >= 1 || t.Ctx.Skipped.Count >= 1)
+        .Then("result is not null", t => t.Result is not null)
+        .And("Applied count is exactly 1", t => t.Ctx.Applied.Count == 1)
+        .And("Skipped count is 0", t => t.Ctx.Skipped.Count == 0)
+        .And("result contains NewMethod", t => t.Result!.ToString().Contains("NewMethod"))
         .AssertPassed();
 
     // ── ChangeParameterRewriter — bare method name invocation ────────────────
@@ -133,6 +135,28 @@ public sealed class RewriterCoverageBoostTests(ITestOutputHelper output) : TinyB
         })
         .Then("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
         .And("result contains buttonSize:", t => t.Result!.ToString().Contains("buttonSize:"))
+        .AssertPassed();
+
+    [Scenario("ChangeParameter on unrelated type records SkippedRewrite (receiver disambiguation)")]
+    [Fact]
+    public Task ChangeParameter_UnrelatedReceiverType_Skipped() =>
+        Given("two types both having Build(size: int); rule targets only Builder", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { void M(OtherBuilder ob) { ob.Build(size: 1); } }");
+            var rule = new ChangeParameterRule
+            {
+                Id = "CP-UNREL",
+                TypeName = "Builder",
+                MethodName = "Build",
+                OldParameterName = "size",
+                NewParameterName = "buttonSize",
+            };
+            var result = new ChangeParameterRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Skipped count >= 1 (receiver type does not match)", t => t.Ctx.Skipped.Count >= 1)
+        .And("Applied count is 0", t => t.Ctx.Applied.Count == 0)
         .AssertPassed();
 
     [Scenario("ChangeParameter with no NewParameterName leaves label unchanged (no rewrite)")]
@@ -195,6 +219,54 @@ public sealed class RewriterCoverageBoostTests(ITestOutputHelper output) : TinyB
         })
         .Then("Applied count is 1", t => t.Ctx.Applied.Count == 1)
         .And("result contains default", t => t.Result!.ToString().Contains("default", StringComparison.Ordinal))
+        .AssertPassed();
+
+    [Scenario("AddRequiredParameter emits null literal when parameter type is interface")]
+    [Fact]
+    public Task AddRequiredParameter_InterfaceType_EmitsNull() =>
+        Given("source with provider.Apply() and rule adding ILogger parameter", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(ThemeProvider provider) { provider.Apply(); } }");
+            var rule = new AddRequiredParameterRule
+            {
+                Id = "ARP-INTF",
+                TypeName = "ThemeProvider",
+                MethodName = "Apply",
+                ParameterName = "logger",
+                ParameterType = "ILogger",
+                Position = 0,
+            };
+            var result = new AddRequiredParameterRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result contains 'null' placeholder (not 'default')", t =>
+        {
+            var s = t.Result!.ToString();
+            return s.Contains("null", StringComparison.Ordinal);
+        })
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("AddRequiredParameter emits null literal when parameter type is nullable")]
+    [Fact]
+    public Task AddRequiredParameter_NullableType_EmitsNull() =>
+        Given("source with provider.Apply() and rule adding MudTheme? parameter", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(ThemeProvider provider) { provider.Apply(); } }");
+            var rule = new AddRequiredParameterRule
+            {
+                Id = "ARP-NULL",
+                TypeName = "ThemeProvider",
+                MethodName = "Apply",
+                ParameterName = "theme",
+                ParameterType = "MudTheme?",
+                Position = 0,
+            };
+            var result = new AddRequiredParameterRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result contains 'null' placeholder", t =>
+            t.Result!.ToString().Contains("null", StringComparison.Ordinal))
         .AssertPassed();
 
     // ── ChangeTypeReferenceRewriter — base list and cast contexts ────────────
@@ -317,13 +389,35 @@ public sealed class RewriterCoverageBoostTests(ITestOutputHelper output) : TinyB
         .Then("Skipped count >= 1 (var type is inferred, not explicit)", t => t.Ctx.Skipped.Count >= 1)
         .AssertPassed();
 
-    [Scenario("RenameMember in property body is skipped (ambiguous receiver)")]
+    [Scenario("RenameMember with private field receiver is renamed (field-receiver inference)")]
     [Fact]
-    public Task RenameMember_PropertyBody_AmbiguousReceiver_Skipped() =>
-        Given("source with property getter calling obj.OldMethod()", () =>
+    public Task RenameMember_PrivateFieldReceiver_Renamed() =>
+        Given("source with 'private readonly MyService _service' and _service.OldMethod()", () =>
         {
             var (root, ctx) = Parse(
-                "class C { int Prop { get { return obj.OldMethod(); } } object obj; }");
+                "class C { private readonly MyService _service; void M() { _service.OldMethod(); } }");
+            var rule = new RenameMemberRule
+            {
+                Id = "RM-FIELD",
+                TypeName = "MyService",
+                OldMemberName = "OldMethod",
+                NewMemberName = "NewMethod",
+            };
+            var result = new RenameMemberRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null", t => t.Result is not null)
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .And("result contains NewMethod", t => t.Result!.ToString().Contains("NewMethod"))
+        .AssertPassed();
+
+    [Scenario("RenameMember with public property receiver is renamed (property-receiver inference)")]
+    [Fact]
+    public Task RenameMember_PropertyReceiver_Renamed() =>
+        Given("source with 'public MyService Service { get; }' and Service.OldMethod()", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { public MyService Service { get; } void M() { Service.OldMethod(); } }");
             var rule = new RenameMemberRule
             {
                 Id = "RM-PROP",
@@ -334,6 +428,72 @@ public sealed class RewriterCoverageBoostTests(ITestOutputHelper output) : TinyB
             var result = new RenameMemberRewriter().TryRewrite(root, rule, ctx);
             return (Result: result, Ctx: ctx);
         })
-        .Then("Skipped count >= 1 (field receiver is unknown type)", t => t.Ctx.Skipped.Count >= 1)
+        .Then("result is not null", t => t.Result is not null)
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .And("result contains NewMethod", t => t.Result!.ToString().Contains("NewMethod"))
+        .AssertPassed();
+
+    [Scenario("RenameMember on static class member is renamed (type-of-name inference)")]
+    [Fact]
+    public Task RenameMember_StaticClassMember_Renamed() =>
+        Given("source with 'MyStatic.OldMethod()' and rule for type MyStatic", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { void M() { MyStatic.OldMethod(); } }");
+            var rule = new RenameMemberRule
+            {
+                Id = "RM-STATIC",
+                TypeName = "MyStatic",
+                OldMemberName = "OldMethod",
+                NewMemberName = "NewMethod",
+            };
+            var result = new RenameMemberRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null", t => t.Result is not null)
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("RenameMember on chained method-call return value records Skipped (truly ambiguous)")]
+    [Fact]
+    public Task RenameMember_ChainedCallReceiver_RecordsSkipped() =>
+        Given("source with 'service.GetThing().OldMethod()' where chained result is unknown", () =>
+        {
+            // The OUTER member access is .OldMethod() on the result of service.GetThing().
+            // The receiver Expression is an InvocationExpression, NOT an IdentifierName, so
+            // TryInferReceiverTypeName returns null immediately → Skipped (ambiguous).
+            var (root, ctx) = Parse(
+                "class C { void M(MyService service) { service.GetThing().OldMethod(); } }");
+            var rule = new RenameMemberRule
+            {
+                Id = "RM-CHAIN",
+                TypeName = "MyService",
+                OldMemberName = "OldMethod",
+                NewMemberName = "NewMethod",
+            };
+            var result = new RenameMemberRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Skipped count >= 1 (chained call receiver is unresolvable)", t => t.Ctx.Skipped.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("RenameMember with field receiver of unrelated type records Skipped")]
+    [Fact]
+    public Task RenameMember_FieldOfUnrelatedType_Skipped() =>
+        Given("source with field 'object obj' (unrelated type)", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { object obj; void M() { obj.OldMethod(); } }");
+            var rule = new RenameMemberRule
+            {
+                Id = "RM-WRONG-FIELD",
+                TypeName = "MyService",
+                OldMemberName = "OldMethod",
+                NewMemberName = "NewMethod",
+            };
+            var result = new RenameMemberRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Skipped count >= 1 (field type 'object' does not match)", t => t.Ctx.Skipped.Count >= 1)
         .AssertPassed();
 }

--- a/WrapGod.Tests/Migration/Engine/Rewriters/RewriterCoverageBoostTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/RewriterCoverageBoostTests.cs
@@ -1,0 +1,339 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.Rewriters;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.Rewriters;
+
+/// <summary>
+/// Additional coverage scenarios targeting specific branches in the rewriter implementations
+/// that are not exercised by the main per-rewriter test files.
+/// </summary>
+[Feature("Rewriter coverage boost: branch coverage for helpers and edge paths")]
+public sealed class RewriterCoverageBoostTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    private static (SyntaxNode Root, RewriteContext Ctx) Parse(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        return (tree.GetRoot(), new RewriteContext("test.cs"));
+    }
+
+    // ── RenameTypeRewriter — qualified name in class body ────────────────────
+
+    [Scenario("RenameType rewrites fully-qualified reference in the tree")]
+    [Fact]
+    public Task RenameType_FullyQualifiedInTree_Rewritten() =>
+        Given("source with fully-qualified type usage and rule", () =>
+        {
+            var (root, ctx) = Parse("class C { Foo.Bar x; }");
+            var rule = new RenameTypeRule { Id = "RT-FQ", OldName = "Foo.Bar", NewName = "Foo.Baz" };
+            var result = new RenameTypeRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null", t => t.Result is not null)
+        .And("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("RenameType rewrites identifier in generic type argument")]
+    [Fact]
+    public Task RenameType_InGenericArgument_Rewritten() =>
+        Given("source with List<Bar> and rule Bar->Baz", () =>
+        {
+            var (root, ctx) = Parse("class C { System.Collections.Generic.List<Bar> x; }");
+            var rule = new RenameTypeRule { Id = "RT-GEN", OldName = "Ns.Bar", NewName = "Ns.Baz" };
+            var result = new RenameTypeRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is not null (Bar matched)", t => t.Result is not null)
+        .AssertPassed();
+
+    // ── RenameNamespaceRewriter — no sub-namespace suffix ────────────────────
+
+    [Scenario("RenameNamespace with extra sub-namespace suffix is updated correctly")]
+    [Fact]
+    public Task RenameNamespace_DeepSubNamespace_Rewritten() =>
+        Given("source with 'using OldNs.A.B.C;' and rule OldNs->NewNs", () =>
+        {
+            var (root, ctx) = Parse("using OldNs.A.B.C;");
+            var rule = new RenameNamespaceRule { Id = "RNS-DEEP", OldNamespace = "OldNs", NewNamespace = "NewNs" };
+            var result = new RenameNamespaceRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result contains NewNs.A.B.C", t => t.Result!.ToFullString().Contains("NewNs.A.B.C"))
+        .AssertPassed();
+
+    // ── RenameMemberRewriter — receiver via qualified parameter type ─────────
+
+    [Scenario("RenameMember with receiver declared as qualified parameter type is renamed")]
+    [Fact]
+    public Task RenameMember_QualifiedParamType_ReceiverInferred() =>
+        Given("source with 'MyService svc' parameter and svc.OldMethod() call", () =>
+        {
+            // The receiver is a parameter declared with a simple type name matching the rule
+            var (root, ctx) = Parse(
+                "class C { void M(MyService svc) { svc.OldMethod(); } }");
+            var rule = new RenameMemberRule
+            {
+                Id = "RM-QP",
+                TypeName = "Ns.MyService",
+                OldMemberName = "OldMethod",
+                NewMemberName = "NewMethod",
+            };
+            var result = new RenameMemberRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
+        .And("result contains NewMethod", t => t.Result!.ToString().Contains("NewMethod"))
+        .AssertPassed();
+
+    [Scenario("RenameMember with constructor parameter as receiver is renamed")]
+    [Fact]
+    public Task RenameMember_ConstructorParam_ReceiverInferred() =>
+        Given("source with constructor parameter MyService and call to OldMethod", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { C(MyService svc) { svc.OldMethod(); } }");
+            var rule = new RenameMemberRule
+            {
+                Id = "RM-CTOR",
+                TypeName = "MyService",
+                OldMemberName = "OldMethod",
+                NewMemberName = "NewMethod",
+            };
+            var result = new RenameMemberRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count >= 1 OR Skipped (constructor body)", t =>
+            t.Ctx.Applied.Count >= 1 || t.Ctx.Skipped.Count >= 1)
+        .AssertPassed();
+
+    // ── ChangeParameterRewriter — bare method name invocation ────────────────
+
+    [Scenario("ChangeParameter renames named arg when method called without receiver")]
+    [Fact]
+    public Task ChangeParameter_BareMethodCall_NamedArgRenamed() =>
+        Given("source with bare Build(size: 1) call and rename rule", () =>
+        {
+            // Invocation via IdentifierNameSyntax (not MemberAccessExpression)
+            var (root, ctx) = Parse("class C { void M() { Build(size: 1); } void Build(int size) {} }");
+            var rule = new ChangeParameterRule
+            {
+                Id = "CP-BARE",
+                TypeName = "C",
+                MethodName = "Build",
+                OldParameterName = "size",
+                NewParameterName = "buttonSize",
+            };
+            var result = new ChangeParameterRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
+        .And("result contains buttonSize:", t => t.Result!.ToString().Contains("buttonSize:"))
+        .AssertPassed();
+
+    [Scenario("ChangeParameter with no NewParameterName leaves label unchanged (no rewrite)")]
+    [Fact]
+    public Task ChangeParameter_NullNewName_NoRewrite() =>
+        Given("source with Build(size: 1) and rule where NewParameterName is null", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(Builder b) { b.Build(size: 1); } }");
+            var rule = new ChangeParameterRule
+            {
+                Id = "CP-NULL",
+                TypeName = "Builder",
+                MethodName = "Build",
+                OldParameterName = "size",
+                NewParameterName = null,  // Name did not change
+                OldParameterType = "int",
+                NewParameterType = "int",
+            };
+            var result = new ChangeParameterRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result is null (nothing changed)", t => t.Result is null)
+        .And("Applied count is 0", t => t.Ctx.Applied.Count == 0)
+        .AssertPassed();
+
+    // ── RemoveMemberRewriter — invocation without member access ─────────────
+
+    [Scenario("RemoveMember does not match bare function call (not a member access)")]
+    [Fact]
+    public Task RemoveMember_BareCall_DoesNotMatch() =>
+        Given("source with bare Deprecated() call (no receiver)", () =>
+        {
+            var (root, ctx) = Parse("class C { void M() { Deprecated(); } void Deprecated() {} }");
+            var rule = new RemoveMemberRule { Id = "DEL-BARE", TypeName = "C", MemberName = "Deprecated" };
+            var result = new RemoveMemberRewriter().TryRewrite(root, rule, ctx);
+            return result;
+        })
+        .Then("result is null (no member access found)", r => r is null)
+        .AssertPassed();
+
+    // ── AddRequiredParameterRewriter — clamped position ─────────────────────
+
+    [Scenario("AddRequiredParameter with position beyond arg count clamps to end")]
+    [Fact]
+    public Task AddRequiredParameter_PositionBeyondCount_ClampsToEnd() =>
+        Given("source with provider.Apply(x) and rule adding at position 99", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(ThemeProvider provider) { provider.Apply(x); } }");
+            var rule = new AddRequiredParameterRule
+            {
+                Id = "ARP-CLAMP",
+                TypeName = "ThemeProvider",
+                MethodName = "Apply",
+                ParameterName = "theme",
+                ParameterType = "MudTheme",
+                Position = 99,
+            };
+            var result = new AddRequiredParameterRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .And("result contains default", t => t.Result!.ToString().Contains("default", StringComparison.Ordinal))
+        .AssertPassed();
+
+    // ── ChangeTypeReferenceRewriter — base list and cast contexts ────────────
+
+    [Scenario("ChangeTypeReference replaces type in base list")]
+    [Fact]
+    public Task ChangeTypeReference_BaseList_Replaced() =>
+        Given("source with 'class C : IList' and rule IList->IReadOnlyList", () =>
+        {
+            var (root, ctx) = Parse("class C : IList { }");
+            var rule = new ChangeTypeReferenceRule { Id = "CTR-BASE", OldType = "IList", NewType = "IReadOnlyList" };
+            var result = new ChangeTypeReferenceRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result contains IReadOnlyList", t => t.Result!.ToString().Contains("IReadOnlyList"))
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("ChangeTypeReference replaces type in cast expression")]
+    [Fact]
+    public Task ChangeTypeReference_CastExpression_Replaced() =>
+        Given("source with '(IList)x' and rule IList->IReadOnlyList", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(object x) { var y = (IList)x; } }");
+            var rule = new ChangeTypeReferenceRule { Id = "CTR-CAST", OldType = "IList", NewType = "IReadOnlyList" };
+            var result = new ChangeTypeReferenceRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result contains IReadOnlyList", t => t.Result!.ToString().Contains("IReadOnlyList"))
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("ChangeTypeReference replaces type in parameter declaration")]
+    [Fact]
+    public Task ChangeTypeReference_ParameterType_Replaced() =>
+        Given("source with method parameter IList p and rule IList->IReadOnlyList", () =>
+        {
+            var (root, ctx) = Parse("class C { void M(IList p) { } }");
+            var rule = new ChangeTypeReferenceRule { Id = "CTR-PARAM", OldType = "IList", NewType = "IReadOnlyList" };
+            var result = new ChangeTypeReferenceRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result contains IReadOnlyList", t => t.Result!.ToString().Contains("IReadOnlyList"))
+        .And("Applied count is 1", t => t.Ctx.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("ChangeTypeReference replaces type in object creation expression")]
+    [Fact]
+    public Task ChangeTypeReference_ObjectCreation_Replaced() =>
+        Given("source with 'new OldType()' and rule OldType->NewType", () =>
+        {
+            var (root, ctx) = Parse("class C { void M() { var x = new OldType(); } }");
+            var rule = new ChangeTypeReferenceRule { Id = "CTR-OBJ", OldType = "OldType", NewType = "NewType" };
+            var result = new ChangeTypeReferenceRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("result contains NewType", t => t.Result!.ToString().Contains("NewType"))
+        .And("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("ChangeTypeReference replaces type in nullable type declaration")]
+    [Fact]
+    public Task ChangeTypeReference_NullableType_Replaced() =>
+        Given("source with 'IList? x' and rule IList->IReadOnlyList", () =>
+        {
+            var (root, ctx) = Parse("class C { IList? x; }");
+            var rule = new ChangeTypeReferenceRule { Id = "CTR-NULL", OldType = "IList", NewType = "IReadOnlyList" };
+            var result = new ChangeTypeReferenceRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("ChangeTypeReference replaces fully-qualified type reference in type context")]
+    [Fact]
+    public Task ChangeTypeReference_FullyQualifiedInTypeContext_Replaced() =>
+        Given("source with 'System.Collections.IList x' and rule for System.Collections.IList", () =>
+        {
+            var (root, ctx) = Parse("class C { System.Collections.IList x; }");
+            var rule = new ChangeTypeReferenceRule { Id = "CTR-FQ", OldType = "System.Collections.IList", NewType = "System.Collections.IReadOnlyList" };
+            var result = new ChangeTypeReferenceRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("ChangeTypeReference replaces method return type")]
+    [Fact]
+    public Task ChangeTypeReference_MethodReturnType_Replaced() =>
+        Given("source with method returning IList and rule IList->IReadOnlyList", () =>
+        {
+            var (root, ctx) = Parse("class C { IList GetItems() => null; }");
+            var rule = new ChangeTypeReferenceRule { Id = "CTR-RET", OldType = "IList", NewType = "IReadOnlyList" };
+            var result = new ChangeTypeReferenceRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Applied count >= 1", t => t.Ctx.Applied.Count >= 1)
+        .And("result contains IReadOnlyList", t => t.Result!.ToString().Contains("IReadOnlyList"))
+        .AssertPassed();
+
+    // ── RewriterHelpers coverage ─────────────────────────────────────────────
+
+    [Scenario("RenameMember with receiver declared via var (implicit type) records Skipped")]
+    [Fact]
+    public Task RenameMember_VarDeclaredReceiver_RecordsSkipped() =>
+        Given("source with 'var svc = ...; svc.OldMethod()' where type is implicit", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { void M() { var svc = GetService(); svc.OldMethod(); } object GetService() => null; }");
+            var rule = new RenameMemberRule
+            {
+                Id = "RM-VAR",
+                TypeName = "MyService",
+                OldMemberName = "OldMethod",
+                NewMemberName = "NewMethod",
+            };
+            var result = new RenameMemberRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Skipped count >= 1 (var type is inferred, not explicit)", t => t.Ctx.Skipped.Count >= 1)
+        .AssertPassed();
+
+    [Scenario("RenameMember in property body is skipped (ambiguous receiver)")]
+    [Fact]
+    public Task RenameMember_PropertyBody_AmbiguousReceiver_Skipped() =>
+        Given("source with property getter calling obj.OldMethod()", () =>
+        {
+            var (root, ctx) = Parse(
+                "class C { int Prop { get { return obj.OldMethod(); } } object obj; }");
+            var rule = new RenameMemberRule
+            {
+                Id = "RM-PROP",
+                TypeName = "MyService",
+                OldMemberName = "OldMethod",
+                NewMemberName = "NewMethod",
+            };
+            var result = new RenameMemberRewriter().TryRewrite(root, rule, ctx);
+            return (Result: result, Ctx: ctx);
+        })
+        .Then("Skipped count >= 1 (field receiver is unknown type)", t => t.Ctx.Skipped.Count >= 1)
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/Rewriters/RewriterIntegrationTests.cs
+++ b/WrapGod.Tests/Migration/Engine/Rewriters/RewriterIntegrationTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.Rewriters;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.Rewriters;
+
+/// <summary>
+/// Integration tests verifying that multiple A-level rewriters applied in schema order to
+/// a single synthetic source file reproduce a hand-authored expected output byte-for-byte
+/// (line endings normalized to <c>\n</c>). This validates rule composition and
+/// trivia preservation across rewriter boundaries — the contract the #196 orchestrator
+/// will rely on.
+/// </summary>
+[Feature("Rewriter integration: multiple rewriters compose on a synthetic source")]
+public sealed class RewriterIntegrationTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Fixture loading ──────────────────────────────────────────────────────
+
+    private static string FixtureDir =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "Migration");
+
+    private static string LoadFixture(string name) =>
+        File.ReadAllText(Path.Combine(FixtureDir, name));
+
+    /// <summary>Normalize line endings to <c>\n</c> so byte-for-byte comparison is
+    /// platform-independent (Windows checkout uses CRLF, Linux uses LF).</summary>
+    private static string NormalizeNewlines(string s) =>
+        s.Replace("\r\n", "\n").Replace("\r", "\n");
+
+    /// <summary>Build the dispatch map from rewriter Kind to rewriter instance.</summary>
+    private static Dictionary<string, IRuleRewriter> BuildRewriterMap() =>
+        new(StringComparer.Ordinal)
+        {
+            { "renameType", new RenameTypeRewriter() },
+            { "renameNamespace", new RenameNamespaceRewriter() },
+            { "renameMember", new RenameMemberRewriter() },
+            { "changeParameter", new ChangeParameterRewriter() },
+            { "removeMember", new RemoveMemberRewriter() },
+            { "addRequiredParameter", new AddRequiredParameterRewriter() },
+            { "changeTypeReference", new ChangeTypeReferenceRewriter() },
+        };
+
+    /// <summary>
+    /// Applies the given schema's rules to the source text in schema order, returning the
+    /// final source text after all rewrites. Each rule walks the tree once; rewriters that
+    /// return null leave the tree unchanged.
+    /// </summary>
+    private static (string FinalText, RewriteContext Ctx) ApplyRulesInOrder(
+        string sourceText,
+        MigrationSchema schema)
+    {
+        var ctx = new RewriteContext("synthetic.cs");
+        var rewriters = BuildRewriterMap();
+
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        SyntaxNode currentRoot = tree.GetRoot();
+
+        foreach (var rule in schema.Rules)
+        {
+            var kindKey = char.ToLowerInvariant(rule.Kind.ToString()[0]) + rule.Kind.ToString()[1..];
+            if (!rewriters.TryGetValue(kindKey, out var rewriter))
+                continue;
+
+            var rewritten = rewriter.TryRewrite(currentRoot, rule, ctx);
+            if (rewritten is not null)
+                currentRoot = rewritten;
+        }
+
+        return (currentRoot.ToFullString(), ctx);
+    }
+
+    // ── happy ────────────────────────────────────────────────────────────────
+
+    [Scenario("MultipleRulesOnOneFile_AllRewritersApply matches hand-authored fixture byte-for-byte")]
+    [Fact]
+    public Task MultipleRulesOnOneFile_AllRewritersApply() =>
+        Given("the synthetic before/after fixtures and the rules schema", () =>
+        {
+            var before = LoadFixture("SyntheticBefore.cs.txt");
+            var expectedAfter = LoadFixture("SyntheticAfter.cs.txt");
+            var rulesJson = LoadFixture("SyntheticRules.json");
+            var schema = MigrationSchemaSerializer.Deserialize(rulesJson)
+                ?? throw new InvalidOperationException("Failed to load SyntheticRules.json");
+
+            var (actual, ctx) = ApplyRulesInOrder(before, schema);
+            return (Actual: actual, Expected: expectedAfter, Ctx: ctx);
+        })
+        .Then("the normalized rewritten text matches the expected fixture", t =>
+            NormalizeNewlines(t.Actual) == NormalizeNewlines(t.Expected))
+        .And("at least 3 rewrites were applied (one per rule)", t => t.Ctx.Applied.Count >= 3)
+        .AssertPassed();
+
+    [Scenario("Integration: namespace rewrite is recorded in the audit trail")]
+    [Fact]
+    public Task Integration_NamespaceRewrite_Applied() =>
+        Given("the synthetic schema applied to the before fixture", () =>
+        {
+            var before = LoadFixture("SyntheticBefore.cs.txt");
+            var rulesJson = LoadFixture("SyntheticRules.json");
+            var schema = MigrationSchemaSerializer.Deserialize(rulesJson)
+                ?? throw new InvalidOperationException("Failed to load SyntheticRules.json");
+
+            var (_, ctx) = ApplyRulesInOrder(before, schema);
+            return ctx;
+        })
+        .Then("Applied contains a RNS-001 entry", ctx =>
+            ctx.Applied.Any(a => a.RuleId == "RNS-001"))
+        .And("Applied contains a RM-001 entry", ctx =>
+            ctx.Applied.Any(a => a.RuleId == "RM-001"))
+        .And("Applied contains a CTR-001 entry", ctx =>
+            ctx.Applied.Any(a => a.RuleId == "CTR-001"))
+        .AssertPassed();
+}

--- a/WrapGod.Tests/WrapGod.Tests.csproj
+++ b/WrapGod.Tests/WrapGod.Tests.csproj
@@ -49,6 +49,7 @@
 
   <ItemGroup>
     <None Include="Snapshots\**\*" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Fixtures\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/migration/engine.md
+++ b/docs/migration/engine.md
@@ -95,13 +95,24 @@ public sealed class MyRenameRewriter : IRuleRewriter
 - **No semantic lookup.** The engine works on syntax only so it can operate on
   broken code; rewriters must not require a `SemanticModel`.
 
+## Rewriters shipping in #195
+
+Seven concrete `IRuleRewriter` implementations are now available under
+`WrapGod.Migration.Engine.Rewriters`. See [A-Level Rewriters](rewriters.md) for the
+full catalogue, per-rewriter contracts, and before/after examples.
+
+| Class | `Kind` | Rule type |
+|---|---|---|
+| `RenameTypeRewriter` | `renameType` | `RenameTypeRule` |
+| `RenameNamespaceRewriter` | `renameNamespace` | `RenameNamespaceRule` |
+| `RenameMemberRewriter` | `renameMember` | `RenameMemberRule` |
+| `ChangeParameterRewriter` | `changeParameter` | `ChangeParameterRule` |
+| `RemoveMemberRewriter` | `removeMember` | `RemoveMemberRule` |
+| `AddRequiredParameterRewriter` | `addRequiredParameter` | `AddRequiredParameterRule` |
+| `ChangeTypeReferenceRewriter` | `changeTypeReference` | `ChangeTypeReferenceRule` |
+
 ## What's next
 
-This issue (#194) ships only the contracts. Concrete pieces follow:
-
-- **#195** — A-level syntax rewriters (`RenameType`, `RenameNamespace`,
-  `RenameMember`, `ChangeParameter`, `RemoveMember`, `AddRequiredParameter`,
-  `ChangeTypeReference`).
 - **#196** — `MigrationEngine` orchestrator with `Apply` and `DryRun` entry points.
 - **#202** — B-level structural rewriters (`SplitMethod`,
   `ExtractParameterObject`, `PropertyToMethod`, `MoveMember`).

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -7,3 +7,4 @@ Strategies and automation for migrating codebases between library versions and a
 - [Migration Schema](schema.md) — `WrapGod.Migration` schema model and rule kinds reference
 - [Migration Engine](engine.md) — `WrapGod.Migration.Engine` rewrite pipeline contracts (`IRuleRewriter`, `RewriteContext`, `MigrationResult`)
 - [Schema Generation](schema-generation.md) — `MigrationSchemaGenerator.FromDiff` — diff → schema mapping, similarity thresholds, deterministic IDs
+- [A-Level Rewriters](rewriters.md) — Seven concrete `IRuleRewriter` implementations: `RenameType`, `RenameNamespace`, `RenameMember`, `ChangeParameter`, `RemoveMember`, `AddRequiredParameter`, `ChangeTypeReference`

--- a/docs/migration/rewriters.md
+++ b/docs/migration/rewriters.md
@@ -1,0 +1,202 @@
+# A-Level Syntax Rewriters
+
+`WrapGod.Migration.Engine` ships seven concrete `IRuleRewriter` implementations that
+handle the most common breaking changes using syntax-only analysis (no `SemanticModel`
+required). Each rewriter handles one `MigrationRuleKind` and can safely operate on
+code that does not compile.
+
+## Rewriter Catalogue
+
+| Class | `Kind` | Rule type | What it transforms |
+|---|---|---|---|
+| `RenameTypeRewriter` | `renameType` | `RenameTypeRule` | Identifier nodes, qualified names |
+| `RenameNamespaceRewriter` | `renameNamespace` | `RenameNamespaceRule` | `using` directives, qualified names |
+| `RenameMemberRewriter` | `renameMember` | `RenameMemberRule` | Member-access expressions |
+| `ChangeParameterRewriter` | `changeParameter` | `ChangeParameterRule` | Named-argument labels in invocations |
+| `RemoveMemberRewriter` | `removeMember` | `RemoveMemberRule` | Call-site expression statements |
+| `AddRequiredParameterRewriter` | `addRequiredParameter` | `AddRequiredParameterRule` | Argument lists |
+| `ChangeTypeReferenceRewriter` | `changeTypeReference` | `ChangeTypeReferenceRule` | Type-position syntax nodes |
+
+---
+
+## Universal Contracts
+
+Every rewriter guarantees:
+
+- **Trivia preserved.** Every replacement node copies trivia from the original via
+  `WithTriviaFrom` or `TriviaPreservation.WithReplacedToken`. Whitespace and comments
+  are never corrupted.
+- **Return `null` on no-match.** When nothing in the tree matches the rule, the
+  rewriter returns `null` so the orchestrator can skip file-write.
+- **Ambiguous → `SkippedRewrite`.** When a match is syntactically uncertain, a
+  `SkippedRewrite` entry is recorded on the `RewriteContext` and the node is left
+  unchanged. Wrong rewrites are never applied.
+- **No `SemanticModel`.** All rewriters work on the raw syntax tree, so they handle
+  broken or partially-compiled code.
+
+---
+
+## RenameTypeRewriter
+
+Renames a type by its short name (unqualified identifier) wherever it appears in
+identifier positions and as fully-qualified names.
+
+```csharp
+// Rule:
+//   OldName = "Foo.OldWidget"
+//   NewName = "Foo.NewWidget"
+
+// Before
+Foo.OldWidget w = new Foo.OldWidget();
+
+// After
+Foo.NewWidget w = new Foo.NewWidget();
+```
+
+**Ambiguity:** Generic arguments and identifiers that are part of the right-hand side
+of a member access are NOT rewritten by this rewriter (the parent qualified name
+handles them).
+
+---
+
+## RenameNamespaceRewriter
+
+Rewrites `using` directives and qualified names whose namespace starts with
+`OldNamespace`. Only exact prefix matches (followed by `.` or end-of-name) are
+updated; unrelated identifiers that share a prefix are left alone.
+
+```csharp
+// Rule:
+//   OldNamespace = "Acme.Legacy"
+//   NewNamespace = "Acme.Modern"
+
+// Before
+using Acme.Legacy.Widgets;
+
+// After
+using Acme.Modern.Widgets;
+```
+
+---
+
+## RenameMemberRewriter
+
+Renames a method or property on a specific declaring type at every `member.Access`
+expression. The receiver type is inferred via syntax-only heuristics (local variable
+declarations and parameter types visible in the enclosing method body). When the
+receiver type cannot be determined, a `SkippedRewrite` is recorded.
+
+```csharp
+// Rule:
+//   TypeName = "MyService"
+//   OldMemberName = "Execute"
+//   NewMemberName = "Run"
+
+// Before
+MyService svc = new MyService();
+svc.Execute();
+
+// After
+MyService svc = new MyService();
+svc.Run();
+```
+
+**Ambiguity heuristic:** If the receiver is declared as `object`, a generic parameter,
+or an interface the rewriter cannot resolve, a `SkippedRewrite` with reason
+`"ambiguous: cannot determine receiver type"` is recorded and the call site is left
+unchanged for manual review.
+
+---
+
+## ChangeParameterRewriter
+
+Rewrites the named-argument label of a parameter that was renamed. For parameter
+**type** changes on positional arguments, a `SkippedRewrite` with reason
+`"type change requires semantic conversion"` is recorded because a syntax-only
+rewriter cannot safely convert argument values.
+
+```csharp
+// Rule:
+//   MethodName = "Build"
+//   OldParameterName = "size"
+//   NewParameterName = "buttonSize"
+
+// Before
+builder.Build(size: 42);
+
+// After
+builder.Build(buttonSize: 42);
+```
+
+---
+
+## RemoveMemberRewriter
+
+When a member has been completely removed from the API, every call site is replaced
+with a comment that preserves the original text for manual inspection. The replacement
+is recorded as an `AppliedRewrite` so the audit trail shows where human action is
+needed.
+
+```csharp
+// Rule:
+//   MemberName = "Deprecated"
+//   Note = "Use NewApi.Process() instead."
+
+// Before
+obj.Deprecated();
+
+// After
+// MIGRATION: DEL-001 removed — Use NewApi.Process() instead.: obj.Deprecated();
+```
+
+---
+
+## AddRequiredParameterRewriter
+
+Inserts a `default` expression at the specified zero-based position in every matching
+invocation's argument list, annotated with a `TODO MIGRATION` comment so developers
+know to supply a real value. The insertion is recorded as an `AppliedRewrite`.
+
+```csharp
+// Rule:
+//   MethodName = "Apply"
+//   ParameterName = "theme"
+//   ParameterType = "MudTheme"
+//   Position = 0
+
+// Before
+provider.Apply();
+
+// After
+provider.Apply( default /* TODO MIGRATION: ARP-001 required arg 'theme' (MudTheme) added */);
+```
+
+---
+
+## ChangeTypeReferenceRewriter
+
+Replaces a type reference (by short name or fully-qualified name) wherever it appears
+in a syntactic **type position**: field declarations, method return types, parameter
+types, cast expressions, `typeof()`, generic type arguments, base lists, and object
+creation expressions. The rewriter also handles generic type names (e.g., `IList<T>`).
+
+```csharp
+// Rule:
+//   OldType = "IList"
+//   NewType = "IReadOnlyList"
+
+// Before
+IList<string> items;
+var t = typeof(IList<int>);
+
+// After
+IReadOnlyList<string> items;
+var t = typeof(IReadOnlyList<int>);
+```
+
+---
+
+## See Also
+
+- [Migration Engine](engine.md) — scaffold contracts (`IRuleRewriter`, `RewriteContext`, `MigrationResult`)
+- [Migration Schema](schema.md) — rule kinds and JSON schema reference

--- a/docs/migration/rewriters.md
+++ b/docs/migration/rewriters.md
@@ -101,22 +101,27 @@ MyService svc = new MyService();
 svc.Run();
 ```
 
-**Ambiguity heuristic:** If the receiver is declared as `object`, a generic parameter,
-or an interface the rewriter cannot resolve, a `SkippedRewrite` with reason
-`"ambiguous: cannot determine receiver type"` is recorded and the call site is left
-unchanged for manual review.
+**Receiver inference scope:** searches in order — (1) local variables and parameters in
+the enclosing method/constructor/property body, (2) field and property declarations on
+the enclosing type, (3) the receiver identifier itself as a type-of-name reference (for
+static class member calls). Falls back to `SkippedRewrite` when the receiver is a
+chained-call result or any expression whose type cannot be inferred syntactically.
 
 ---
 
 ## ChangeParameterRewriter
 
-Rewrites the named-argument label of a parameter that was renamed. For parameter
-**type** changes on positional arguments, a `SkippedRewrite` with reason
+Rewrites the named-argument label of a parameter that was renamed. Also performs
+**receiver-type disambiguation** — when the receiver type can be inferred (via
+`RewriterHelpers.TryInferReceiverTypeName`) and does not match the rule's declaring
+type, the invocation is skipped to avoid rewriting unrelated methods that share a name.
+For parameter **type** changes on positional arguments, a `SkippedRewrite` with reason
 `"type change requires semantic conversion"` is recorded because a syntax-only
 rewriter cannot safely convert argument values.
 
 ```csharp
 // Rule:
+//   TypeName = "Builder"
 //   MethodName = "Build"
 //   OldParameterName = "size"
 //   NewParameterName = "buttonSize"
@@ -132,10 +137,11 @@ builder.Build(buttonSize: 42);
 
 ## RemoveMemberRewriter
 
-When a member has been completely removed from the API, every call site is replaced
-with a comment that preserves the original text for manual inspection. The replacement
-is recorded as an `AppliedRewrite` so the audit trail shows where human action is
-needed.
+When a member has been completely removed from the API, every call site is removed
+entirely and its location is annotated with a comment that preserves the original text
+for manual inspection. The comment is attached as trivia to the next sibling statement
+(or the closing brace if the removed call was the last statement), so no orphan `;`
+is left in the output. Each removal is recorded as an `AppliedRewrite`.
 
 ```csharp
 // Rule:
@@ -143,19 +149,30 @@ needed.
 //   Note = "Use NewApi.Process() instead."
 
 // Before
-obj.Deprecated();
+void M(OldApi obj)
+{
+    obj.Deprecated();
+    var x = 1;
+}
 
 // After
-// MIGRATION: DEL-001 removed — Use NewApi.Process() instead.: obj.Deprecated();
+void M(OldApi obj)
+{
+    // MIGRATION: DEL-001 removed — Use NewApi.Process() instead.: obj.Deprecated();
+    var x = 1;
+}
 ```
 
 ---
 
 ## AddRequiredParameterRewriter
 
-Inserts a `default` expression at the specified zero-based position in every matching
+Inserts a placeholder expression at the specified zero-based position in every matching
 invocation's argument list, annotated with a `TODO MIGRATION` comment so developers
-know to supply a real value. The insertion is recorded as an `AppliedRewrite`.
+know to supply a real value. The placeholder is `null` when the parameter type is
+syntactically a reference type (nullable annotation, array, `string`/`object`, or an
+interface following the `I + UpperCamelCase` convention) and `default` otherwise. The
+insertion is recorded as an `AppliedRewrite`.
 
 ```csharp
 // Rule:

--- a/docs/migration/toc.yml
+++ b/docs/migration/toc.yml
@@ -12,3 +12,6 @@
 
 - name: Migration Engine
   href: engine.md
+
+- name: A-Level Rewriters
+  href: rewriters.md


### PR DESCRIPTION
## Summary

Implements #195. Seven syntax-only `IRuleRewriter` implementations covering all A-level `MigrationRuleKind` values:

- `RenameTypeRewriter` — identifier nodes and qualified names
- `RenameNamespaceRewriter` — `using` directives and qualified names
- `RenameMemberRewriter` — member-access expressions with receiver-type heuristics
- `ChangeParameterRewriter` — named-argument label renames; records `SkippedRewrite` for type-change cases
- `RemoveMemberRewriter` — comment-out call sites with `// MIGRATION:` prefix
- `AddRequiredParameterRewriter` — inserts `default /* TODO MIGRATION: ... */` at specified position
- `ChangeTypeReferenceRewriter` — type-position nodes (fields, params, casts, typeof, generics)

## Design decisions

- **Ambiguity in `RenameMemberRewriter`:** receiver type is inferred by scanning local variable declarations and parameter types in the enclosing method/constructor body. When the receiver cannot be resolved to the declaring type, a `SkippedRewrite` with `"ambiguous: cannot determine receiver type"` is emitted.
- **`ChangeParameterRewriter` type changes:** positional argument with a type change records `SkippedRewrite("type change requires semantic conversion")` because syntax-only mode cannot safely convert values.
- **`InternalsVisibleTo`:** rewriters are `internal sealed`; `InternalsVisibleTo("WrapGod.Tests")` added to the engine `.csproj` via `AssemblyAttribute`.

## Test coverage

50 TinyBDD scenarios across 7 test files (7-8 per rewriter):

- Happy: single match, multiple matches, Kind property
- Sad: wrong rule kind returns null, no match returns null, ambiguous match records SkippedRewrite
- Edge: trivia preserved, partial-name collision not renamed, generic type arguments

## Build

- `dotnet build WrapGod.slnx -c Release -warnaserror` - 0 warnings, 0 errors
- `dotnet test WrapGod.slnx -c Release` - 635/635 passed

## Docs

- `docs/migration/rewriters.md` - new, full catalogue with before/after examples
- `docs/migration/engine.md` - updated to reflect rewriters shipped
- `docs/migration/index.md` - cross-link to rewriters page
- `docs/migration/toc.yml` - entry added

Closes #195