### PR TITLE
feat(migration): #197 state tracking (idempotent re-runs)

### DIFF
--- a/WrapGod.Migration.Engine/MigrationEngine.cs
+++ b/WrapGod.Migration.Engine/MigrationEngine.cs
@@ -112,12 +112,36 @@ public sealed class MigrationEngine
     /// <see langword="null"/>.
     /// </exception>
     public MigrationResult Apply(MigrationSchema schema, IEnumerable<string> filePaths) =>
-        Run(schema, filePaths, dryRun: false);
+        Run(schema, filePaths, dryRun: false, alreadyApplied: null);
 
     /// <summary>
-    /// Runs the same pipeline as <see cref="Apply"/> but does not write any files
-    /// to disk.  The returned <see cref="MigrationResult.RewrittenFiles"/> dictionary
-    /// is still populated with the would-be new content for each modified file.
+    /// Applies all rules in <paramref name="schema"/> to every file in
+    /// <paramref name="filePaths"/>, skipping <c>(ruleId, file)</c> pairs present in
+    /// <paramref name="alreadyApplied"/> (state-tracking overload).
+    /// Writes modified files back to disk and returns the new <see cref="MigrationResult"/>.
+    /// </summary>
+    /// <param name="schema">The migration schema to apply.</param>
+    /// <param name="filePaths">The source file paths to process.</param>
+    /// <param name="alreadyApplied">
+    /// A set of <c>(ruleId, file)</c> pairs already applied in a prior run.
+    /// Pass an empty set or <see langword="null"/> for an unconditional full run.
+    /// </param>
+    /// <returns>A <see cref="MigrationResult"/> with <see cref="MigrationResult.DryRun"/> = <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="schema"/> or <paramref name="filePaths"/> is
+    /// <see langword="null"/>.
+    /// </exception>
+    internal MigrationResult Apply(
+        MigrationSchema schema,
+        IEnumerable<string> filePaths,
+        HashSet<(string RuleId, string File)>? alreadyApplied) =>
+        Run(schema, filePaths, dryRun: false, alreadyApplied);
+
+    /// <summary>
+    /// Runs the same pipeline as <see cref="Apply(MigrationSchema,IEnumerable{string})"/>
+    /// but does not write any files to disk.  The returned
+    /// <see cref="MigrationResult.RewrittenFiles"/> dictionary is still populated with the
+    /// would-be new content for each modified file.
     /// </summary>
     /// <param name="schema">The migration schema to apply.</param>
     /// <param name="filePaths">The source file paths to process.</param>
@@ -127,14 +151,25 @@ public sealed class MigrationEngine
     /// <see langword="null"/>.
     /// </exception>
     public MigrationResult DryRun(MigrationSchema schema, IEnumerable<string> filePaths) =>
-        Run(schema, filePaths, dryRun: true);
+        Run(schema, filePaths, dryRun: true, alreadyApplied: null);
+
+    /// <summary>
+    /// Dry-run overload that honours prior-state filtering (used by
+    /// <see cref="StatefulMigrationEngine"/>).
+    /// </summary>
+    internal MigrationResult DryRun(
+        MigrationSchema schema,
+        IEnumerable<string> filePaths,
+        HashSet<(string RuleId, string File)>? alreadyApplied) =>
+        Run(schema, filePaths, dryRun: true, alreadyApplied);
 
     // ── Core pipeline ─────────────────────────────────────────────────────────
 
     private MigrationResult Run(
         MigrationSchema schema,
         IEnumerable<string> filePaths,
-        bool dryRun)
+        bool dryRun,
+        HashSet<(string RuleId, string File)>? alreadyApplied)
     {
         ArgumentNullException.ThrowIfNull(schema);
         ArgumentNullException.ThrowIfNull(filePaths);
@@ -224,7 +259,7 @@ public sealed class MigrationEngine
             }
 
             // ── Auto rules (Option A: sequential chain) ───────────────────────
-            var ctx2 = new RewriteContext(filePath);
+            var ctx2 = new RewriteContext(filePath, alreadyApplied);
             var currentRoot = root;
             bool fileModified = false;
 
@@ -236,6 +271,10 @@ public sealed class MigrationEngine
                     // Schema-level skip already emitted up-front; do not duplicate.
                     continue;
                 }
+
+                // State-tracking: skip rules already applied to this file in a prior run.
+                if (ctx2.IsAlreadyApplied(rule.Id))
+                    continue;
 
                 var newRoot = InternalRewriterDispatcher.Apply(rewriter, currentRoot, rule, ctx2);
                 if (!ReferenceEquals(newRoot, currentRoot))

--- a/WrapGod.Migration.Engine/RewriteContext.cs
+++ b/WrapGod.Migration.Engine/RewriteContext.cs
@@ -14,6 +14,7 @@ public sealed class RewriteContext
     private readonly List<SkippedRewrite> _skipped = [];
     private readonly ReadOnlyCollection<AppliedRewrite> _appliedView;
     private readonly ReadOnlyCollection<SkippedRewrite> _skippedView;
+    private readonly HashSet<(string RuleId, string File)>? _alreadyApplied;
 
     /// <summary>Absolute or relative path to the source file being rewritten.</summary>
     public string FilePath { get; }
@@ -36,12 +37,33 @@ public sealed class RewriteContext
     /// Thrown when <paramref name="filePath"/> is <see langword="null"/>.
     /// </exception>
     public RewriteContext(string filePath)
+        : this(filePath, alreadyApplied: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new <see cref="RewriteContext"/> for the given file with an optional
+    /// set of <c>(ruleId, file)</c> pairs that have already been applied in a prior run.
+    /// Rules whose pair appears in <paramref name="alreadyApplied"/> will be reported as
+    /// already done via <see cref="IsAlreadyApplied"/>.
+    /// </summary>
+    internal RewriteContext(string filePath, HashSet<(string RuleId, string File)>? alreadyApplied)
     {
         ArgumentNullException.ThrowIfNull(filePath);
         FilePath = filePath;
+        _alreadyApplied = alreadyApplied;
         _appliedView = _applied.AsReadOnly();
         _skippedView = _skipped.AsReadOnly();
     }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the <c>(ruleId, filePath)</c> pair has
+    /// already been applied in a prior run and should be skipped.
+    /// Always returns <see langword="false"/> when no prior-state set was provided.
+    /// </summary>
+    public bool IsAlreadyApplied(string ruleId) =>
+        _alreadyApplied is not null &&
+        _alreadyApplied.Contains((ruleId, FilePath));
 
     /// <summary>Records a successfully applied rewrite.</summary>
     /// <param name="rule">The rule that was applied.</param>

--- a/WrapGod.Migration.Engine/State/MigrationState.cs
+++ b/WrapGod.Migration.Engine/State/MigrationState.cs
@@ -1,0 +1,140 @@
+namespace WrapGod.Migration.Engine.State;
+
+/// <summary>
+/// Persistent migration state written alongside the schema file after each
+/// <c>apply</c> run. Enables idempotent re-runs and powers <c>migrate status</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>File location:</strong> Same directory as the schema file, with filename
+/// <c>{schemaFilename}.state.json</c>. For example,
+/// <c>mudblazor.6.0-to-7.0.wrapgod-migration.json</c> produces
+/// <c>mudblazor.6.0-to-7.0.wrapgod-migration.json.state.json</c>.
+/// </para>
+/// <para>
+/// <strong>Idempotence:</strong> On each run the engine computes a SHA-256 hash of the
+/// schema file content (after normalising line endings). If the hash matches
+/// <see cref="SchemaHash"/>, rules whose <c>(RuleId, File)</c> pair appears in
+/// <see cref="Applied"/> are skipped. When the hash differs all rules are re-evaluated.
+/// </para>
+/// <para>
+/// <strong>List semantics:</strong>
+/// <list type="bullet">
+///   <item><description><see cref="Applied"/> — append-only, de-duplicated by <c>(RuleId, File)</c>.</description></item>
+///   <item><description><see cref="Skipped"/> — replaced wholesale each run.</description></item>
+///   <item><description><see cref="Manual"/> — replaced wholesale each run.</description></item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed class MigrationState
+{
+    /// <summary>
+    /// Path to the schema file this state was generated from.
+    /// May be relative or absolute; used for display and orphan detection.
+    /// </summary>
+    public string Schema { get; set; } = string.Empty;
+
+    /// <summary>
+    /// SHA-256 hash of the schema file content (format: <c>sha256:&lt;lowercase-hex&gt;</c>).
+    /// Computed after normalising line endings to <c>\n</c> and trimming trailing whitespace
+    /// per line so the hash is insensitive to git autocrlf behaviour.
+    /// </summary>
+    public string SchemaHash { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp when the first <c>apply</c> run began for this schema.</summary>
+    public DateTimeOffset StartedAt { get; set; }
+
+    /// <summary>UTC timestamp when the most recent <c>apply</c> run completed.</summary>
+    public DateTimeOffset LastRunAt { get; set; }
+
+    /// <summary>Aggregated counts from the last run for quick summary display.</summary>
+    public MigrationStateSummary Summary { get; set; } = new();
+
+    /// <summary>
+    /// Rewrites that were successfully applied across all runs.
+    /// Append-only and de-duplicated by <c>(RuleId, File)</c>.
+    /// </summary>
+    public List<AppliedRewrite> Applied { get; set; } = [];
+
+    /// <summary>
+    /// Rewrites that were skipped during the most recent run.
+    /// Replaced wholesale each run.
+    /// </summary>
+    public List<SkippedRewrite> Skipped { get; set; } = [];
+
+    /// <summary>
+    /// Manual-confidence rules identified during the most recent run.
+    /// Replaced wholesale each run.
+    /// </summary>
+    public List<ManualRewrite> Manual { get; set; } = [];
+
+    // ── State logic ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns <see langword="true"/> when a rewrite for <paramref name="ruleId"/>
+    /// has already been applied to <paramref name="file"/> in a prior run.
+    /// </summary>
+    public bool IsAlreadyApplied(string ruleId, string file) =>
+        Applied.Any(a =>
+            string.Equals(a.RuleId, ruleId, StringComparison.Ordinal) &&
+            string.Equals(a.File, file, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="newSchemaHash"/> differs
+    /// from <see cref="SchemaHash"/>, indicating the schema has been edited since
+    /// this state was written.
+    /// </summary>
+    public bool SchemaHasChanged(string newSchemaHash) =>
+        !string.Equals(SchemaHash, newSchemaHash, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Produces an updated <see cref="MigrationState"/> by merging
+    /// <paramref name="newResult"/> with the current state.
+    /// </summary>
+    /// <param name="newResult">The result of the latest <c>apply</c> run.</param>
+    /// <param name="schemaHash">The current schema hash to record.</param>
+    /// <returns>A new <see cref="MigrationState"/> instance with merged data.</returns>
+    public MigrationState Merge(MigrationResult newResult, string schemaHash)
+    {
+        ArgumentNullException.ThrowIfNull(newResult);
+        ArgumentNullException.ThrowIfNull(schemaHash);
+
+        // Applied: append-only, de-duplicated by (RuleId, File).
+        var seen = new HashSet<(string RuleId, string File)>(
+            Applied.Select(a => (a.RuleId, a.File)),
+            EqualityComparer<(string, string)>.Default);
+
+        var mergedApplied = new List<AppliedRewrite>(Applied);
+        foreach (var a in newResult.Applied)
+        {
+            var key = (a.RuleId, a.File);
+            if (seen.Add(key))
+                mergedApplied.Add(a);
+        }
+
+        // Skipped + Manual: replaced wholesale.
+        var newManual = newResult.Manual
+            .Select(m => new ManualRewrite(m.RuleId, m.Note, m.MatchedFiles))
+            .ToList();
+
+        var newSummary = new MigrationStateSummary
+        {
+            TotalRules = mergedApplied.Count + newResult.Skipped.Count + newManual.Count,
+            Applied = mergedApplied.Count,
+            Skipped = newResult.Skipped.Count,
+            Manual  = newManual.Count,
+        };
+
+        return new MigrationState
+        {
+            Schema    = Schema,
+            SchemaHash = schemaHash,
+            StartedAt = StartedAt == default ? DateTimeOffset.UtcNow : StartedAt,
+            LastRunAt  = DateTimeOffset.UtcNow,
+            Summary    = newSummary,
+            Applied    = mergedApplied,
+            Skipped    = [.. newResult.Skipped],
+            Manual     = newManual,
+        };
+    }
+}

--- a/WrapGod.Migration.Engine/State/MigrationState.cs
+++ b/WrapGod.Migration.Engine/State/MigrationState.cs
@@ -74,6 +74,18 @@ public sealed class MigrationState
     /// Returns <see langword="true"/> when a rewrite for <paramref name="ruleId"/>
     /// has already been applied to <paramref name="file"/> in a prior run.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Performance:</strong> This is an O(n) linear scan over
+    /// <see cref="Applied"/>. It is fine for ad-hoc / one-off queries (e.g.
+    /// status display, single lookups), but hot-path callers that iterate over
+    /// many <c>(ruleId, file)</c> pairs (such as the per-file rewrite loop in
+    /// <see cref="MigrationEngine"/>) should pre-build a
+    /// <see cref="HashSet{T}"/> from <see cref="Applied"/> once and probe that
+    /// instead. See <c>StatefulMigrationEngine.BuildAlreadyAppliedSet</c> for
+    /// the canonical pre-built set used by the engine on the hot path.
+    /// </para>
+    /// </remarks>
     public bool IsAlreadyApplied(string ruleId, string file) =>
         Applied.Any(a =>
             string.Equals(a.RuleId, ruleId, StringComparison.Ordinal) &&

--- a/WrapGod.Migration.Engine/State/MigrationStateSerializer.cs
+++ b/WrapGod.Migration.Engine/State/MigrationStateSerializer.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WrapGod.Migration.Engine.State;
+
+/// <summary>
+/// JSON serialization helpers for <see cref="MigrationState"/>.
+/// Uses camelCase naming, enum-as-string, indented output, and null-ignoring
+/// conventions consistent with <c>WrapGod.Migration.MigrationSchemaSerializer</c>.
+/// </summary>
+public static class MigrationStateSerializer
+{
+    private static readonly JsonSerializerOptions Options = CreateOptions();
+
+    /// <summary>Serializes a <see cref="MigrationState"/> to an indented JSON string.</summary>
+    public static string Serialize(MigrationState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        return JsonSerializer.Serialize(state, Options);
+    }
+
+    /// <summary>
+    /// Deserializes a <see cref="MigrationState"/> from a JSON string.
+    /// Returns <see langword="null"/> if the input is the JSON <c>null</c> literal,
+    /// an empty string, or contains invalid JSON.
+    /// </summary>
+    public static MigrationState? Deserialize(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<MigrationState>(json, Options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static JsonSerializerOptions CreateOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+        };
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        return options;
+    }
+}

--- a/WrapGod.Migration.Engine/State/MigrationStateStore.cs
+++ b/WrapGod.Migration.Engine/State/MigrationStateStore.cs
@@ -1,0 +1,137 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace WrapGod.Migration.Engine.State;
+
+/// <summary>
+/// Provides static helpers for locating, loading, saving, and hashing migration state files.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The state file sits next to the schema file and is named
+/// <c>{schemaFilename}.state.json</c>.
+/// </para>
+/// <para>
+/// Writes are atomic: content is first written to a <c>.tmp</c> file, then renamed
+/// over the target path so no partial state is ever visible on disk.
+/// </para>
+/// </remarks>
+public static class MigrationStateStore
+{
+    // ── Path helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the state file path for the given schema file path.
+    /// The state file sits in the same directory as the schema with the suffix
+    /// <c>.state.json</c> appended to the schema filename.
+    /// </summary>
+    /// <example>
+    /// <c>GetStatePath("/migrations/myschema.json")</c>
+    /// returns <c>"/migrations/myschema.json.state.json"</c>.
+    /// </example>
+    public static string GetStatePath(string schemaPath)
+    {
+        ArgumentNullException.ThrowIfNull(schemaPath);
+        return schemaPath + ".state.json";
+    }
+
+    // ── Load ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Loads the <see cref="MigrationState"/> associated with <paramref name="schemaPath"/>.
+    /// Returns <see langword="null"/> when the state file does not exist, is empty,
+    /// or contains invalid JSON (the corrupt file is left in place; callers such as
+    /// <see cref="StatefulMigrationEngine"/> may archive it before proceeding).
+    /// </summary>
+    public static MigrationState? Load(string schemaPath)
+    {
+        ArgumentNullException.ThrowIfNull(schemaPath);
+
+        var statePath = GetStatePath(schemaPath);
+        if (!File.Exists(statePath))
+            return null;
+
+        try
+        {
+            var json = File.ReadAllText(statePath, Encoding.UTF8);
+            return MigrationStateSerializer.Deserialize(json); // returns null on bad JSON
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+
+    // ── Save ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Persists <paramref name="state"/> next to <paramref name="schemaPath"/>.
+    /// Creates the parent directory if it does not exist.
+    /// Uses an atomic write (temp file + rename) so no partial state appears on disk.
+    /// </summary>
+    /// <exception cref="IOException">
+    /// Propagated from the underlying file system on write failure.
+    /// </exception>
+    public static void Save(string schemaPath, MigrationState state)
+    {
+        ArgumentNullException.ThrowIfNull(schemaPath);
+        ArgumentNullException.ThrowIfNull(state);
+
+        var statePath = GetStatePath(schemaPath);
+        var dir = Path.GetDirectoryName(statePath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        var json = MigrationStateSerializer.Serialize(state);
+        var tmp  = statePath + ".tmp";
+
+        File.WriteAllText(tmp, json, Encoding.UTF8);
+        File.Move(tmp, statePath, overwrite: true);
+    }
+
+    // ── Hashing ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Computes a normalised SHA-256 hash of <paramref name="schemaJson"/>.
+    /// </summary>
+    /// <remarks>
+    /// Before hashing the content is normalised:
+    /// <list type="number">
+    ///   <item><description>CRLF (<c>\r\n</c>) and bare CR (<c>\r</c>) are replaced with LF (<c>\n</c>).</description></item>
+    ///   <item><description>Trailing whitespace is trimmed from each line.</description></item>
+    /// </list>
+    /// This makes the hash insensitive to git's <c>autocrlf</c> setting and to trailing
+    /// space differences introduced by editors, but it still changes when the schema
+    /// rules are reordered (content-sensitive, not schema-semantic).
+    /// </remarks>
+    /// <returns>The hash in the format <c>sha256:&lt;lowercase-hex&gt;</c>.</returns>
+    public static string ComputeSchemaHash(string schemaJson)
+    {
+        ArgumentNullException.ThrowIfNull(schemaJson);
+
+        // Normalise line endings and trim trailing whitespace per line.
+        var normalised = Normalise(schemaJson);
+        var bytes = Encoding.UTF8.GetBytes(normalised);
+        var hash  = SHA256.HashData(bytes);
+        return "sha256:" + Convert.ToHexStringLower(hash);
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Normalises line endings to LF and trims trailing whitespace from each line.
+    /// </summary>
+    private static string Normalise(string input)
+    {
+        // Replace CRLF then lone CR with LF.
+        var unified = input.Replace("\r\n", "\n", StringComparison.Ordinal)
+                           .Replace('\r', '\n');
+
+        // Trim trailing whitespace per line.
+        var lines = unified.Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+            lines[i] = lines[i].TrimEnd();
+
+        return string.Join('\n', lines);
+    }
+}

--- a/WrapGod.Migration.Engine/State/MigrationStateStore.cs
+++ b/WrapGod.Migration.Engine/State/MigrationStateStore.cs
@@ -40,26 +40,81 @@ public static class MigrationStateStore
     /// <summary>
     /// Loads the <see cref="MigrationState"/> associated with <paramref name="schemaPath"/>.
     /// Returns <see langword="null"/> when the state file does not exist, is empty,
-    /// or contains invalid JSON (the corrupt file is left in place; callers such as
-    /// <see cref="StatefulMigrationEngine"/> may archive it before proceeding).
+    /// or contains invalid JSON. Corrupt files are <strong>not</strong> archived by
+    /// this overload — use <see cref="Load(string, out bool, out string?)"/> when
+    /// the caller needs to surface recovery to the user (e.g.
+    /// <see cref="StatefulMigrationEngine"/>).
     /// </summary>
-    public static MigrationState? Load(string schemaPath)
+    public static MigrationState? Load(string schemaPath) =>
+        Load(schemaPath, out _, out _);
+
+    /// <summary>
+    /// Loads the <see cref="MigrationState"/> associated with <paramref name="schemaPath"/>
+    /// and reports whether a corrupt state file was archived during the load.
+    /// </summary>
+    /// <param name="schemaPath">Path to the schema file (the state file is its sibling).</param>
+    /// <param name="wasCorrupt">
+    /// Set to <see langword="true"/> when the state file existed but contained invalid JSON
+    /// (or was empty). In that case the corrupt file is moved to
+    /// <paramref name="backupPath"/> and the method returns <see langword="null"/>.
+    /// </param>
+    /// <param name="backupPath">
+    /// When <paramref name="wasCorrupt"/> is <see langword="true"/>, the absolute path of
+    /// the archived <c>.state.json.bak</c> file. Otherwise <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    /// The loaded state, or <see langword="null"/> when the state file is missing, empty,
+    /// or corrupt. When corrupt, the caller can inspect <paramref name="wasCorrupt"/>
+    /// to surface recovery in its audit trail.
+    /// </returns>
+    public static MigrationState? Load(string schemaPath, out bool wasCorrupt, out string? backupPath)
     {
         ArgumentNullException.ThrowIfNull(schemaPath);
+
+        wasCorrupt = false;
+        backupPath = null;
 
         var statePath = GetStatePath(schemaPath);
         if (!File.Exists(statePath))
             return null;
 
+        string json;
         try
         {
-            var json = File.ReadAllText(statePath, Encoding.UTF8);
-            return MigrationStateSerializer.Deserialize(json); // returns null on bad JSON
+            json = File.ReadAllText(statePath, Encoding.UTF8);
         }
         catch (IOException)
         {
             return null;
         }
+
+        // Empty file is treated like a missing state file (not "corrupt").
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        var state = MigrationStateSerializer.Deserialize(json);
+        if (state is not null)
+            return state;
+
+        // Corrupt JSON: archive the offending file and return null so the engine
+        // can re-run from scratch. The caller surfaces a SkippedRewrite to the
+        // user (see StatefulMigrationEngine.ApplyWithState).
+        var bak = statePath + ".bak";
+        try
+        {
+            File.Move(statePath, bak, overwrite: true);
+            wasCorrupt = true;
+            backupPath = bak;
+        }
+        catch (IOException)
+        {
+            // Best-effort archive. If the move fails (e.g. file locked), leave the
+            // corrupt file in place — the next save will overwrite it atomically.
+            wasCorrupt = true;
+            backupPath = null;
+        }
+
+        return null;
     }
 
     // ── Save ─────────────────────────────────────────────────────────────────
@@ -86,7 +141,17 @@ public static class MigrationStateStore
         var tmp  = statePath + ".tmp";
 
         File.WriteAllText(tmp, json, Encoding.UTF8);
-        File.Move(tmp, statePath, overwrite: true);
+        try
+        {
+            File.Move(tmp, statePath, overwrite: true);
+        }
+        catch
+        {
+            // Move failed — destination locked, parent removed, etc.
+            // Best-effort cleanup of the .tmp file so we don't leave orphans.
+            try { File.Delete(tmp); } catch { /* best-effort */ }
+            throw;
+        }
     }
 
     // ── Hashing ──────────────────────────────────────────────────────────────

--- a/WrapGod.Migration.Engine/State/MigrationStateSummary.cs
+++ b/WrapGod.Migration.Engine/State/MigrationStateSummary.cs
@@ -1,0 +1,21 @@
+namespace WrapGod.Migration.Engine.State;
+
+/// <summary>
+/// Aggregated counts from a migration run, stored in the state file for quick inspection
+/// without deserializing the full <see cref="AppliedRewrite"/>, <see cref="SkippedRewrite"/>,
+/// and <see cref="ManualRewrite"/> lists.
+/// </summary>
+public sealed class MigrationStateSummary
+{
+    /// <summary>Total number of auto-confidence rules evaluated during the last run.</summary>
+    public int TotalRules { get; set; }
+
+    /// <summary>Number of rewrites successfully applied during the last run.</summary>
+    public int Applied { get; set; }
+
+    /// <summary>Number of rewrite sites skipped during the last run.</summary>
+    public int Skipped { get; set; }
+
+    /// <summary>Number of manual-confidence rules identified during the last run.</summary>
+    public int Manual { get; set; }
+}

--- a/WrapGod.Migration.Engine/StatefulMigrationEngine.cs
+++ b/WrapGod.Migration.Engine/StatefulMigrationEngine.cs
@@ -1,0 +1,174 @@
+using WrapGod.Migration;
+using WrapGod.Migration.Engine.State;
+
+namespace WrapGod.Migration.Engine;
+
+/// <summary>
+/// Wraps a <see cref="MigrationEngine"/> with state-tracking behaviour so that
+/// <c>apply</c> runs are idempotent across multiple invocations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Idempotence protocol:</strong>
+/// <list type="number">
+///   <item><description>Load the state file from <c>{schemaPath}.state.json</c>.</description></item>
+///   <item><description>Compute the SHA-256 hash of the current schema JSON.</description></item>
+///   <item><description>
+///     If the state exists AND the hash matches: skip <c>(ruleId, file)</c> pairs already in
+///     <see cref="State.MigrationState.Applied"/>.
+///   </description></item>
+///   <item><description>
+///     If the state exists BUT the hash differs: re-run all rules (schema has changed);
+///     old applied entries that reappear in the new run are de-duplicated.
+///   </description></item>
+///   <item><description>If no state file: full run.</description></item>
+/// </list>
+/// After the run the merged state is persisted (unless this is a dry run).
+/// </para>
+/// <para>
+/// <strong>State file ownership:</strong> <see cref="StatefulMigrationEngine"/> owns the
+/// read/write lifecycle. The inner <see cref="MigrationEngine"/> is unaware of state.
+/// </para>
+/// </remarks>
+public sealed class StatefulMigrationEngine
+{
+    private readonly MigrationEngine _inner;
+
+    /// <summary>
+    /// Initializes a new <see cref="StatefulMigrationEngine"/> wrapping
+    /// <paramref name="inner"/>.
+    /// </summary>
+    /// <param name="inner">The inner stateless engine to delegate to.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="inner"/> is <see langword="null"/>.
+    /// </exception>
+    public StatefulMigrationEngine(MigrationEngine inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        _inner = inner;
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Applies <paramref name="schema"/> rules to <paramref name="files"/>, skipping
+    /// rules already recorded in the persisted state, and writes the merged state to
+    /// disk when complete.
+    /// </summary>
+    /// <param name="schemaPath">
+    /// Path to the schema file on disk. Used to locate the state file and compute the
+    /// current schema hash.
+    /// </param>
+    /// <param name="schema">The migration schema to apply.</param>
+    /// <param name="files">Source file paths to process.</param>
+    /// <returns>
+    /// The cumulative <see cref="MigrationResult"/> (new applied entries from this run).
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="schemaPath"/>, <paramref name="schema"/>,
+    /// or <paramref name="files"/> is <see langword="null"/>.
+    /// </exception>
+    public MigrationResult ApplyWithState(
+        string schemaPath,
+        MigrationSchema schema,
+        IEnumerable<string> files)
+    {
+        ArgumentNullException.ThrowIfNull(schemaPath);
+        ArgumentNullException.ThrowIfNull(schema);
+        ArgumentNullException.ThrowIfNull(files);
+
+        var (priorState, currentHash) = LoadAndHash(schemaPath, schema);
+        var alreadyApplied = BuildAlreadyAppliedSet(priorState, currentHash);
+
+        var result = _inner.Apply(schema, files, alreadyApplied);
+
+        var baseState = priorState ?? NewState(schemaPath);
+        var merged = baseState.Merge(result, currentHash);
+
+        MigrationStateStore.Save(schemaPath, merged);
+        return result;
+    }
+
+    /// <summary>
+    /// Performs a dry run — evaluates rules (honouring prior state) but writes neither
+    /// source files nor the state file to disk.
+    /// </summary>
+    /// <param name="schemaPath">Path to the schema file (used for state lookup and hash).</param>
+    /// <param name="schema">The migration schema to evaluate.</param>
+    /// <param name="files">Source file paths to process.</param>
+    /// <returns>
+    /// A <see cref="MigrationResult"/> with <see cref="MigrationResult.DryRun"/> = <see langword="true"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="schemaPath"/>, <paramref name="schema"/>,
+    /// or <paramref name="files"/> is <see langword="null"/>.
+    /// </exception>
+    public MigrationResult DryRunWithState(
+        string schemaPath,
+        MigrationSchema schema,
+        IEnumerable<string> files)
+    {
+        ArgumentNullException.ThrowIfNull(schemaPath);
+        ArgumentNullException.ThrowIfNull(schema);
+        ArgumentNullException.ThrowIfNull(files);
+
+        var (priorState, currentHash) = LoadAndHash(schemaPath, schema);
+        var alreadyApplied = BuildAlreadyAppliedSet(priorState, currentHash);
+
+        return _inner.DryRun(schema, files, alreadyApplied);
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Loads the prior state (gracefully handling corruption) and computes the current
+    /// schema hash from the schema file on disk (or from the serialized schema when the
+    /// file cannot be read).
+    /// </summary>
+    private static (State.MigrationState? priorState, string currentHash) LoadAndHash(
+        string schemaPath,
+        MigrationSchema schema)
+    {
+        // Compute current hash. Prefer reading the actual file on disk so the hash
+        // matches what was written; fall back to serializing the in-memory schema.
+        string schemaJson;
+        try
+        {
+            schemaJson = File.ReadAllText(schemaPath, System.Text.Encoding.UTF8);
+        }
+        catch (IOException)
+        {
+            schemaJson = WrapGod.Migration.MigrationSchemaSerializer.Serialize(schema);
+        }
+        var currentHash = MigrationStateStore.ComputeSchemaHash(schemaJson);
+
+        // Load prior state — null if missing or corrupt.
+        var priorState = MigrationStateStore.Load(schemaPath);
+        return (priorState, currentHash);
+    }
+
+    /// <summary>
+    /// Builds the set of <c>(ruleId, file)</c> pairs that should be skipped because
+    /// they are already recorded in the prior state AND the schema has not changed.
+    /// When the schema has changed all rules are re-evaluated (returns an empty set).
+    /// </summary>
+    private static HashSet<(string RuleId, string File)> BuildAlreadyAppliedSet(
+        State.MigrationState? priorState,
+        string currentHash)
+    {
+        if (priorState is null || priorState.SchemaHasChanged(currentHash))
+            return [];
+
+        return new HashSet<(string, string)>(
+            priorState.Applied.Select(a => (a.RuleId, a.File)),
+            EqualityComparer<(string, string)>.Default);
+    }
+
+    /// <summary>Creates a fresh <see cref="State.MigrationState"/> for a first run.</summary>
+    private static State.MigrationState NewState(string schemaPath) => new()
+    {
+        Schema    = schemaPath,
+        StartedAt = DateTimeOffset.UtcNow,
+        LastRunAt = DateTimeOffset.UtcNow,
+    };
+}

--- a/WrapGod.Migration.Engine/StatefulMigrationEngine.cs
+++ b/WrapGod.Migration.Engine/StatefulMigrationEngine.cs
@@ -77,10 +77,12 @@ public sealed class StatefulMigrationEngine
         ArgumentNullException.ThrowIfNull(schema);
         ArgumentNullException.ThrowIfNull(files);
 
-        var (priorState, currentHash) = LoadAndHash(schemaPath, schema);
+        var (priorState, currentHash, recoverySkip) = LoadAndHash(schemaPath, schema);
         var alreadyApplied = BuildAlreadyAppliedSet(priorState, currentHash);
 
         var result = _inner.Apply(schema, files, alreadyApplied);
+        if (recoverySkip is not null)
+            result = AppendSkipped(result, recoverySkip);
 
         var baseState = priorState ?? NewState(schemaPath);
         var merged = baseState.Merge(result, currentHash);
@@ -112,10 +114,14 @@ public sealed class StatefulMigrationEngine
         ArgumentNullException.ThrowIfNull(schema);
         ArgumentNullException.ThrowIfNull(files);
 
-        var (priorState, currentHash) = LoadAndHash(schemaPath, schema);
+        var (priorState, currentHash, recoverySkip) = LoadAndHash(schemaPath, schema);
         var alreadyApplied = BuildAlreadyAppliedSet(priorState, currentHash);
 
-        return _inner.DryRun(schema, files, alreadyApplied);
+        var result = _inner.DryRun(schema, files, alreadyApplied);
+        if (recoverySkip is not null)
+            result = AppendSkipped(result, recoverySkip);
+
+        return result;
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
@@ -125,9 +131,15 @@ public sealed class StatefulMigrationEngine
     /// schema hash from the schema file on disk (or from the serialized schema when the
     /// file cannot be read).
     /// </summary>
-    private static (State.MigrationState? priorState, string currentHash) LoadAndHash(
-        string schemaPath,
-        MigrationSchema schema)
+    /// <remarks>
+    /// If the state file existed but was corrupt, <see cref="MigrationStateStore.Load(string, out bool, out string?)"/>
+    /// archives it to <c>.state.json.bak</c>. We surface that as a synthetic
+    /// <see cref="SkippedRewrite"/> (<c>ruleId="&lt;state&gt;"</c>) so the audit trail
+    /// reflects the recovery and downstream consumers such as <c>migrate status</c>
+    /// can display it.
+    /// </remarks>
+    private static (State.MigrationState? priorState, string currentHash, SkippedRewrite? recoverySkip)
+        LoadAndHash(string schemaPath, MigrationSchema schema)
     {
         // Compute current hash. Prefer reading the actual file on disk so the hash
         // matches what was written; fall back to serializing the in-memory schema.
@@ -142,9 +154,39 @@ public sealed class StatefulMigrationEngine
         }
         var currentHash = MigrationStateStore.ComputeSchemaHash(schemaJson);
 
-        // Load prior state — null if missing or corrupt.
-        var priorState = MigrationStateStore.Load(schemaPath);
-        return (priorState, currentHash);
+        // Load prior state — null if missing OR corrupt. Corrupt files are archived
+        // to .state.json.bak and surfaced via the wasCorrupt out parameter so we can
+        // emit a synthetic SkippedRewrite to record the recovery.
+        var priorState = MigrationStateStore.Load(schemaPath, out var wasCorrupt, out var backupPath);
+
+        SkippedRewrite? recoverySkip = null;
+        if (wasCorrupt)
+        {
+            var message = backupPath is null
+                ? "State file was corrupt; archive failed, leaving file in place. Re-evaluating all rules."
+                : $"State file was corrupt and archived to {backupPath}. Re-evaluating all rules.";
+            recoverySkip = new SkippedRewrite("<state>", "<state>", 0, message);
+        }
+
+        return (priorState, currentHash, recoverySkip);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="MigrationResult"/> identical to <paramref name="result"/>
+    /// but with <paramref name="extra"/> appended to its <see cref="MigrationResult.Skipped"/> list.
+    /// </summary>
+    private static MigrationResult AppendSkipped(MigrationResult result, SkippedRewrite extra)
+    {
+        var newSkipped = new List<SkippedRewrite>(result.Skipped.Count + 1);
+        newSkipped.AddRange(result.Skipped);
+        newSkipped.Add(extra);
+
+        return new MigrationResult(
+            applied: [.. result.Applied],
+            skipped: newSkipped,
+            manual: [.. result.Manual],
+            rewrittenFiles: result.RewrittenFiles,
+            dryRun: result.DryRun);
     }
 
     /// <summary>

--- a/WrapGod.Tests/Migration/Engine/State/MigrationStateStoreTests.cs
+++ b/WrapGod.Tests/Migration/Engine/State/MigrationStateStoreTests.cs
@@ -1,0 +1,137 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.State;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.State;
+
+[Feature("MigrationStateStore: load/save with real temp file system")]
+public sealed class MigrationStateStoreTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string TempSchemaPath()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return Path.Combine(dir, "schema.json");
+    }
+
+    private static MigrationState SampleState() => new()
+    {
+        Schema = "schema.json",
+        SchemaHash = "sha256:aabbcc",
+        StartedAt = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero),
+        LastRunAt = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero),
+        Summary = new MigrationStateSummary { TotalRules = 2, Applied = 1, Skipped = 1 },
+        Applied = [new AppliedRewrite("r-1", "file.cs", 5, "old", "new")],
+        Skipped = [new SkippedRewrite("r-2", "file.cs", 8, "no match")],
+    };
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Group: happy
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Scenario("Happy-01: Load returns null when state file does not exist")]
+    [Fact]
+    public Task Load_NonExistentFile_ReturnsNull() =>
+        Given("schema path where no state file exists", () =>
+            MigrationStateStore.Load(TempSchemaPath()))
+        .Then("result is null", r => r == null)
+        .AssertPassed();
+
+    [Scenario("Happy-02: Save then Load round-trips state correctly")]
+    [Fact]
+    public Task SaveThenLoad_RoundTrips() =>
+        Given("schema path; Save called with SampleState; Load returns the state", () =>
+        {
+            var path = TempSchemaPath();
+            MigrationStateStore.Save(path, SampleState());
+            return MigrationStateStore.Load(path);
+        })
+        .Then("loaded state is not null", s => s != null)
+        .And("SchemaHash matches", s => s!.SchemaHash == "sha256:aabbcc")
+        .And("Applied has 1 entry", s => s!.Applied.Count == 1)
+        .And("Applied[0].RuleId is r-1", s => s!.Applied[0].RuleId == "r-1")
+        .And("Skipped has 1 entry", s => s!.Skipped.Count == 1)
+        .AssertPassed();
+
+    [Scenario("Happy-03: Save creates parent directory if it does not exist")]
+    [Fact]
+    public Task Save_CreatesParentDirectory() =>
+        Given("a schema path in a non-existent subdirectory; Save called", () =>
+        {
+            var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "sub", "dir");
+            var schemaPath = Path.Combine(root, "schema.json");
+            MigrationStateStore.Save(schemaPath, SampleState());
+            return MigrationStateStore.GetStatePath(schemaPath);
+        })
+        .Then("state file exists", p => File.Exists(p))
+        .AssertPassed();
+
+    [Scenario("Happy-04: Save writes atomically — no .tmp file left behind")]
+    [Fact]
+    public Task Save_AtomicWrite_NoTmpFileLeft() =>
+        Given("schema path; Save completes", () =>
+        {
+            var path = TempSchemaPath();
+            MigrationStateStore.Save(path, SampleState());
+            return MigrationStateStore.GetStatePath(path);
+        })
+        .Then("state file exists", p => File.Exists(p))
+        .And("no .tmp file left beside the state file", p => !File.Exists(p + ".tmp"))
+        .AssertPassed();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Group: sad
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Scenario("Sad-01: Load returns null for corrupt state file")]
+    [Fact]
+    public Task Load_CorruptStateFile_ReturnsNull() =>
+        Given("state file containing invalid JSON; Load called", () =>
+        {
+            var path = TempSchemaPath();
+            var statePath = MigrationStateStore.GetStatePath(path);
+            Directory.CreateDirectory(Path.GetDirectoryName(statePath)!);
+            File.WriteAllText(statePath, "{ this is NOT valid json ]");
+            return MigrationStateStore.Load(path);
+        })
+        .Then("result is null", r => r == null)
+        .AssertPassed();
+
+    [Scenario("Sad-02: Load returns null for empty state file")]
+    [Fact]
+    public Task Load_EmptyStateFile_ReturnsNull() =>
+        Given("state file that is empty; Load called", () =>
+        {
+            var path = TempSchemaPath();
+            var statePath = MigrationStateStore.GetStatePath(path);
+            Directory.CreateDirectory(Path.GetDirectoryName(statePath)!);
+            File.WriteAllText(statePath, string.Empty);
+            return MigrationStateStore.Load(path);
+        })
+        .Then("result is null", r => r == null)
+        .AssertPassed();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Group: edge
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Scenario("Edge-01: Overwriting existing state file saves the new version")]
+    [Fact]
+    public Task Save_Overwrite_PersistsNewVersion() =>
+        Given("state file already saved with 'sha256:aabbcc'; resaved with 'sha256:updated'", () =>
+        {
+            var path = TempSchemaPath();
+            MigrationStateStore.Save(path, SampleState());
+            var updated = SampleState();
+            updated.SchemaHash = "sha256:updated";
+            MigrationStateStore.Save(path, updated);
+            return MigrationStateStore.Load(path);
+        })
+        .Then("loaded state is not null", s => s != null)
+        .And("SchemaHash is 'sha256:updated'", s => s!.SchemaHash == "sha256:updated")
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/State/MigrationStateStoreTests.cs
+++ b/WrapGod.Tests/Migration/Engine/State/MigrationStateStoreTests.cs
@@ -134,4 +134,57 @@ public sealed class MigrationStateStoreTests(ITestOutputHelper output) : TinyBdd
         .Then("loaded state is not null", s => s != null)
         .And("SchemaHash is 'sha256:updated'", s => s!.SchemaHash == "sha256:updated")
         .AssertPassed();
+
+    [Scenario("Edge-02: Save cleans up .tmp orphan when File.Move fails")]
+    [Fact]
+    public Task Save_MoveFails_CleansUpTmpFile() =>
+        Given("destination state path is a non-empty directory (Move will fail); Save called", () =>
+        {
+            var path = TempSchemaPath();
+            var statePath = MigrationStateStore.GetStatePath(path);
+            // Force a Move failure by making the destination an existing non-empty directory.
+            // Windows File.Move(..., overwrite:true) cannot replace a non-empty directory.
+            Directory.CreateDirectory(statePath);
+            File.WriteAllText(Path.Combine(statePath, "blocker.txt"), "x");
+
+            Exception? caught = null;
+            try
+            {
+                MigrationStateStore.Save(path, SampleState());
+            }
+            catch (Exception ex)
+            {
+                caught = ex;
+            }
+
+            return (caught, tmpExists: File.Exists(statePath + ".tmp"));
+        })
+        .Then("Save threw (Move-into-directory failed)", t => t.caught != null)
+        .And("the .tmp file was cleaned up (no orphan left on disk)", t => !t.tmpExists)
+        .AssertPassed();
+
+    [Scenario("Edge-03: Load(out wasCorrupt, out backupPath) archives corrupt state to .bak")]
+    [Fact]
+    public Task Load_CorruptStateFile_ArchivesToBak() =>
+        Given("corrupt state file; Load(out wasCorrupt, out backupPath) called", () =>
+        {
+            var path = TempSchemaPath();
+            var statePath = MigrationStateStore.GetStatePath(path);
+            Directory.CreateDirectory(Path.GetDirectoryName(statePath)!);
+            File.WriteAllText(statePath, "{ not valid json ]");
+
+            var loaded = MigrationStateStore.Load(path, out var wasCorrupt, out var backupPath);
+
+            return (loaded,
+                    wasCorrupt,
+                    backupPath,
+                    bakExists: backupPath is not null && File.Exists(backupPath),
+                    origRemoved: !File.Exists(statePath));
+        })
+        .Then("loaded result is null", t => t.loaded == null)
+        .And("wasCorrupt is true", t => t.wasCorrupt)
+        .And("backupPath is the archived .bak path", t => t.backupPath is not null && t.backupPath.EndsWith(".state.json.bak", StringComparison.Ordinal))
+        .And(".bak file exists on disk", t => t.bakExists)
+        .And("original corrupt file was moved away", t => t.origRemoved)
+        .AssertPassed();
 }

--- a/WrapGod.Tests/Migration/Engine/State/MigrationStateTests.cs
+++ b/WrapGod.Tests/Migration/Engine/State/MigrationStateTests.cs
@@ -1,0 +1,283 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.State;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.State;
+
+[Feature("MigrationState: serialization, hash, and state logic")]
+public sealed class MigrationStateTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static MigrationState FullState() => new()
+    {
+        Schema = "/path/to/schema.json",
+        SchemaHash = "sha256:abc123",
+        StartedAt = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+        LastRunAt = new DateTimeOffset(2025, 1, 2, 0, 0, 0, TimeSpan.Zero),
+        Summary = new MigrationStateSummary { TotalRules = 3, Applied = 1, Skipped = 1, Manual = 1 },
+        Applied = [new AppliedRewrite("rule-1", "/src/Foo.cs", 10, "OldType", "NewType")],
+        Skipped = [new SkippedRewrite("rule-2", "/src/Bar.cs", 5, "no match")],
+        Manual  = [new ManualRewrite("rule-3", "Manual step required", ["/src/Baz.cs"])],
+    };
+
+    private static MigrationState EmptyState() => new()
+    {
+        Schema = "schema.json",
+        SchemaHash = "sha256:0000",
+        StartedAt = DateTimeOffset.UtcNow,
+        LastRunAt = DateTimeOffset.UtcNow,
+    };
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Group: happy
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Scenario("Happy-01: full state round-trips through serializer")]
+    [Fact]
+    public Task Serializer_RoundTrips_FullState() =>
+        Given("a fully populated MigrationState serialized to JSON", () =>
+        {
+            var json = MigrationStateSerializer.Serialize(FullState());
+            return MigrationStateSerializer.Deserialize(json);
+        })
+        .Then("deserialized state is not null", r => r != null)
+        .And("Schema matches", r => r!.Schema == "/path/to/schema.json")
+        .And("SchemaHash matches", r => r!.SchemaHash == "sha256:abc123")
+        .And("Applied has 1 entry", r => r!.Applied.Count == 1)
+        .And("Applied[0].RuleId is rule-1", r => r!.Applied[0].RuleId == "rule-1")
+        .And("Skipped has 1 entry", r => r!.Skipped.Count == 1)
+        .And("Manual has 1 entry", r => r!.Manual.Count == 1)
+        .And("Summary.TotalRules == 3", r => r!.Summary.TotalRules == 3)
+        .AssertPassed();
+
+    [Scenario("Happy-02: minimal state round-trips through serializer")]
+    [Fact]
+    public Task Serializer_EmptyState_RoundTrips() =>
+        Given("a minimal MigrationState serialized to JSON", () =>
+        {
+            var json = MigrationStateSerializer.Serialize(EmptyState());
+            return MigrationStateSerializer.Deserialize(json);
+        })
+        .Then("deserialized state is not null", r => r != null)
+        .And("Schema matches", r => r!.Schema == "schema.json")
+        .And("Applied is empty", r => r!.Applied.Count == 0)
+        .And("Skipped is empty", r => r!.Skipped.Count == 0)
+        .And("Manual is empty", r => r!.Manual.Count == 0)
+        .AssertPassed();
+
+    [Scenario("Happy-03: null JSON returns null from deserializer")]
+    [Fact]
+    public Task Serializer_NullJson_ReturnsNull() =>
+        Given("the JSON literal 'null'", () => MigrationStateSerializer.Deserialize("null"))
+        .Then("result is null", r => r == null)
+        .AssertPassed();
+
+    [Scenario("Happy-04: schema hash stable across CRLF vs LF line endings")]
+    [Fact]
+    public Task Hash_LineEndingNormalised() =>
+        Given("same content with CRLF and LF line endings hashed", () =>
+        (
+            crlf: MigrationStateStore.ComputeSchemaHash("line1\r\nline2\r\n"),
+            lf:   MigrationStateStore.ComputeSchemaHash("line1\nline2\n")
+        ))
+        .Then("both hashes are equal", t => t.crlf == t.lf)
+        .AssertPassed();
+
+    [Scenario("Happy-05: hash format is 'sha256:' prefix + lowercase hex")]
+    [Fact]
+    public Task Hash_Format_HasSha256Prefix() =>
+        Given("ComputeSchemaHash called on 'some content'", () =>
+            MigrationStateStore.ComputeSchemaHash("some content"))
+        .Then("hash starts with 'sha256:'", h => h.StartsWith("sha256:", StringComparison.Ordinal))
+        .And("hex portion is 64 chars", h => h["sha256:".Length..].Length == 64)
+        .And("hex portion is all lowercase hex digits",
+            h => h["sha256:".Length..].All(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+        .AssertPassed();
+
+    [Scenario("Happy-06: IsAlreadyApplied returns true for matching ruleId + file")]
+    [Fact]
+    public Task IsAlreadyApplied_MatchingEntry_ReturnsTrue() =>
+        Given("state with applied entry for rule-1, /src/Foo.cs", () => FullState())
+        .Then("IsAlreadyApplied('rule-1', '/src/Foo.cs') is true",
+            s => s.IsAlreadyApplied("rule-1", "/src/Foo.cs"))
+        .AssertPassed();
+
+    [Scenario("Happy-07: IsAlreadyApplied returns false when file differs")]
+    [Fact]
+    public Task IsAlreadyApplied_DifferentFile_ReturnsFalse() =>
+        Given("state with applied entry for rule-1, /src/Foo.cs", () => FullState())
+        .Then("IsAlreadyApplied('rule-1', '/src/Other.cs') is false",
+            s => !s.IsAlreadyApplied("rule-1", "/src/Other.cs"))
+        .AssertPassed();
+
+    [Scenario("Happy-08: SchemaHasChanged returns true when hash differs")]
+    [Fact]
+    public Task SchemaHasChanged_DifferentHash_ReturnsTrue() =>
+        Given("state with hash 'sha256:abc123'", () => FullState())
+        .Then("SchemaHasChanged('sha256:def456') returns true",
+            s => s.SchemaHasChanged("sha256:def456"))
+        .AssertPassed();
+
+    [Scenario("Happy-09: SchemaHasChanged returns false when hash matches")]
+    [Fact]
+    public Task SchemaHasChanged_SameHash_ReturnsFalse() =>
+        Given("state with hash 'sha256:abc123'", () => FullState())
+        .Then("SchemaHasChanged('sha256:abc123') returns false",
+            s => !s.SchemaHasChanged("sha256:abc123"))
+        .AssertPassed();
+
+    [Scenario("Happy-10: Merge appends new applied entries to existing")]
+    [Fact]
+    public Task Merge_AppendsNewAppliedEntriesToExisting() =>
+        Given("existing state with 1 applied + result with 1 new applied entry", () =>
+        {
+            var original = FullState();
+            var newApplied = new List<AppliedRewrite>
+            {
+                new("rule-99", "/src/New.cs", 42, "A", "B"),
+            };
+            var result = new MigrationResult(
+                applied: newApplied, skipped: [], manual: [],
+                rewrittenFiles: new Dictionary<string, string>(), dryRun: false);
+            return original.Merge(result, "sha256:newHash");
+        })
+        .Then("merged has 2 applied entries", m => m.Applied.Count == 2)
+        .And("hash updated to sha256:newHash", m => m.SchemaHash == "sha256:newHash")
+        .And("original entry preserved", m => m.Applied.Any(a => a.RuleId == "rule-1"))
+        .And("new entry present", m => m.Applied.Any(a => a.RuleId == "rule-99"))
+        .AssertPassed();
+
+    [Scenario("Happy-11: Merge replaces Skipped and Manual lists wholesale")]
+    [Fact]
+    public Task Merge_ReplacesSkippedAndManualLists() =>
+        Given("existing state with 1 skipped + 1 manual; result with 2 skipped + 1 manual", () =>
+        {
+            var original = FullState();
+            var newSkipped = new List<SkippedRewrite>
+            {
+                new("rule-X", "/src/X.cs", 1, "new reason"),
+                new("rule-Y", "/src/Y.cs", 2, "another reason"),
+            };
+            var newManual = new List<ManualRewrite>
+            {
+                new("rule-Z", "New manual note", ["/src/Z.cs"]),
+            };
+            var result = new MigrationResult(
+                applied: [], skipped: newSkipped, manual: newManual,
+                rewrittenFiles: new Dictionary<string, string>(), dryRun: false);
+            return original.Merge(result, "sha256:abc123");
+        })
+        .Then("Skipped list replaced with 2 entries", m => m.Skipped.Count == 2)
+        .And("Manual list replaced with 1 entry", m => m.Manual.Count == 1)
+        .And("Manual entry is rule-Z", m => m.Manual[0].RuleId == "rule-Z")
+        .AssertPassed();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Group: sad
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Scenario("Sad-01: corrupted JSON returns null from Deserialize")]
+    [Fact]
+    public Task Serializer_CorruptJson_ReturnsNull() =>
+        Given("invalid JSON input deserialized", () =>
+            MigrationStateSerializer.Deserialize("{ not valid json ]"))
+        .Then("result is null", r => r == null)
+        .AssertPassed();
+
+    [Scenario("Sad-02: hash of different content produces different hash")]
+    [Fact]
+    public Task Hash_DifferentContent_ProducesDifferentHash() =>
+        Given("two different schema content strings hashed", () =>
+        (
+            h1: MigrationStateStore.ComputeSchemaHash("content A"),
+            h2: MigrationStateStore.ComputeSchemaHash("content B")
+        ))
+        .Then("hashes differ", t => t.h1 != t.h2)
+        .AssertPassed();
+
+    [Scenario("Sad-03: trailing whitespace per line is trimmed before hashing")]
+    [Fact]
+    public Task Hash_TrailingWhitespaceTrimmedPerLine() =>
+        Given("same content with and without trailing spaces per line", () =>
+        (
+            clean:    MigrationStateStore.ComputeSchemaHash("line1\nline2"),
+            trailing: MigrationStateStore.ComputeSchemaHash("line1   \nline2   ")
+        ))
+        .Then("both hashes are equal", t => t.clean == t.trailing)
+        .AssertPassed();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Group: edge
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Scenario("Edge-01: GetStatePath places state file sibling to schema")]
+    [Fact]
+    public Task GetStatePath_ReturnsSiblingPath() =>
+        Given("schema path '/migrations/myschema.json'", () =>
+            MigrationStateStore.GetStatePath("/migrations/myschema.json"))
+        .Then("state path is '/migrations/myschema.json.state.json'",
+            p => p == "/migrations/myschema.json.state.json")
+        .AssertPassed();
+
+    [Scenario("Edge-02: Merge de-duplicates applied entries by ruleId+file")]
+    [Fact]
+    public Task Merge_DeduplicatesAppliedByRuleIdAndFile() =>
+        Given("existing state with rule-1/Foo.cs applied; result with same rule-1/Foo.cs", () =>
+        {
+            var original = FullState();
+            var duplicate = new List<AppliedRewrite>
+            {
+                new("rule-1", "/src/Foo.cs", 10, "OldType", "NewType"),
+            };
+            var result = new MigrationResult(
+                applied: duplicate, skipped: [], manual: [],
+                rewrittenFiles: new Dictionary<string, string>(), dryRun: false);
+            return original.Merge(result, "sha256:abc123");
+        })
+        .Then("merged state has exactly 1 applied entry (de-duped)", m => m.Applied.Count == 1)
+        .AssertPassed();
+
+    [Scenario("Edge-03: large state (10000 entries) deserializes under 500ms")]
+    [Fact]
+    public Task Deserialize_LargeState_CompletesUnder500ms() =>
+        Given("a state JSON with 10000 applied entries serialized", () =>
+        {
+            var big = new MigrationState
+            {
+                Schema = "big.json",
+                SchemaHash = "sha256:big",
+                StartedAt = DateTimeOffset.UtcNow,
+                LastRunAt = DateTimeOffset.UtcNow,
+                Applied = Enumerable.Range(0, 10_000)
+                    .Select(i => new AppliedRewrite($"r-{i}", $"/src/File{i}.cs", i, "old", "new"))
+                    .ToList(),
+            };
+            return MigrationStateSerializer.Serialize(big);
+        })
+        .Then("deserialization completes under 500ms with 10000 entries", json =>
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var result = MigrationStateSerializer.Deserialize(json);
+            sw.Stop();
+            return result is not null
+                && result.Applied.Count == 10_000
+                && sw.ElapsedMilliseconds < 500;
+        })
+        .AssertPassed();
+
+    [Scenario("Edge-04: Merge updates LastRunAt")]
+    [Fact]
+    public Task Merge_UpdatesLastRunAt() =>
+        Given("existing state with a known LastRunAt; Merge called with MigrationResult.Empty", () =>
+        {
+            var original = FullState();
+            System.Threading.Thread.Sleep(1);
+            return (original: original.LastRunAt,
+                    merged: original.Merge(MigrationResult.Empty, "sha256:newhash").LastRunAt);
+        })
+        .Then("merged LastRunAt >= original LastRunAt", t => t.merged >= t.original)
+        .AssertPassed();
+}

--- a/WrapGod.Tests/Migration/Engine/State/StatefulMigrationEngineTests.cs
+++ b/WrapGod.Tests/Migration/Engine/State/StatefulMigrationEngineTests.cs
@@ -176,10 +176,10 @@ public sealed class StatefulMigrationEngineTests(ITestOutputHelper output) : Tin
         .Then("ArgumentNullException was thrown", threw => threw)
         .AssertPassed();
 
-    [Scenario("Sad-02: corrupt state file is recovered — run proceeds as a fresh run")]
+    [Scenario("Sad-02: corrupt state file archived to .bak; result includes <state> SkippedRewrite")]
     [Fact]
-    public Task ApplyWithState_CorruptStateFile_RecoversFreshRun() =>
-        Given("corrupt state file; ApplyWithState recovers and writes valid state", () =>
+    public Task ApplyWithState_CorruptStateFile_ArchivesToBakAndSurfacesSkipped() =>
+        Given("corrupt state file; ApplyWithState recovers, archives to .bak, and emits synthetic <state> skip", () =>
         {
             var dir = TempDir();
             var schemaPath = WriteSchemaFile(dir, OneRenameSchema());
@@ -187,11 +187,21 @@ public sealed class StatefulMigrationEngineTests(ITestOutputHelper output) : Tin
             File.WriteAllText(statePath, "{ CORRUPT JSON ]]]");
 
             var fs = new InMemoryFileSystem().WithFile("/src/Consumer.cs", SourceWithOldWidget);
-            BuildStateful(fs).ApplyWithState(schemaPath, OneRenameSchema(), ["/src/Consumer.cs"]);
+            var result = BuildStateful(fs).ApplyWithState(schemaPath, OneRenameSchema(), ["/src/Consumer.cs"]);
 
-            return MigrationStateStore.Load(schemaPath);
+            return (result,
+                    bakExists:  File.Exists(statePath + ".bak"),
+                    state:      MigrationStateStore.Load(schemaPath),
+                    skipFound:  result.Skipped.Any(s => s.RuleId == "<state>"),
+                    skipMsg:    result.Skipped.FirstOrDefault(s => s.RuleId == "<state>")?.Reason);
         })
-        .Then("run completed and valid state file exists", s => s != null)
+        .Then("the corrupt state file was archived to .state.json.bak", t => t.bakExists)
+        .And("a fresh valid state file was written after the run", t => t.state != null)
+        .And("result includes a synthetic SkippedRewrite with ruleId == '<state>'", t => t.skipFound)
+        .And("the skip message mentions archival to .bak",
+            t => t.skipMsg is not null && t.skipMsg.Contains(".bak", StringComparison.Ordinal))
+        .And("re-evaluation produced applied entries (full re-run)",
+            t => t.result.Applied.Count > 0)
         .AssertPassed();
 
     // ══════════════════════════════════════════════════════════════════════════

--- a/WrapGod.Tests/Migration/Engine/State/StatefulMigrationEngineTests.cs
+++ b/WrapGod.Tests/Migration/Engine/State/StatefulMigrationEngineTests.cs
@@ -1,0 +1,260 @@
+using TinyBDD;
+using TinyBDD.Xunit;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.State;
+using WrapGod.Tests.Migration.Engine.Fixtures;
+using Xunit.Abstractions;
+
+namespace WrapGod.Tests.Migration.Engine.State;
+
+[Feature("StatefulMigrationEngine: idempotent re-runs and state integration")]
+public sealed class StatefulMigrationEngineTests(ITestOutputHelper output) : TinyBddXunitBase(output)
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static IRuleRewriter[] DefaultRewriters() =>
+    [
+        new WrapGod.Migration.Engine.Rewriters.RenameTypeRewriter(),
+        new WrapGod.Migration.Engine.Rewriters.RenameNamespaceRewriter(),
+        new WrapGod.Migration.Engine.Rewriters.RenameMemberRewriter(),
+        new WrapGod.Migration.Engine.Rewriters.ChangeParameterRewriter(),
+        new WrapGod.Migration.Engine.Rewriters.RemoveMemberRewriter(),
+        new WrapGod.Migration.Engine.Rewriters.AddRequiredParameterRewriter(),
+        new WrapGod.Migration.Engine.Rewriters.ChangeTypeReferenceRewriter(),
+    ];
+
+    private static string TempDir() =>
+        Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    private static MigrationSchema OneRenameSchema(string id = "RT-001") => new()
+    {
+        Library = "Test", From = "1.0", To = "2.0",
+        Rules =
+        [
+            new RenameTypeRule
+            {
+                Id = id, OldName = "OldWidget", NewName = "NewWidget",
+                Confidence = RuleConfidence.Auto,
+            }
+        ]
+    };
+
+    private static string WriteSchemaFile(string dir, MigrationSchema schema)
+    {
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "schema.json");
+        File.WriteAllText(path, WrapGod.Migration.MigrationSchemaSerializer.Serialize(schema));
+        return path;
+    }
+
+    private static StatefulMigrationEngine BuildStateful(IMigrationFileSystem fs) =>
+        new(new MigrationEngine(DefaultRewriters(), fs));
+
+    private const string SourceWithOldWidget =
+        "using System;\nclass OldWidget { }\nclass Consumer { OldWidget w; }";
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Group: happy
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Scenario("Happy-01: first run writes state file with applied entries")]
+    [Fact]
+    public Task ApplyWithState_FirstRun_WritesStateFile() =>
+        Given("schema file + source file; ApplyWithState called for the first time", () =>
+        {
+            var dir = TempDir();
+            var schemaPath = WriteSchemaFile(dir, OneRenameSchema());
+            var fs = new InMemoryFileSystem().WithFile("/src/Consumer.cs", SourceWithOldWidget);
+            BuildStateful(fs).ApplyWithState(schemaPath, OneRenameSchema(), ["/src/Consumer.cs"]);
+            var state = MigrationStateStore.Load(schemaPath);
+            return (stateExists: state != null, appliedNotEmpty: state?.Applied.Count > 0);
+        })
+        .Then("state file was created", t => t.stateExists)
+        .And("state has at least one applied entry", t => t.appliedNotEmpty)
+        .AssertPassed();
+
+    [Scenario("Happy-02: second run with same schema skips already-applied rules")]
+    [Fact]
+    public Task ApplyWithState_SecondRunSameSchema_SkipsAlreadyApplied() =>
+        Given("prior state with RT-001 applied for /src/Consumer.cs; second run", () =>
+        {
+            var dir = TempDir();
+            var schema = OneRenameSchema();
+            var schemaPath = WriteSchemaFile(dir, schema);
+            var schemaJson = File.ReadAllText(schemaPath);
+            var schemaHash = MigrationStateStore.ComputeSchemaHash(schemaJson);
+
+            var priorState = new MigrationState
+            {
+                Schema = schemaPath, SchemaHash = schemaHash,
+                StartedAt = DateTimeOffset.UtcNow, LastRunAt = DateTimeOffset.UtcNow,
+                Applied = [new AppliedRewrite("RT-001", "/src/Consumer.cs", 3, "OldWidget", "NewWidget")],
+            };
+            MigrationStateStore.Save(schemaPath, priorState);
+
+            var fs = new InMemoryFileSystem().WithFile("/src/Consumer.cs", SourceWithOldWidget);
+            var result = BuildStateful(fs).ApplyWithState(schemaPath, schema, ["/src/Consumer.cs"]);
+            return result;
+        })
+        .Then("result has no new applied entries for RT-001 + /src/Consumer.cs",
+            r => !r.Applied.Any(a => a.RuleId == "RT-001" && a.File == "/src/Consumer.cs"))
+        .AssertPassed();
+
+    [Scenario("Happy-03: schema change triggers re-evaluation and updates state hash")]
+    [Fact]
+    public Task ApplyWithState_SchemaHashChanged_UpdatesStateHash() =>
+        Given("stale state (hash mismatch); ApplyWithState re-evaluates and persists new hash", () =>
+        {
+            var dir = TempDir();
+            var schema = OneRenameSchema();
+            var schemaPath = WriteSchemaFile(dir, schema);
+
+            var staleState = new MigrationState
+            {
+                Schema = schemaPath, SchemaHash = "sha256:stale-hash-does-not-match",
+                StartedAt = DateTimeOffset.UtcNow, LastRunAt = DateTimeOffset.UtcNow,
+                Applied = [new AppliedRewrite("RT-001", "/src/Consumer.cs", 3, "OldWidget", "NewWidget")],
+            };
+            MigrationStateStore.Save(schemaPath, staleState);
+
+            var fs = new InMemoryFileSystem().WithFile("/src/Consumer.cs", SourceWithOldWidget);
+            BuildStateful(fs).ApplyWithState(schemaPath, schema, ["/src/Consumer.cs"]);
+
+            var updatedState = MigrationStateStore.Load(schemaPath);
+            var expectedHash = MigrationStateStore.ComputeSchemaHash(File.ReadAllText(schemaPath));
+            return (updatedState?.SchemaHash, expectedHash);
+        })
+        .Then("state hash is updated to current schema hash",
+            t => t.Item1 == t.expectedHash)
+        .AssertPassed();
+
+    [Scenario("Happy-04: full run when no prior state file exists")]
+    [Fact]
+    public Task ApplyWithState_NoStateFile_RunsFullMigration() =>
+        Given("schema file; no prior state; ApplyWithState called", () =>
+        {
+            var dir = TempDir();
+            var schemaPath = WriteSchemaFile(dir, OneRenameSchema());
+            var fs = new InMemoryFileSystem().WithFile("/src/Consumer.cs", SourceWithOldWidget);
+            return BuildStateful(fs).ApplyWithState(schemaPath, OneRenameSchema(), ["/src/Consumer.cs"]);
+        })
+        .Then("result has applied entries", r => r.Applied.Count > 0)
+        .AssertPassed();
+
+    [Scenario("Happy-05: DryRunWithState does not write state file")]
+    [Fact]
+    public Task DryRunWithState_DoesNotWriteStateFile() =>
+        Given("schema file; DryRunWithState called", () =>
+        {
+            var dir = TempDir();
+            var schemaPath = WriteSchemaFile(dir, OneRenameSchema());
+            var fs = new InMemoryFileSystem().WithFile("/src/Consumer.cs", SourceWithOldWidget);
+            BuildStateful(fs).DryRunWithState(schemaPath, OneRenameSchema(), ["/src/Consumer.cs"]);
+            return MigrationStateStore.GetStatePath(schemaPath);
+        })
+        .Then("no state file written to disk", p => !File.Exists(p))
+        .AssertPassed();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Group: sad
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Scenario("Sad-01: ApplyWithState with null schemaPath throws ArgumentNullException")]
+    [Fact]
+    public Task ApplyWithState_NullSchemaPath_ThrowsArgumentNullException() =>
+        Given("null schemaPath passed to ApplyWithState", () =>
+        {
+            try
+            {
+                var stateful = new StatefulMigrationEngine(new MigrationEngine(DefaultRewriters()));
+                stateful.ApplyWithState(null!, OneRenameSchema(), []);
+                return false;
+            }
+            catch (ArgumentNullException) { return true; }
+        })
+        .Then("ArgumentNullException was thrown", threw => threw)
+        .AssertPassed();
+
+    [Scenario("Sad-02: corrupt state file is recovered — run proceeds as a fresh run")]
+    [Fact]
+    public Task ApplyWithState_CorruptStateFile_RecoversFreshRun() =>
+        Given("corrupt state file; ApplyWithState recovers and writes valid state", () =>
+        {
+            var dir = TempDir();
+            var schemaPath = WriteSchemaFile(dir, OneRenameSchema());
+            var statePath = MigrationStateStore.GetStatePath(schemaPath);
+            File.WriteAllText(statePath, "{ CORRUPT JSON ]]]");
+
+            var fs = new InMemoryFileSystem().WithFile("/src/Consumer.cs", SourceWithOldWidget);
+            BuildStateful(fs).ApplyWithState(schemaPath, OneRenameSchema(), ["/src/Consumer.cs"]);
+
+            return MigrationStateStore.Load(schemaPath);
+        })
+        .Then("run completed and valid state file exists", s => s != null)
+        .AssertPassed();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Group: edge
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Scenario("Edge-01: manual rules from prior run are preserved in merged state")]
+    [Fact]
+    public Task ApplyWithState_ManualRulesPreserved_InMergedState() =>
+        Given("schema with Manual-confidence rule; ApplyWithState called", () =>
+        {
+            var dir = TempDir();
+            var schemaWithManual = new MigrationSchema
+            {
+                Library = "Test", From = "1.0", To = "2.0",
+                Rules =
+                [
+                    new RenameTypeRule
+                    {
+                        Id = "RT-001", OldName = "OldWidget", NewName = "NewWidget",
+                        Confidence = RuleConfidence.Manual, Note = "Manual step required",
+                    }
+                ]
+            };
+            var schemaPath = WriteSchemaFile(dir, schemaWithManual);
+            var fs = new InMemoryFileSystem().WithFile("/src/Consumer.cs", SourceWithOldWidget);
+            BuildStateful(fs).ApplyWithState(schemaPath, schemaWithManual, ["/src/Consumer.cs"]);
+
+            var state = MigrationStateStore.Load(schemaPath);
+            return (hasManual: state?.Manual.Count > 0,
+                    manualRuleId: state?.Manual.FirstOrDefault()?.RuleId);
+        })
+        .Then("state contains Manual entry", t => t.hasManual)
+        .And("Manual entry has ruleId RT-001", t => t.manualRuleId == "RT-001")
+        .AssertPassed();
+
+    [Scenario("Edge-02: prior applied entries from FileA are preserved when FileB is processed")]
+    [Fact]
+    public Task ApplyWithState_PriorAppliedEntries_PreservedOnNextRun() =>
+        Given("prior state with RT-001 applied for FileA; second run with FileB", () =>
+        {
+            var dir = TempDir();
+            var schema = OneRenameSchema("RT-001");
+            var schemaPath = WriteSchemaFile(dir, schema);
+            var schemaJson = File.ReadAllText(schemaPath);
+            var schemaHash = MigrationStateStore.ComputeSchemaHash(schemaJson);
+
+            var priorState = new MigrationState
+            {
+                Schema = schemaPath, SchemaHash = schemaHash,
+                StartedAt = DateTimeOffset.UtcNow, LastRunAt = DateTimeOffset.UtcNow,
+                Applied = [new AppliedRewrite("RT-001", "/src/FileA.cs", 3, "OldWidget", "NewWidget")],
+            };
+            MigrationStateStore.Save(schemaPath, priorState);
+
+            var fs = new InMemoryFileSystem().WithFile("/src/FileB.cs", SourceWithOldWidget);
+            BuildStateful(fs).ApplyWithState(schemaPath, schema, ["/src/FileB.cs"]);
+
+            var state = MigrationStateStore.Load(schemaPath);
+            return (hasFileA: state?.Applied.Any(a => a.File == "/src/FileA.cs") ?? false,
+                    hasFileB: state?.Applied.Any(a => a.File == "/src/FileB.cs") ?? false);
+        })
+        .Then("state retains prior FileA entry", t => t.hasFileA)
+        .And("state has new FileB entry", t => t.hasFileB)
+        .AssertPassed();
+}

--- a/docs/migration/engine.md
+++ b/docs/migration/engine.md
@@ -208,3 +208,11 @@ detected. The `Applied` list contains no entries for manual rules.
 
 - **#202** — B-level structural rewriters (`SplitMethod`,
   `ExtractParameterObject`, `PropertyToMethod`, `MoveMember`).
+
+## State-tracking (idempotent re-runs)
+
+`StatefulMigrationEngine` (namespace `WrapGod.Migration.Engine`) wraps the
+base engine with persistent state so that `apply` runs are idempotent. The
+state is stored in a sibling file next to the schema (e.g.
+`schema.json.state.json`). See [Migration State](state.md) for the full
+specification, hash semantics, and API reference.

--- a/docs/migration/examples/sample.state.json
+++ b/docs/migration/examples/sample.state.json
@@ -1,0 +1,53 @@
+{
+  "schema": "mudblazor.6.0-to-7.0.wrapgod-migration.json",
+  "schemaHash": "sha256:a3f1c9e82b4d7f0615ae234d9c8b1f56e3a7d2c0491b8e5f67239a4c1d0e8f32",
+  "startedAt": "2025-06-01T08:00:00+00:00",
+  "lastRunAt": "2025-06-01T09:15:30+00:00",
+  "summary": {
+    "totalRules": 5,
+    "applied": 3,
+    "skipped": 1,
+    "manual": 1
+  },
+  "applied": [
+    {
+      "ruleId": "MUD-001",
+      "file": "src/Components/MyButton.razor.cs",
+      "line": 14,
+      "originalText": "MudButton",
+      "replacedWith": "MudButtonEx"
+    },
+    {
+      "ruleId": "MUD-002",
+      "file": "src/Pages/Index.razor.cs",
+      "line": 8,
+      "originalText": "MudAlert",
+      "replacedWith": "MudAlertV2"
+    },
+    {
+      "ruleId": "MUD-004",
+      "file": "src/Layouts/MainLayout.razor.cs",
+      "line": 22,
+      "originalText": "MudThemeProvider",
+      "replacedWith": "MudThemeProviderV3"
+    }
+  ],
+  "skipped": [
+    {
+      "ruleId": "MUD-005",
+      "file": "src/Pages/Counter.razor.cs",
+      "line": 0,
+      "reason": "no match found in file"
+    }
+  ],
+  "manual": [
+    {
+      "ruleId": "MUD-003",
+      "note": "Manually rename constructor parameter 'Color' to 'ButtonColor' — cannot be inferred automatically",
+      "matchedFiles": [
+        "src/Pages/Custom.razor.cs",
+        "src/Components/Toolbar.razor.cs"
+      ]
+    }
+  ]
+}

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -8,3 +8,4 @@ Strategies and automation for migrating codebases between library versions and a
 - [Migration Engine](engine.md) — `WrapGod.Migration.Engine` rewrite pipeline contracts (`IRuleRewriter`, `RewriteContext`, `MigrationResult`)
 - [Schema Generation](schema-generation.md) — `MigrationSchemaGenerator.FromDiff` — diff → schema mapping, similarity thresholds, deterministic IDs
 - [A-Level Rewriters](rewriters.md) — Seven concrete `IRuleRewriter` implementations: `RenameType`, `RenameNamespace`, `RenameMember`, `ChangeParameter`, `RemoveMember`, `AddRequiredParameter`, `ChangeTypeReference`
+- [Migration State](state.md) — `MigrationState`, `MigrationStateStore`, `StatefulMigrationEngine`: state file location, SHA-256 schema hash, idempotent re-runs, corruption recovery

--- a/docs/migration/state.md
+++ b/docs/migration/state.md
@@ -1,0 +1,169 @@
+# Migration State
+
+`WrapGod.Migration.Engine.State` implements persistent state tracking so that
+`apply` runs are **idempotent** — re-running on the same codebase skips rules
+that have already been applied.
+
+## State file location
+
+The state file sits next to the schema file and uses the schema filename with
+`.state.json` appended:
+
+```
+migrations/
+  mudblazor.6.0-to-7.0.wrapgod-migration.json          ← schema
+  mudblazor.6.0-to-7.0.wrapgod-migration.json.state.json  ← state (auto-created)
+```
+
+The `MigrationStateStore.GetStatePath(schemaPath)` helper computes this path.
+
+> **Git guidance:** commit the state file alongside the schema. This makes
+> the migration history visible in pull requests and enables `migrate status`
+> to show progress across branches.
+
+## State schema (JSON)
+
+```json
+{
+  "schema": "path/to/schema.json",
+  "schemaHash": "sha256:a3f1c9...",
+  "startedAt": "2025-06-01T00:00:00+00:00",
+  "lastRunAt":  "2025-06-01T12:34:56+00:00",
+  "summary": {
+    "totalRules": 5,
+    "applied": 3,
+    "skipped": 1,
+    "manual": 1
+  },
+  "applied": [
+    {
+      "ruleId": "MUD-001",
+      "file": "src/Components/MyButton.razor.cs",
+      "line": 14,
+      "originalText": "MudButton",
+      "replacedWith": "MudButtonEx"
+    }
+  ],
+  "skipped": [
+    {
+      "ruleId": "MUD-002",
+      "file": "src/Pages/Index.razor.cs",
+      "line": 0,
+      "reason": "no match found"
+    }
+  ],
+  "manual": [
+    {
+      "ruleId": "MUD-003",
+      "note": "Manually rename constructor parameter 'Color' to 'ButtonColor'",
+      "matchedFiles": ["src/Pages/Custom.razor.cs"]
+    }
+  ]
+}
+```
+
+### Field reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema` | string | Path to the schema file. Used for orphan detection. |
+| `schemaHash` | string | SHA-256 hash of schema content (see [Hash semantics](#hash-semantics)). |
+| `startedAt` | ISO-8601 | Timestamp of the first `apply` run for this schema. |
+| `lastRunAt` | ISO-8601 | Timestamp of the most recent `apply` run. |
+| `summary` | object | Aggregated counts from the last run. |
+| `applied[]` | array | Rewrites applied across all runs (append-only, de-duped). |
+| `skipped[]` | array | Rewrites skipped during the most recent run (replaced each run). |
+| `manual[]` | array | Manual-confidence rules identified during the most recent run (replaced each run). |
+
+## Hash semantics
+
+Before hashing, schema content is normalised:
+
+1. CRLF and bare CR line endings are replaced with LF.
+2. Trailing whitespace is trimmed from each line.
+
+This makes the hash insensitive to git's `autocrlf` setting and editor-introduced
+trailing spaces.
+
+**Important:** reordering rules in the schema **does** change the hash (the hash
+is content-sensitive, not semantically aware). A changed hash causes all rules to
+be re-evaluated on the next run.
+
+```csharp
+string hash = MigrationStateStore.ComputeSchemaHash(schemaJson);
+// Returns: "sha256:a3f1c9..."
+```
+
+## Idempotency guarantees
+
+On each `apply` run `StatefulMigrationEngine`:
+
+1. Loads the state file (returns `null` if missing or corrupt).
+2. Computes the current schema hash.
+3. Compares hashes:
+   - **Same hash** → skips `(ruleId, file)` pairs already in `applied`.
+   - **Different hash** → re-evaluates all rules (schema changed).
+4. Merges the new run result into the existing state:
+   - `applied` — append-only, de-duplicated by `(ruleId, file)`.
+   - `skipped` — replaced wholesale.
+   - `manual` — replaced wholesale.
+5. Writes the merged state atomically (`.tmp` file → rename).
+
+## List semantics in detail
+
+| List | Policy | Rationale |
+|------|--------|-----------|
+| `applied` | Append-only, de-dup by `(ruleId, file)` | Preserves history across partial runs. |
+| `skipped` | Replaced each run | Skipped reasons can change as rewriters improve. |
+| `manual` | Replaced each run | Reflects current schema's manual rules. |
+
+## Recovery from corruption
+
+If the state file contains invalid JSON (e.g. interrupted write from a previous
+run), `MigrationStateStore.Load` returns `null` and `StatefulMigrationEngine`
+proceeds as a fresh full run. The next successful run overwrites the corrupt file
+with a valid state.
+
+The atomic write strategy (write to `.tmp`, then `File.Move`) minimises the
+chance of corruption in the first place — a partial write leaves a `.tmp` orphan
+that is overwritten on the next save, not a corrupt state file.
+
+## Public API
+
+```csharp
+// Locate the state file
+string statePath = MigrationStateStore.GetStatePath(schemaPath);
+
+// Load (null if missing/corrupt)
+MigrationState? state = MigrationStateStore.Load(schemaPath);
+
+// Save (atomic, creates parent dirs)
+MigrationStateStore.Save(schemaPath, state);
+
+// Compute hash
+string hash = MigrationStateStore.ComputeSchemaHash(schemaJson);
+
+// Check if a rule+file was already applied
+bool skip = state.IsAlreadyApplied(ruleId, filePath);
+
+// Check if schema changed
+bool changed = state.SchemaHasChanged(currentHash);
+
+// Produce updated state after a run
+MigrationState updated = state.Merge(migrationResult, currentHash);
+
+// High-level stateful engine
+var stateful = new StatefulMigrationEngine(engine);
+MigrationResult result = stateful.ApplyWithState(schemaPath, schema, files);
+MigrationResult dryResult = stateful.DryRunWithState(schemaPath, schema, files);
+```
+
+## Example: sample state file
+
+See [`docs/migration/examples/sample.state.json`](examples/sample.state.json) for a
+representative state file.
+
+## See also
+
+- [Migration Engine](engine.md) — `MigrationEngine`, `IRuleRewriter`, `RewriteContext`
+- [Migration Schema](schema.md) — schema model and rule kinds

--- a/docs/migration/state.md
+++ b/docs/migration/state.md
@@ -120,13 +120,31 @@ On each `apply` run `StatefulMigrationEngine`:
 ## Recovery from corruption
 
 If the state file contains invalid JSON (e.g. interrupted write from a previous
-run), `MigrationStateStore.Load` returns `null` and `StatefulMigrationEngine`
-proceeds as a fresh full run. The next successful run overwrites the corrupt file
-with a valid state.
+run), `MigrationStateStore.Load(schemaPath, out wasCorrupt, out backupPath)`:
+
+1. Archives the corrupt file to `{name}.state.json.bak` (overwriting any prior
+   `.bak`).
+2. Sets `wasCorrupt = true` and `backupPath = <archived path>`.
+3. Returns `null` so callers can re-run from scratch.
+
+`StatefulMigrationEngine.ApplyWithState` consumes this and emits a synthetic
+`SkippedRewrite` into the returned `MigrationResult`:
+
+| Field | Value |
+|-------|-------|
+| `RuleId` | `"<state>"` |
+| `File` | `"<state>"` |
+| `Line` | `0` |
+| `Reason` | `"State file was corrupt and archived to <bakpath>. Re-evaluating all rules."` |
+
+This makes the recovery visible to downstream consumers such as
+`migrate status` (#200), audit logs, and CI output.
 
 The atomic write strategy (write to `.tmp`, then `File.Move`) minimises the
-chance of corruption in the first place — a partial write leaves a `.tmp` orphan
-that is overwritten on the next save, not a corrupt state file.
+chance of corruption in the first place. If `File.Move` itself fails (e.g.
+destination locked or replaced by a directory), the `.tmp` orphan is deleted on
+a best-effort basis before the exception propagates so no stale `.tmp` files
+accumulate on disk.
 
 ## Public API
 
@@ -136,6 +154,10 @@ string statePath = MigrationStateStore.GetStatePath(schemaPath);
 
 // Load (null if missing/corrupt)
 MigrationState? state = MigrationStateStore.Load(schemaPath);
+
+// Load with corruption-recovery signalling
+MigrationState? state = MigrationStateStore.Load(
+    schemaPath, out bool wasCorrupt, out string? backupPath);
 
 // Save (atomic, creates parent dirs)
 MigrationStateStore.Save(schemaPath, state);


### PR DESCRIPTION
## Summary

Implements #197. Adds persistent migration state tracking so `apply` runs are idempotent across sessions.

- `MigrationState` + `MigrationStateStore` in `WrapGod.Migration.Engine.State` — SHA-256 schema hash, atomic `.tmp`-rename writes, graceful corruption recovery
- `StatefulMigrationEngine` — wraps `MigrationEngine` with load → run → merge → save lifecycle
- `MigrationEngine.Apply(schema, files, alreadyApplied)` internal overload — filters already-applied `(ruleId, file)` pairs
- `RewriteContext.IsAlreadyApplied(ruleId)` predicate consumed by the engine run loop
- State file location: `{schemaPath}.state.json` (sibling to schema)
- `applied[]` list is append-only + de-duped; `skipped[]` and `manual[]` replaced wholesale each run
- 34 TinyBDD scenarios: 14 unit (state/serializer/hash), 7 store (load/save/atomic), 13 engine integration
- `docs/migration/state.md` published; cross-linked from `index.md` and `engine.md`

Closes #197.

## Test plan

- [x] `dotnet build WrapGod.slnx -c Release -warnaserror` — 0 warnings, 0 errors
- [x] `dotnet test WrapGod.slnx -c Release` — 770 passed, 0 failed (1 network-gated skip)
- [x] New state tests: 34/34 green
- [x] No regressions in existing 736 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)