### PR TITLE
feat(cli): #201 migrate verify (semantic verification)

### DIFF
--- a/WrapGod.Cli/MigrateCommandBuilder.cs
+++ b/WrapGod.Cli/MigrateCommandBuilder.cs
@@ -16,6 +16,7 @@ internal static class MigrateCommandBuilder
             MigrateGenerateCommand.Create(),
             MigrateApplyCommand.Create(),
             MigrateStatusCommand.Create(),
+            MigrateVerifyCommand.Create(),
         };
 
         return migrateCommand;

--- a/WrapGod.Cli/MigrateVerifyCommand.cs
+++ b/WrapGod.Cli/MigrateVerifyCommand.cs
@@ -1,0 +1,527 @@
+using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using WrapGod.Cli.Verification;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine.State;
+
+namespace WrapGod.Cli;
+
+/// <summary>
+/// Implements <c>wrap-god migrate verify [options]</c>.
+///
+/// Optionally invokes <c>dotnet build</c>, parses the compiler diagnostic output, and
+/// attributes each diagnostic to the nearest migration rule in the state file via
+/// ±3-line proximity. The command is explicitly non-gating — it never blocks
+/// <c>migrate apply</c> and always exits 0 unless argument parsing fails.
+///
+/// Exit codes:
+/// <list type="bullet">
+///   <item><description>0 – verify ran (even if there are attributed errors)</description></item>
+///   <item><description>1 – IO error: baseline file not found, schema not found, etc.</description></item>
+///   <item><description>2 – bad arguments</description></item>
+/// </list>
+/// </summary>
+internal static class MigrateVerifyCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented        = true,
+    };
+
+    // ── Command factory ──────────────────────────────────────────────────────
+
+    public static Command Create() => Create(new DotnetBuildRunner());
+
+    internal static Command Create(IBuildRunner buildRunner)
+    {
+        var schemaOption = new Option<FileInfo?>(
+            ["--schema", "-s"],
+            "Path to the migration schema JSON file. The state file is the sibling <schema>.state.json. " +
+            "When omitted, the command searches --project-dir for *.wrapgod-migration.json.state.json files.");
+
+        var projectDirOption = new Option<DirectoryInfo?>(
+            ["--project-dir", "-p"],
+            "Project root directory. Used to find the .csproj and to auto-detect state files when " +
+            "--schema is omitted. Defaults to the current directory.");
+
+        var noBuildOption = new Option<bool>(
+            "--no-build",
+            "Skip the dotnet build invocation. Only reports the state-file summary. " +
+            "Useful in CI when the build runs as a separate job.");
+
+        var jsonOption = new Option<bool>(
+            "--json",
+            "Emit output as JSON instead of human-readable text.");
+
+        var verboseOption = new Option<bool>(
+            ["--verbose", "-v"],
+            "Include per-diagnostic details in human-readable mode.");
+
+        var buildConfigOption = new Option<string>(
+            "--build-config",
+            () => "Debug",
+            "Build configuration passed to dotnet build (Debug or Release).");
+
+        var baselineOption = new Option<FileInfo?>(
+            "--baseline",
+            "Path to a pre-migration diagnostic baseline JSON file. " +
+            "When provided, diagnostics present in the baseline are classified as pre-existing.");
+
+        var command = new Command("verify", "Optionally build the project and correlate compiler diagnostics to migration rules")
+        {
+            schemaOption,
+            projectDirOption,
+            noBuildOption,
+            jsonOption,
+            verboseOption,
+            buildConfigOption,
+            baselineOption,
+        };
+
+        command.SetHandler(async (context) =>
+        {
+            var schema      = context.ParseResult.GetValueForOption(schemaOption);
+            var projectDir  = context.ParseResult.GetValueForOption(projectDirOption);
+            var noBuild     = context.ParseResult.GetValueForOption(noBuildOption);
+            var json        = context.ParseResult.GetValueForOption(jsonOption);
+            var verbose     = context.ParseResult.GetValueForOption(verboseOption);
+            var buildConfig = context.ParseResult.GetValueForOption(buildConfigOption)!;
+            var baseline    = context.ParseResult.GetValueForOption(baselineOption);
+
+            context.ExitCode = await HandleAsync(
+                schema, projectDir, noBuild, json, verbose, buildConfig, baseline,
+                buildRunner, context.GetCancellationToken());
+        });
+
+        return command;
+    }
+
+    // ── Handler ─────────────────────────────────────────────────────────────
+
+    internal static async Task<int> HandleAsync(
+        FileInfo? schemaOption,
+        DirectoryInfo? projectDirOption,
+        bool noBuild,
+        bool jsonOutput,
+        bool verbose,
+        string buildConfig,
+        FileInfo? baselineFile,
+        IBuildRunner buildRunner,
+        CancellationToken cancellationToken = default)
+    {
+        var projectDir = projectDirOption?.FullName ?? Directory.GetCurrentDirectory();
+
+        // ── 1. Resolve schema path ───────────────────────────────────────────
+        string? schemaPath = null;
+        if (schemaOption is not null)
+        {
+            schemaPath = schemaOption.FullName;
+            if (!File.Exists(schemaPath))
+            {
+                Console.Error.WriteLine($"Error: schema file not found: {schemaPath}");
+                return 1;
+            }
+        }
+        else
+        {
+            // Auto-detect: look for *.wrapgod-migration.json.state.json in project-dir
+            schemaPath = AutoDetectSchemaPath(projectDir);
+            if (schemaPath is null)
+            {
+                // Graceful: no state file → nothing to verify.
+                Console.Error.WriteLine("No migration state found. Run 'migrate apply' first.");
+                return 0;
+            }
+        }
+
+        // ── 2. Load state ────────────────────────────────────────────────────
+        var state = MigrationStateStore.Load(schemaPath, out var wasCorrupt, out _);
+        if (wasCorrupt)
+        {
+            Console.Error.WriteLine("Warning: migration state file was corrupt and has been archived. " +
+                "Re-run 'migrate apply' to regenerate state.");
+            // Degraded but non-fatal
+        }
+
+        if (state is null)
+        {
+            Console.Error.WriteLine("No migration state; nothing to verify.");
+            return 0;
+        }
+
+        // ── 3. Schema hash check ─────────────────────────────────────────────
+        bool schemaChanged = false;
+        if (File.Exists(schemaPath))
+        {
+            try
+            {
+                var schemaJson = await File.ReadAllTextAsync(schemaPath, cancellationToken).ConfigureAwait(false);
+                var currentHash = MigrationStateStore.ComputeSchemaHash(schemaJson);
+                schemaChanged = state.SchemaHasChanged(currentHash);
+            }
+            catch (IOException)
+            {
+                // Best-effort — skip hash check
+            }
+        }
+
+        // ── 4. Load baseline ─────────────────────────────────────────────────
+        IReadOnlyList<Verification.CompilerDiagnostic>? baselineDiags = null;
+        if (baselineFile is not null)
+        {
+            if (!baselineFile.Exists)
+            {
+                Console.Error.WriteLine($"Error: baseline file not found: {baselineFile.FullName}");
+                return 1;
+            }
+
+            try
+            {
+                var baselineJson = await File.ReadAllTextAsync(baselineFile.FullName, cancellationToken)
+                    .ConfigureAwait(false);
+                baselineDiags = LoadBaselineDiagnostics(baselineJson);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error reading baseline file: {ex.Message}");
+                return 1;
+            }
+        }
+
+        // ── 5. Build step ────────────────────────────────────────────────────
+        BuildResult? buildResult = null;
+        IReadOnlyList<Verification.CompilerDiagnostic> diagnostics = [];
+
+        if (!noBuild)
+        {
+            buildResult = await buildRunner.RunAsync(projectDir, buildConfig, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!buildResult.Launched)
+            {
+                Console.Error.WriteLine($"dotnet build not found; skipping verify. ({buildResult.LaunchError})");
+                // Graceful degradation — exit 0 per plan §a.
+                if (jsonOutput)
+                    PrintJson(schemaPath, projectDir, state, schemaChanged, null, null, [], []);
+                return 0;
+            }
+
+            // Parse diagnostics; log unparseable lines as warnings when verbose.
+            diagnostics = ParseDiagnosticsWithWarnings(buildResult.Output, verbose);
+        }
+
+        // ── 6. Attribute diagnostics to rules ────────────────────────────────
+        var attributions = RuleAttributor.Attribute(diagnostics, state.Applied, baselineDiags);
+
+        // ── 7. Emit report ───────────────────────────────────────────────────
+        if (jsonOutput)
+            PrintJson(schemaPath, projectDir, state, schemaChanged, buildResult, noBuild, attributions, baselineDiags ?? []);
+        else
+            PrintHuman(schemaPath, projectDir, state, schemaChanged, buildResult, noBuild, attributions, baselineDiags ?? [], verbose);
+
+        return 0;
+    }
+
+    // ── Auto-detect helpers ──────────────────────────────────────────────────
+
+    private static string? AutoDetectSchemaPath(string projectDir)
+    {
+        // Search projectDir and its parent for *.wrapgod-migration.json.state.json
+        var stateFiles = new List<string>();
+
+        var searchDirs = new[] { projectDir, Directory.GetParent(projectDir)?.FullName }
+            .Where(d => d is not null)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        foreach (var dir in searchDirs)
+        {
+            if (dir is null) continue;
+            try
+            {
+                stateFiles.AddRange(
+                    Directory.GetFiles(dir, "*.wrapgod-migration.json.state.json",
+                        SearchOption.TopDirectoryOnly));
+            }
+            catch (IOException)
+            {
+                // Skip unreadable directories
+            }
+        }
+
+        if (stateFiles.Count == 0)
+            return null;
+
+        // Pick most recently written state file; strip the .state.json suffix to get the schema path.
+        var mostRecent = stateFiles
+            .OrderByDescending(f => new FileInfo(f).LastWriteTimeUtc)
+            .First();
+
+        // State file is <schema>.state.json
+        const string stateSuffix = ".state.json";
+        if (mostRecent.EndsWith(stateSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            var candidateSchema = mostRecent[..^stateSuffix.Length];
+            if (File.Exists(candidateSchema))
+                return candidateSchema;
+        }
+
+        // Return the state file itself so Load() can find it (GetStatePath would append .state.json again).
+        // In this case we trust the state file was written correctly.
+        return null;
+    }
+
+    // ── Diagnostic helpers ───────────────────────────────────────────────────
+
+    private static List<Verification.CompilerDiagnostic> ParseDiagnosticsWithWarnings(
+        string buildOutput, bool verbose)
+    {
+        var parsed = new List<Verification.CompilerDiagnostic>();
+        var regex  = Verification.DiagnosticParser.Parse(buildOutput);
+        parsed.AddRange(regex);
+
+        if (verbose)
+        {
+            // Log lines that matched nothing but look like they could be diagnostics.
+            foreach (var line in buildOutput.Split('\n'))
+            {
+                var trimmed = line.Trim();
+                if (trimmed.Length == 0) continue;
+                if (trimmed.Contains("): error") || trimmed.Contains("): warning"))
+                {
+                    // Check if this line produced a parsed diagnostic
+                    var alreadyParsed = parsed.Any(d => d.RawLine == line.TrimEnd('\r'));
+                    if (!alreadyParsed)
+                        Console.Error.WriteLine($"[verify] Could not parse diagnostic line: {trimmed}");
+                }
+            }
+        }
+
+        return parsed;
+    }
+
+    private static readonly JsonSerializerOptions BaselineDeserializeOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static List<Verification.CompilerDiagnostic> LoadBaselineDiagnostics(string json)
+    {
+        // Baseline is a JSON array of objects with properties matching CompilerDiagnostic.
+        var items = JsonSerializer.Deserialize<BaselineDiagnosticDto[]>(
+            json,
+            BaselineDeserializeOptions);
+
+        if (items is null) return [];
+
+        return items.Select(d => new Verification.CompilerDiagnostic
+        {
+            FilePath = d.FilePath,
+            Line     = d.Line,
+            Column   = d.Column,
+            Severity = Enum.TryParse<Verification.DiagnosticSeverity>(d.Severity, ignoreCase: true, out var sev)
+                ? sev : Verification.DiagnosticSeverity.Error,
+            Code     = d.Code ?? string.Empty,
+            Message  = d.Message ?? string.Empty,
+            RawLine  = string.Empty,
+        }).ToList();
+    }
+
+    // ── Human-readable output ────────────────────────────────────────────────
+
+    private static void PrintHuman(
+        string schemaPath,
+        string projectDir,
+        MigrationState state,
+        bool schemaChanged,
+        BuildResult? buildResult,
+        bool noBuild,
+        IReadOnlyList<DiagnosticAttribution> attributions,
+        IReadOnlyList<Verification.CompilerDiagnostic> baseline,
+        bool verbose)
+    {
+        const string header = "WrapGod migrate verify";
+        Console.WriteLine(header);
+        Console.WriteLine(new string('-', header.Length));
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Project:  {0}", projectDir));
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Schema:   {0}", Path.GetFileName(schemaPath)));
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Baseline: {0}", baseline.Count > 0 ? $"{baseline.Count} pre-migration diagnostics" : "(none)"));
+        Console.WriteLine();
+
+        if (schemaChanged)
+            Console.WriteLine("WARNING: Schema has changed since last apply. Attribution may be inaccurate.");
+
+        if (noBuild)
+        {
+            Console.WriteLine("Build:    SKIPPED (--no-build)");
+            PrintStateSummary(state);
+            return;
+        }
+
+        if (buildResult is null)
+        {
+            Console.WriteLine("Build:    NOT RUN");
+            return;
+        }
+
+        var errors   = attributions.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Error);
+        var warnings = attributions.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Warning);
+        var buildStatus = buildResult.ExitCode == 0 ? "SUCCEEDED" : "FAILED";
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+            "Build:    {0} ({1} error(s), {2} warning(s))", buildStatus, errors, warnings));
+        Console.WriteLine();
+
+        // Attribution section
+        var attributed = attributions
+            .Where(a => a.AttributedRuleId is not null && !a.IsPreExisting)
+            .ToList();
+        var unattributed = attributions
+            .Where(a => a.AttributedRuleId is null && !a.IsPreExisting)
+            .ToList();
+        var preExisting = attributions
+            .Where(a => a.IsPreExisting)
+            .ToList();
+
+        Console.WriteLine("Attribution:");
+
+        if (attributed.Count == 0 && unattributed.Count == 0 && preExisting.Count == 0)
+        {
+            Console.WriteLine("  No errors or warnings.");
+            return;
+        }
+
+        // Group attributed by rule id
+        var byRule = attributed
+            .GroupBy(a => a.AttributedRuleId!, StringComparer.Ordinal)
+            .OrderBy(g => g.Key, StringComparer.Ordinal);
+
+        foreach (var group in byRule)
+        {
+            var errorCount = group.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Error);
+            var warnCount  = group.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Warning);
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                "  {0}   {1} error(s), {2} warning(s)", group.Key, errorCount, warnCount));
+
+            if (verbose)
+            {
+                foreach (var a in group.OrderBy(a => a.Diagnostic.FilePath, StringComparer.OrdinalIgnoreCase)
+                                       .ThenBy(a => a.Diagnostic.Line))
+                {
+                    Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                        "    {0}:{1}  {2} {3}",
+                        a.Diagnostic.FilePath, a.Diagnostic.Line,
+                        a.Diagnostic.Code, a.Diagnostic.Message));
+                }
+            }
+        }
+
+        var unattributedErrors   = unattributed.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Error);
+        var unattributedWarnings = unattributed.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Warning);
+        if (unattributed.Count > 0)
+        {
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                "  Unattributed: {0} error(s), {1} warning(s) (likely pre-existing or unrelated)",
+                unattributedErrors, unattributedWarnings));
+        }
+
+        if (preExisting.Count > 0)
+        {
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                "  Pre-existing (from baseline): {0} diagnostic(s)", preExisting.Count));
+        }
+    }
+
+    private static void PrintStateSummary(MigrationState state)
+    {
+        Console.WriteLine();
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+            "State:  {0} applied, {1} skipped, {2} manual",
+            state.Summary.Applied, state.Summary.Skipped, state.Summary.Manual));
+    }
+
+    // ── JSON output ──────────────────────────────────────────────────────────
+
+    private static void PrintJson(
+        string schemaPath,
+        string projectDir,
+        MigrationState state,
+        bool schemaChanged,
+        BuildResult? buildResult,
+        bool? noBuild,
+        IReadOnlyList<DiagnosticAttribution> attributions,
+        IReadOnlyList<Verification.CompilerDiagnostic> baseline)
+    {
+        var attribution = attributions
+            .Where(a => a.AttributedRuleId is not null && !a.IsPreExisting)
+            .GroupBy(a => a.AttributedRuleId!, StringComparer.Ordinal)
+            .Select(g => new
+            {
+                ruleId   = g.Key,
+                errors   = g.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Error),
+                warnings = g.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Warning),
+                diagnostics = g.Select(a => new
+                {
+                    file     = a.Diagnostic.FilePath,
+                    line     = a.Diagnostic.Line,
+                    code     = a.Diagnostic.Code,
+                    message  = a.Diagnostic.Message,
+                    severity = a.Diagnostic.Severity.ToString().ToLowerInvariant(),
+                }).ToList(),
+            })
+            .OrderBy(e => e.ruleId, StringComparer.Ordinal)
+            .ToList();
+
+        var unattributed = attributions
+            .Where(a => a.AttributedRuleId is null && !a.IsPreExisting)
+            .Select(a => new
+            {
+                file     = a.Diagnostic.FilePath,
+                line     = a.Diagnostic.Line,
+                code     = a.Diagnostic.Code,
+                message  = a.Diagnostic.Message,
+                severity = a.Diagnostic.Severity.ToString().ToLowerInvariant(),
+            })
+            .ToList();
+
+        var output = new
+        {
+            schema        = Path.GetFileName(schemaPath),
+            projectDir,
+            schemaChanged,
+            noBuild       = noBuild ?? false,
+            build = buildResult is null ? null : (object)new
+            {
+                exitCode = buildResult.ExitCode,
+                launched = buildResult.Launched,
+                errors   = attributions.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Error),
+                warnings = attributions.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Warning),
+            },
+            baselineDiagnosticsLoaded = baseline.Count,
+            state = new
+            {
+                applied = state.Summary.Applied,
+                skipped = state.Summary.Skipped,
+                manual  = state.Summary.Manual,
+            },
+            attribution,
+            unattributed,
+        };
+
+        Console.WriteLine(JsonSerializer.Serialize(output, JsonOptions));
+    }
+
+    // ── Private DTOs ─────────────────────────────────────────────────────────
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private sealed class BaselineDiagnosticDto
+    {
+        public string? FilePath { get; init; }
+        public int Line { get; init; }
+        public int Column { get; init; }
+        public string? Severity { get; init; }
+        public string? Code { get; init; }
+        public string? Message { get; init; }
+    }
+}

--- a/WrapGod.Cli/MigrateVerifyCommand.cs
+++ b/WrapGod.Cli/MigrateVerifyCommand.cs
@@ -226,6 +226,20 @@ internal static class MigrateVerifyCommand
 
     // ── Auto-detect helpers ──────────────────────────────────────────────────
 
+    /// <summary>
+    /// Searches <paramref name="projectDir"/> and its parent directory for
+    /// <c>*.wrapgod-migration.json.state.json</c> files and returns the schema path
+    /// associated with the most recently written state file.
+    /// </summary>
+    /// <returns>
+    /// The schema path (i.e. the state path with the <c>.state.json</c> suffix
+    /// stripped) when both the state and its schema sibling exist. When the schema
+    /// sibling is missing, returns the state-file path itself so the caller can
+    /// pass it to <see cref="MigrationStateStore.Load(string)"/> directly —
+    /// <c>Load</c> takes a schema path and appends <c>.state.json</c>, so we hand
+    /// it the original schema path. Returns <see langword="null"/> only when no
+    /// state files are found at all.
+    /// </returns>
     private static string? AutoDetectSchemaPath(string projectDir)
     {
         // Search projectDir and its parent for *.wrapgod-migration.json.state.json
@@ -259,17 +273,23 @@ internal static class MigrateVerifyCommand
             .OrderByDescending(f => new FileInfo(f).LastWriteTimeUtc)
             .First();
 
-        // State file is <schema>.state.json
         const string stateSuffix = ".state.json";
         if (mostRecent.EndsWith(stateSuffix, StringComparison.OrdinalIgnoreCase))
         {
+            // Strip the .state.json suffix to recover the schema path.
             var candidateSchema = mostRecent[..^stateSuffix.Length];
-            if (File.Exists(candidateSchema))
-                return candidateSchema;
+
+            // Return the schema path even when the schema file is missing. The state file
+            // contains enough information for verify to run in state-only mode (similar to
+            // --no-build). The caller's schema-hash check is wrapped in an existence guard
+            // so a missing schema simply skips the schema-changed warning. Returning the
+            // schema path here lets MigrationStateStore.Load() find the state sibling.
+            return candidateSchema;
         }
 
-        // Return the state file itself so Load() can find it (GetStatePath would append .state.json again).
-        // In this case we trust the state file was written correctly.
+        // Last-resort: the state file did not end with .state.json (shouldn't happen
+        // given the glob filter, but defensive). Return null to fall back to the
+        // "no migration state" branch.
         return null;
     }
 
@@ -485,19 +505,44 @@ internal static class MigrateVerifyCommand
             })
             .ToList();
 
+        // Build a structured sentinel for the `build` key so consumers never have to
+        // null-deref. When --no-build is set OR the build runner failed to launch,
+        // `skipped` is true and `exitCode` is null; otherwise it carries the real
+        // exit code + diagnostic counts.
+        var skipped     = noBuild == true || buildResult is null;
+        var skipReason  = noBuild == true
+            ? "--no-build flag set"
+            : buildResult is null
+                ? "build was not invoked"
+                : null;
+
+        object buildBlock = skipped
+            ? new
+            {
+                skipped     = true,
+                reason      = skipReason,
+                exitCode    = (int?)null,
+                launched    = (bool?)null,
+                errors      = 0,
+                warnings    = 0,
+            }
+            : new
+            {
+                skipped     = false,
+                reason      = (string?)null,
+                exitCode    = (int?)buildResult!.ExitCode,
+                launched    = (bool?)buildResult!.Launched,
+                errors      = attributions.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Error),
+                warnings    = attributions.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Warning),
+            };
+
         var output = new
         {
             schema        = Path.GetFileName(schemaPath),
             projectDir,
             schemaChanged,
             noBuild       = noBuild ?? false,
-            build = buildResult is null ? null : (object)new
-            {
-                exitCode = buildResult.ExitCode,
-                launched = buildResult.Launched,
-                errors   = attributions.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Error),
-                warnings = attributions.Count(a => a.Diagnostic.Severity == Verification.DiagnosticSeverity.Warning),
-            },
+            build         = buildBlock,
             baselineDiagnosticsLoaded = baseline.Count,
             state = new
             {

--- a/WrapGod.Cli/Verification/CompilerDiagnostic.cs
+++ b/WrapGod.Cli/Verification/CompilerDiagnostic.cs
@@ -1,0 +1,40 @@
+namespace WrapGod.Cli.Verification;
+
+/// <summary>The severity of a compiler diagnostic.</summary>
+internal enum DiagnosticSeverity
+{
+    Error,
+    Warning,
+    Info,
+}
+
+/// <summary>
+/// A single compiler diagnostic parsed from <c>dotnet build</c> output.
+/// </summary>
+internal sealed class CompilerDiagnostic
+{
+    /// <summary>
+    /// The absolute (or relative) path to the file that produced the diagnostic,
+    /// or <see langword="null"/> when the diagnostic has no file context
+    /// (e.g. MSBuild-level errors, linker errors).
+    /// </summary>
+    public string? FilePath { get; init; }
+
+    /// <summary>1-based line number, or <c>0</c> when unavailable.</summary>
+    public int Line { get; init; }
+
+    /// <summary>1-based column number, or <c>0</c> when unavailable.</summary>
+    public int Column { get; init; }
+
+    /// <summary>Error, Warning, or Info.</summary>
+    public DiagnosticSeverity Severity { get; init; }
+
+    /// <summary>Diagnostic code such as <c>CS0103</c>.</summary>
+    public string Code { get; init; } = string.Empty;
+
+    /// <summary>Human-readable diagnostic message.</summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>The original unparsed line for debugging purposes.</summary>
+    public string RawLine { get; init; } = string.Empty;
+}

--- a/WrapGod.Cli/Verification/DiagnosticAttribution.cs
+++ b/WrapGod.Cli/Verification/DiagnosticAttribution.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using WrapGod.Migration.Engine;
 
 namespace WrapGod.Cli.Verification;
@@ -30,9 +31,33 @@ internal sealed class DiagnosticAttribution
 /// source location against the <see cref="AppliedRewrite"/> entries from the state file,
 /// using a ±3 line proximity window.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Path comparison:</strong> Paths are normalised to forward-slash separators
+/// and compared case-insensitively on Windows and case-sensitively on Linux/macOS to
+/// match the native filesystem semantics. See <see cref="GetPathComparer"/>.
+/// </para>
+/// <para>
+/// <strong>Tiebreak:</strong> When multiple rewrites fall within ±3 lines of a single
+/// diagnostic, the one with the smallest absolute line distance wins. If two are
+/// equidistant, the rewrite with the latest <see cref="AppliedRewrite.AppliedAt"/>
+/// timestamp wins (per MIGRATION-ENGINE-PLAN.md §201.a). When timestamps are equal
+/// (e.g. legacy state files that pre-date the AppliedAt field), the later index in the
+/// state's Applied list wins as a secondary tiebreak.
+/// </para>
+/// </remarks>
 internal static class RuleAttributor
 {
     private const int ProximityWindow = 3;
+
+    /// <summary>
+    /// Returns the appropriate path comparer for the current platform:
+    /// case-insensitive on Windows, case-sensitive elsewhere.
+    /// </summary>
+    private static StringComparer GetPathComparer() =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
 
     /// <summary>
     /// Attributes each diagnostic in <paramref name="diagnostics"/> to the nearest
@@ -54,13 +79,16 @@ internal static class RuleAttributor
         ArgumentNullException.ThrowIfNull(diagnostics);
         ArgumentNullException.ThrowIfNull(appliedRewrites);
 
+        var pathComparer = GetPathComparer();
+
         // Build a quick-lookup set from the baseline.
         var baselineSet = BuildBaselineSet(baselineDiagnostics);
 
         // Group applied rewrites by normalised file path for O(1) lookup.
+        // Group key comparison must use the platform-aware path comparer.
         var rewritesByFile = appliedRewrites
-            .GroupBy(r => NormalisePath(r.File), StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+            .GroupBy(r => NormalisePath(r.File), pathComparer)
+            .ToDictionary(g => g.Key, g => g.ToList(), pathComparer);
 
         var results = new List<DiagnosticAttribution>();
 
@@ -78,10 +106,10 @@ internal static class RuleAttributor
                 if (rewritesByFile.TryGetValue(normFile, out var candidates))
                 {
                     // Find the nearest rewrite within ±3 lines.
-                    // Tiebreak: smallest distance wins; if equal, latest AppliedAt wins.
-                    // AppliedRewrite does not currently carry an AppliedAt timestamp exposed
-                    // by the model, so we use declaration order as the secondary tiebreak
-                    // (later in the list = later applied, consistent with append-only semantics).
+                    // Tiebreak (per MIGRATION-ENGINE-PLAN.md §201.a):
+                    //   1. Smallest absolute distance wins.
+                    //   2. If equal, latest AppliedAt wins.
+                    //   3. If AppliedAt also equal (legacy state files), later index wins.
                     AppliedRewrite? best = null;
                     int bestIdx = -1;
 
@@ -92,12 +120,29 @@ internal static class RuleAttributor
                         if (dist > ProximityWindow)
                             continue;
 
-                        if (dist < bestDistance ||
-                            (dist == bestDistance && idx > bestIdx))
+                        if (dist < bestDistance)
                         {
-                            bestDistance      = dist;
-                            best              = candidate;
-                            bestIdx           = idx;
+                            bestDistance = dist;
+                            best         = candidate;
+                            bestIdx      = idx;
+                            continue;
+                        }
+
+                        if (dist == bestDistance && best is not null)
+                        {
+                            // Compare AppliedAt — latest wins.
+                            // Default-valued AppliedAt (MinValue) on either side means we
+                            // fall back to index-order which equals engine record order.
+                            if (candidate.AppliedAt > best.AppliedAt)
+                            {
+                                best    = candidate;
+                                bestIdx = idx;
+                            }
+                            else if (candidate.AppliedAt == best.AppliedAt && idx > bestIdx)
+                            {
+                                best    = candidate;
+                                bestIdx = idx;
+                            }
                         }
                     }
 

--- a/WrapGod.Cli/Verification/DiagnosticAttribution.cs
+++ b/WrapGod.Cli/Verification/DiagnosticAttribution.cs
@@ -1,0 +1,139 @@
+using WrapGod.Migration.Engine;
+
+namespace WrapGod.Cli.Verification;
+
+/// <summary>The result of attributing a single <see cref="CompilerDiagnostic"/>.</summary>
+internal sealed class DiagnosticAttribution
+{
+    /// <summary>The diagnostic that was attributed.</summary>
+    public CompilerDiagnostic Diagnostic { get; init; } = null!;
+
+    /// <summary>
+    /// The <c>RuleId</c> of the applied rewrite that is closest to this diagnostic,
+    /// or <see langword="null"/> when the diagnostic is unattributed (pre-existing or
+    /// no rewrite within ±3 lines).
+    /// </summary>
+    public string? AttributedRuleId { get; init; }
+
+    /// <summary>Absolute distance in lines between the diagnostic and the attributed rewrite.</summary>
+    public int Distance { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when the diagnostic existed in the baseline snapshot and is
+    /// therefore classified as pre-existing rather than migration-introduced.
+    /// </summary>
+    public bool IsPreExisting { get; init; }
+}
+
+/// <summary>
+/// Attributes compiler diagnostics to migration rules by comparing each diagnostic's
+/// source location against the <see cref="AppliedRewrite"/> entries from the state file,
+/// using a ±3 line proximity window.
+/// </summary>
+internal static class RuleAttributor
+{
+    private const int ProximityWindow = 3;
+
+    /// <summary>
+    /// Attributes each diagnostic in <paramref name="diagnostics"/> to the nearest
+    /// <see cref="AppliedRewrite"/> within ±3 lines of the same file.
+    /// </summary>
+    /// <param name="diagnostics">Parsed compiler diagnostics to attribute.</param>
+    /// <param name="appliedRewrites">Applied rewrites from the migration state file.</param>
+    /// <param name="baselineDiagnostics">
+    /// Optional baseline diagnostics (pre-migration). When provided, diagnostics that appear
+    /// in both <paramref name="diagnostics"/> and <paramref name="baselineDiagnostics"/>
+    /// (matched by file+line+code) are marked <see cref="DiagnosticAttribution.IsPreExisting"/>.
+    /// </param>
+    /// <returns>One <see cref="DiagnosticAttribution"/> per input diagnostic.</returns>
+    public static IReadOnlyList<DiagnosticAttribution> Attribute(
+        IEnumerable<CompilerDiagnostic> diagnostics,
+        IEnumerable<AppliedRewrite> appliedRewrites,
+        IEnumerable<CompilerDiagnostic>? baselineDiagnostics = null)
+    {
+        ArgumentNullException.ThrowIfNull(diagnostics);
+        ArgumentNullException.ThrowIfNull(appliedRewrites);
+
+        // Build a quick-lookup set from the baseline.
+        var baselineSet = BuildBaselineSet(baselineDiagnostics);
+
+        // Group applied rewrites by normalised file path for O(1) lookup.
+        var rewritesByFile = appliedRewrites
+            .GroupBy(r => NormalisePath(r.File), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        var results = new List<DiagnosticAttribution>();
+
+        foreach (var diag in diagnostics)
+        {
+            var isPreExisting = baselineSet.Contains(BaselineKey(diag));
+
+            string? attributedRuleId = null;
+            var bestDistance = int.MaxValue;
+
+            if (diag.FilePath is not null)
+            {
+                var normFile = NormalisePath(diag.FilePath);
+
+                if (rewritesByFile.TryGetValue(normFile, out var candidates))
+                {
+                    // Find the nearest rewrite within ±3 lines.
+                    // Tiebreak: smallest distance wins; if equal, latest AppliedAt wins.
+                    // AppliedRewrite does not currently carry an AppliedAt timestamp exposed
+                    // by the model, so we use declaration order as the secondary tiebreak
+                    // (later in the list = later applied, consistent with append-only semantics).
+                    AppliedRewrite? best = null;
+                    int bestIdx = -1;
+
+                    for (var idx = 0; idx < candidates.Count; idx++)
+                    {
+                        var candidate = candidates[idx];
+                        var dist = Math.Abs(candidate.Line - diag.Line);
+                        if (dist > ProximityWindow)
+                            continue;
+
+                        if (dist < bestDistance ||
+                            (dist == bestDistance && idx > bestIdx))
+                        {
+                            bestDistance      = dist;
+                            best              = candidate;
+                            bestIdx           = idx;
+                        }
+                    }
+
+                    if (best is not null)
+                        attributedRuleId = best.RuleId;
+                }
+            }
+
+            results.Add(new DiagnosticAttribution
+            {
+                Diagnostic       = diag,
+                AttributedRuleId = attributedRuleId,
+                Distance         = attributedRuleId is null ? -1 : bestDistance,
+                IsPreExisting    = isPreExisting,
+            });
+        }
+
+        return results;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string NormalisePath(string path)
+    {
+        // Normalise separators to forward slash for cross-platform key comparison.
+        return path.Replace('\\', '/').Trim();
+    }
+
+    private static string BaselineKey(CompilerDiagnostic d) =>
+        $"{NormalisePath(d.FilePath ?? string.Empty)}|{d.Line}|{d.Code}";
+
+    private static HashSet<string> BuildBaselineSet(IEnumerable<CompilerDiagnostic>? baseline)
+    {
+        if (baseline is null)
+            return [];
+
+        return [.. baseline.Select(BaselineKey)];
+    }
+}

--- a/WrapGod.Cli/Verification/DiagnosticParser.cs
+++ b/WrapGod.Cli/Verification/DiagnosticParser.cs
@@ -24,8 +24,10 @@ internal static partial class DiagnosticParser
 {
     // Pattern: <file>(<line>,<col>): <severity> <code>: <message> [optional project ref]
     // Handles both absolute Unix paths and Windows drive-letter paths.
+    // Code prefix is up to 6 letters to cover MSBuild / NETSDK / NuGet codes
+    // (e.g. NETSDK1138, NU1605, MSB3001) alongside the standard CS#### / VBNC#### / IDE####.
     [GeneratedRegex(
-        @"^(?<file>.+?)\((?<line>\d+),(?<col>\d+)\):\s+(?<sev>error|warning|info)\s+(?<code>[A-Za-z]{1,3}\d+):\s+(?<msg>.+?)(?:\s+\[.*?\])?\s*$",
+        @"^(?<file>.+?)\((?<line>\d+),(?<col>\d+)\):\s+(?<sev>error|warning|info)\s+(?<code>[A-Za-z]{1,6}\d+):\s+(?<msg>.+?)(?:\s+\[.*?\])?\s*$",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex DiagnosticLineRegex();
 

--- a/WrapGod.Cli/Verification/DiagnosticParser.cs
+++ b/WrapGod.Cli/Verification/DiagnosticParser.cs
@@ -1,0 +1,81 @@
+using System.Text.RegularExpressions;
+
+namespace WrapGod.Cli.Verification;
+
+/// <summary>
+/// Parses <c>dotnet build</c> / MSBuild / Roslyn output into structured
+/// <see cref="CompilerDiagnostic"/> records.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The canonical diagnostic line format produced by Roslyn/MSBuild is:
+/// <code>
+/// /path/to/File.cs(42,5): error CS0103: The name 'X' does not exist in the current context [/path/to/proj.csproj]
+/// </code>
+/// This parser handles both Unix-style (<c>/abs/path</c>) and Windows-style
+/// (<c>C:\abs\path</c> or relative) file paths.
+/// </para>
+/// <para>
+/// Lines that do not match the pattern (e.g. MSBuild progress messages) are silently
+/// ignored — they are available to the caller via the raw output string if needed.
+/// </para>
+/// </remarks>
+internal static partial class DiagnosticParser
+{
+    // Pattern: <file>(<line>,<col>): <severity> <code>: <message> [optional project ref]
+    // Handles both absolute Unix paths and Windows drive-letter paths.
+    [GeneratedRegex(
+        @"^(?<file>.+?)\((?<line>\d+),(?<col>\d+)\):\s+(?<sev>error|warning|info)\s+(?<code>[A-Za-z]{1,3}\d+):\s+(?<msg>.+?)(?:\s+\[.*?\])?\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex DiagnosticLineRegex();
+
+    /// <summary>
+    /// Parses the combined stdout+stderr output of a <c>dotnet build</c> invocation and
+    /// returns all lines that match the diagnostic pattern.
+    /// </summary>
+    /// <param name="buildOutput">Combined stdout + stderr from the build.</param>
+    /// <returns>
+    /// Sequence of parsed diagnostics. Lines that do not match are silently skipped.
+    /// </returns>
+    public static IReadOnlyList<CompilerDiagnostic> Parse(string buildOutput)
+    {
+        ArgumentNullException.ThrowIfNull(buildOutput);
+
+        var results = new List<CompilerDiagnostic>();
+        var regex   = DiagnosticLineRegex();
+
+        foreach (var rawLine in buildOutput.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            var m = regex.Match(line);
+            if (!m.Success)
+                continue;
+
+            var severity = m.Groups["sev"].Value.ToLowerInvariant() switch
+            {
+                "error"   => DiagnosticSeverity.Error,
+                "warning" => DiagnosticSeverity.Warning,
+                _         => DiagnosticSeverity.Info,
+            };
+
+            _ = int.TryParse(m.Groups["line"].Value, out var lineNo);
+            _ = int.TryParse(m.Groups["col"].Value,  out var colNo);
+
+            results.Add(new CompilerDiagnostic
+            {
+                FilePath = m.Groups["file"].Value,
+                Line     = lineNo,
+                Column   = colNo,
+                Severity = severity,
+                Code     = m.Groups["code"].Value,
+                Message  = m.Groups["msg"].Value.Trim(),
+                RawLine  = line,
+            });
+        }
+
+        return results;
+    }
+}

--- a/WrapGod.Cli/Verification/DotnetBuildRunner.cs
+++ b/WrapGod.Cli/Verification/DotnetBuildRunner.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace WrapGod.Cli.Verification;
+
+/// <summary>
+/// Real implementation of <see cref="IBuildRunner"/> that spawns <c>dotnet build</c>
+/// as a child process and captures its combined stdout + stderr.
+/// </summary>
+/// <remarks>
+/// Excluded from code coverage because it requires a real <c>dotnet</c> SDK on PATH
+/// and spawns an out-of-process build. Unit tests inject <c>StubBuildRunner</c> instead.
+/// Integration coverage is provided by the CI pipeline's own build step.
+/// </remarks>
+[ExcludeFromCodeCoverage]
+internal sealed class DotnetBuildRunner : IBuildRunner
+{
+    public async Task<BuildResult> RunAsync(
+        string projectDir,
+        string buildConfig,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(projectDir);
+        ArgumentNullException.ThrowIfNull(buildConfig);
+
+        var output = new StringBuilder();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName               = "dotnet",
+            // --nologo suppresses the Microsoft banner; --no-restore avoids implicit restore
+            // noise; -p:RunAnalyzers=false keeps output clean; -p:WarningLevel=4 maximises
+            // diagnostic emission so we catch as much as possible.
+            Arguments              = $"build --nologo --no-restore -c {buildConfig} -p:WarningLevel=4 -p:RunAnalyzers=false",
+            WorkingDirectory       = projectDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+            CreateNoWindow         = true,
+        };
+
+        Process? process;
+        try
+        {
+            process = Process.Start(psi);
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or Win32Exception or InvalidOperationException)
+        {
+            return BuildResult.LaunchFailed($"dotnet build could not be started: {ex.Message}");
+        }
+
+        if (process is null)
+            return BuildResult.LaunchFailed("dotnet build process failed to start (returned null).");
+
+        using (process)
+        {
+            // Read output asynchronously to avoid deadlocks on large output.
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+            output.Append(await stdoutTask.ConfigureAwait(false));
+            output.Append(await stderrTask.ConfigureAwait(false));
+
+            return BuildResult.Completed(output.ToString(), process.ExitCode);
+        }
+    }
+}

--- a/WrapGod.Cli/Verification/IBuildRunner.cs
+++ b/WrapGod.Cli/Verification/IBuildRunner.cs
@@ -1,0 +1,50 @@
+namespace WrapGod.Cli.Verification;
+
+/// <summary>
+/// Abstraction over the build invocation step so tests can inject a stub without
+/// spawning a real <c>dotnet build</c> process.
+/// </summary>
+internal interface IBuildRunner
+{
+    /// <summary>
+    /// Invokes a build against <paramref name="projectDir"/>.
+    /// </summary>
+    /// <param name="projectDir">The directory that contains the <c>.csproj</c> to build.</param>
+    /// <param name="buildConfig">Build configuration, e.g. <c>Debug</c> or <c>Release</c>.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>
+    /// A <see cref="BuildResult"/> containing the combined stdout+stderr output and the
+    /// process exit code, or a failure result if the build could not be invoked.
+    /// </returns>
+    Task<BuildResult> RunAsync(
+        string projectDir,
+        string buildConfig,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Represents the outcome of a build invocation.</summary>
+internal sealed class BuildResult
+{
+    /// <summary>Whether <c>dotnet build</c> was successfully launched (independent of exit code).</summary>
+    public bool Launched { get; init; }
+
+    /// <summary>
+    /// When <see cref="Launched"/> is <see langword="false"/>, contains the reason the build
+    /// could not be started (e.g. "dotnet not found on PATH").
+    /// </summary>
+    public string? LaunchError { get; init; }
+
+    /// <summary>Combined stdout + stderr output captured from the build process.</summary>
+    public string Output { get; init; } = string.Empty;
+
+    /// <summary>The process exit code (0 = success, non-zero = build errors).</summary>
+    public int ExitCode { get; init; }
+
+    /// <summary>Creates a result for a failed launch (dotnet not found, etc.).</summary>
+    public static BuildResult LaunchFailed(string error) =>
+        new() { Launched = false, LaunchError = error };
+
+    /// <summary>Creates a result for a completed build invocation.</summary>
+    public static BuildResult Completed(string output, int exitCode) =>
+        new() { Launched = true, Output = output, ExitCode = exitCode };
+}

--- a/WrapGod.Migration.Engine/AppliedRewrite.cs
+++ b/WrapGod.Migration.Engine/AppliedRewrite.cs
@@ -8,9 +8,18 @@ namespace WrapGod.Migration.Engine;
 /// <param name="Line">1-based line number of the rewrite site.</param>
 /// <param name="OriginalText">The original source text that was replaced.</param>
 /// <param name="ReplacedWith">The replacement source text.</param>
+/// <param name="AppliedAt">
+/// UTC timestamp when the rewrite was recorded by the engine. Used by downstream
+/// consumers (e.g. <c>migrate verify</c>) to disambiguate which rule is the
+/// most recently-applied when multiple rewrites are equidistant from a compiler
+/// diagnostic line. Defaults to <see cref="DateTimeOffset.MinValue"/> when not
+/// supplied — older state files that predate this field will deserialize with
+/// the default value, in which case index-order tiebreaking still applies.
+/// </param>
 public sealed record AppliedRewrite(
     string RuleId,
     string File,
     int Line,
     string OriginalText,
-    string ReplacedWith);
+    string ReplacedWith,
+    DateTimeOffset AppliedAt = default);

--- a/WrapGod.Migration.Engine/RewriteContext.cs
+++ b/WrapGod.Migration.Engine/RewriteContext.cs
@@ -86,7 +86,13 @@ public sealed class RewriteContext
         ArgumentNullException.ThrowIfNull(originalText);
         ArgumentNullException.ThrowIfNull(replacementText);
 
-        _applied.Add(new AppliedRewrite(rule.Id, FilePath, line, originalText, replacementText));
+        _applied.Add(new AppliedRewrite(
+            rule.Id,
+            FilePath,
+            line,
+            originalText,
+            replacementText,
+            DateTimeOffset.UtcNow));
     }
 
     /// <summary>Records a rewrite that was skipped.</summary>

--- a/WrapGod.Tests/CliCommandTests.cs
+++ b/WrapGod.Tests/CliCommandTests.cs
@@ -9,7 +9,7 @@ public sealed class CliCommandTests
     private static readonly string[] ExpectedRootCommands =
         ["analyze", "ci", "doctor", "explain", "extract", "generate", "init", "migrate"];
 
-    private static readonly string[] ExpectedMigrateCommands = ["apply", "generate", "init", "status"];
+    private static readonly string[] ExpectedMigrateCommands = ["apply", "generate", "init", "status", "verify"];
 
     private static readonly string[] ExpectedCiCommands = ["bootstrap", "parity"];
 

--- a/WrapGod.Tests/MigrateVerifyCliTests.cs
+++ b/WrapGod.Tests/MigrateVerifyCliTests.cs
@@ -345,18 +345,23 @@ public sealed class MigrateVerifyCliTests
 
     // ── Scenario 10: Tiebreak — two rewrites equidistant, latest index wins ──
 
-    [Scenario("When two rewrites are equidistant the one appearing later in the state (latest applied) wins")]
+    [Scenario("When two rewrites are equidistant the one with the latest AppliedAt timestamp wins")]
     [Fact]
-    public async Task Verify_TwoRulesEquidistant_PicksLatest()
+    public async Task Verify_TwoRulesEquidistant_PicksLatestAppliedAt()
     {
         var dir = CreateTempDir();
         try
         {
             const string file = "Foo.cs";
             // Two rewrites: R-001 at line 10, R-002 at line 14. Diagnostic at line 12.
-            // |12 - 10| = 2 == |12 - 14| = 2. Tie → latest by index wins → R-002.
-            var r1 = new AppliedRewrite("R-001", file, 10, "A", "B");
-            var r2 = new AppliedRewrite("R-002", file, 14, "C", "D");
+            // |12 - 10| = 2 == |12 - 14| = 2. Tie → latest AppliedAt wins.
+            // We arrange R-001 with the LATER timestamp despite being earlier in the
+            // list — this proves we tiebreak by AppliedAt and not by index alone.
+            var laterTimestamp   = new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+            var earlierTimestamp = new DateTimeOffset(2026, 3, 14, 12, 0, 0, TimeSpan.Zero);
+
+            var r1 = new AppliedRewrite("R-001", file, 10, "A", "B", laterTimestamp);
+            var r2 = new AppliedRewrite("R-002", file, 14, "C", "D", earlierTimestamp);
             var schemaPath = await WriteStateAsync(dir, BuildState([r1, r2]));
 
             var diagLine = DiagLine(file, 12, 1, "error", "CS0001", "msg");
@@ -366,7 +371,36 @@ public sealed class MigrateVerifyCliTests
                 $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
 
             Assert.Equal(0, exitCode);
-            Assert.Contains("R-002", stdout); // tiebreak: later index wins
+            Assert.Contains("R-001", stdout); // tiebreak: later AppliedAt wins
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 10b: AppliedAt equal → falls back to index order ────────────
+
+    [Scenario("Equal AppliedAt timestamps fall back to index-order tiebreak (legacy state files)")]
+    [Fact]
+    public async Task Verify_EqualAppliedAt_FallsBackToIndexOrder()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            const string file = "Foo.cs";
+            // Both rewrites carry the default DateTimeOffset (MinValue), simulating
+            // a state file written by a build that predates the AppliedAt field.
+            var r1 = new AppliedRewrite("R-001", file, 10, "A", "B"); // default AppliedAt
+            var r2 = new AppliedRewrite("R-002", file, 14, "C", "D"); // default AppliedAt
+            var schemaPath = await WriteStateAsync(dir, BuildState([r1, r2]));
+
+            var diagLine = DiagLine(file, 12, 1, "error", "CS0001", "msg");
+            var stub = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            // Equal AppliedAt → secondary tiebreak by index → later index wins → R-002
+            Assert.Contains("R-002", stdout);
         }
         finally { SafeDelete(dir); }
     }
@@ -626,6 +660,129 @@ public sealed class MigrateVerifyCliTests
 
             Assert.Equal(0, exitCode);
             Assert.Contains("CS0200", stdout);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 21: --no-build --json emits build.skipped sentinel ─────────
+
+    [Scenario("--no-build --json emits a structured build.skipped=true sentinel instead of null")]
+    [Fact]
+    public async Task Verify_NoBuild_Json_EmitsSkippedSentinel()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var schemaPath = await WriteStateAsync(dir, BuildState());
+
+            // Stub would return errors; --no-build must short-circuit so this is never called.
+            var stub = new StubBuildRunner(BuildResult.Completed("noise", 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\" --no-build --json", stub);
+
+            Assert.Equal(0, exitCode);
+
+            var doc = JsonDocument.Parse(stdout);
+            var buildEl = doc.RootElement.GetProperty("build");
+
+            // Must be a structured object, not null
+            Assert.Equal(JsonValueKind.Object, buildEl.ValueKind);
+
+            // skipped must be true and a reason must be present
+            Assert.True(buildEl.GetProperty("skipped").GetBoolean());
+            Assert.Equal("--no-build flag set", buildEl.GetProperty("reason").GetString());
+
+            // exitCode is null (not present as a non-null int) so consumers know not to read it
+            Assert.Equal(JsonValueKind.Null, buildEl.GetProperty("exitCode").ValueKind);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 22: Auto-detect schema when --schema omitted ───────────────
+
+    [Scenario("When --schema is omitted the command auto-detects the most recent state file")]
+    [Fact]
+    public async Task Verify_AutoDetectsSchemaFromStateFile()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            // Write schema + state file with a known applied rewrite
+            const string file = "Foo.cs";
+            var applied = new AppliedRewrite("R-AUTO", file, 10, "A", "B",
+                new DateTimeOffset(2026, 3, 14, 0, 0, 0, TimeSpan.Zero));
+            await WriteStateAsync(dir, BuildState([applied]));
+
+            // No --schema given; should auto-detect from --project-dir
+            var diagLine = DiagLine(file, 11, 1, "error", "CS0001", "near R-AUTO");
+            var stub = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("R-AUTO", stdout);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 23: Auto-detect when schema file missing but state file exists ──
+
+    [Scenario("Auto-detect works when only the state file exists (schema deleted) — runs in state-only mode")]
+    [Fact]
+    public async Task Verify_AutoDetect_StateExists_SchemaMissing_ProceedsGracefully()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            // Write schema + state, then delete the schema file to simulate
+            // schema-deleted-but-state-retained scenarios (e.g. cleanup script).
+            var applied = new AppliedRewrite("R-001", "Foo.cs", 10, "A", "B");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+            File.Delete(schemaPath);
+            Assert.False(File.Exists(schemaPath), "schema file should be deleted for this scenario");
+
+            // State sibling still exists
+            Assert.True(File.Exists(schemaPath + ".state.json"), "state file must remain");
+
+            var stub = new StubBuildRunner(BuildResult.Completed(string.Empty, 0));
+
+            // Auto-detect via --project-dir (no --schema)
+            var (exitCode, stdout, _) = await InvokeAsync($"--project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            // The state-file's recorded rule appears (via state.Applied being read)
+            // and the command runs through to attribution without crashing.
+            Assert.Contains("verify", stdout, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 24: Regex accepts wider NETSDK-style codes ──────────────────
+
+    [Scenario("DiagnosticParser regex accepts 6-letter NETSDK-style diagnostic codes")]
+    [Fact]
+    public async Task Verify_Parses_NetSdkLongCode()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            const string file = "Foo.cs";
+            var applied    = new AppliedRewrite("R-001", file, 10, "A", "B");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+
+            // NETSDK1138 is a 6-letter-prefix code; the old [A-Za-z]{1,3} regex would reject it.
+            var diagLine = DiagLine(file, 11, 1, "error", "NETSDK1138", "long-prefix code");
+            var stub = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\" --verbose", stub);
+
+            Assert.Equal(0, exitCode);
+            // The diagnostic must have been parsed AND attributed (delta = 1)
+            Assert.Contains("R-001", stdout);
+            Assert.Contains("NETSDK1138", stdout);
         }
         finally { SafeDelete(dir); }
     }

--- a/WrapGod.Tests/MigrateVerifyCliTests.cs
+++ b/WrapGod.Tests/MigrateVerifyCliTests.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using TinyBDD;
 using WrapGod.Cli;
@@ -405,12 +406,18 @@ public sealed class MigrateVerifyCliTests
         finally { SafeDelete(dir); }
     }
 
-    // ── Scenario 11: Case-insensitive path matching ──────────────────────────
+    // ── Scenario 11a: Case-insensitive path matching (Windows-only) ─────────
 
-    [Scenario("Path matching is case-insensitive on Windows")]
+    [Scenario("Path matching is case-insensitive on Windows (matches NTFS behavior)")]
     [Fact]
-    public async Task Verify_PathCaseInsensitiveMatch()
+    public async Task Verify_PathCaseInsensitive_OnWindowsOnly()
     {
+        // The path comparer is platform-aware: OrdinalIgnoreCase on Windows,
+        // Ordinal on Linux/macOS. This test only asserts the Windows behavior.
+        // The POSIX counterpart is Verify_PathCaseSensitive_OnPosix below.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return; // skip on non-Windows; behavior documented to differ
+
         var dir = CreateTempDir();
         try
         {
@@ -430,6 +437,43 @@ public sealed class MigrateVerifyCliTests
 
             Assert.Equal(0, exitCode);
             Assert.Contains("R-001", stdout); // matched despite case difference
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 11b: Case-sensitive path matching (POSIX) ──────────────────
+
+    [Scenario("Path matching is case-sensitive on Linux/macOS (matches POSIX filesystem behavior)")]
+    [Fact]
+    public async Task Verify_PathCaseSensitive_OnPosix()
+    {
+        // Complementary to Verify_PathCaseInsensitive_OnWindowsOnly.
+        // On POSIX filesystems "Foo.cs" and "foo.cs" really are different files,
+        // so the attribution must NOT cross-match.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return; // skip on Windows; the inverse test covers that platform
+
+        var dir = CreateTempDir();
+        try
+        {
+            const string upperFile = "Foo.cs";
+            var lowerFile = upperFile.ToLowerInvariant(); // "foo.cs"
+
+            // Rewrite recorded with the uppercase variant
+            var applied    = new AppliedRewrite("R-001", upperFile, 5, "A", "B");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+
+            // Diagnostic comes in with the lowercase variant — distinct file on POSIX
+            var diagLine = DiagLine(lowerFile, 6, 1, "error", "CS0001", "msg");
+            var stub = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            // Case-sensitive comparison → diagnostic is NOT attributed to R-001.
+            // It falls into the Unattributed bucket.
+            Assert.Contains("Unattributed", stdout, StringComparison.OrdinalIgnoreCase);
         }
         finally { SafeDelete(dir); }
     }

--- a/WrapGod.Tests/MigrateVerifyCliTests.cs
+++ b/WrapGod.Tests/MigrateVerifyCliTests.cs
@@ -1,0 +1,632 @@
+using System.CommandLine;
+using System.Text.Json;
+using TinyBDD;
+using WrapGod.Cli;
+using WrapGod.Cli.Verification;
+using WrapGod.Migration.Engine;
+using WrapGod.Migration.Engine.State;
+
+namespace WrapGod.Tests;
+
+/// <summary>
+/// BDD-style tests for <c>wrap-god migrate verify</c>.
+///
+/// All scenarios use a <see cref="StubBuildRunner"/> to avoid spawning a real
+/// <c>dotnet build</c> process. The stub returns pre-canned output covering the
+/// full range of diagnostic lines described in Issue #201.
+///
+/// Exit code contract per MIGRATION-ENGINE-PLAN.md §201.a:
+///   0 – verify ran (even if there are attributed errors; verify is non-gating)
+///   1 – IO error (baseline missing, schema not found, etc.)
+///   2 – bad arguments
+/// </summary>
+[Feature("CLI: migrate verify command performs semantic verification post-apply")]
+[Collection("CLI")]
+public sealed class MigrateVerifyCliTests
+{
+    // ── StubBuildRunner ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A test double for <see cref="IBuildRunner"/> that returns a pre-canned
+    /// <see cref="BuildResult"/> without spawning any process.
+    /// </summary>
+    private sealed class StubBuildRunner(BuildResult result) : IBuildRunner
+    {
+        public Task<BuildResult> RunAsync(string projectDir, string buildConfig, CancellationToken ct)
+            => Task.FromResult(result);
+    }
+
+    // ── Invoke helpers ───────────────────────────────────────────────────────
+
+    private static async Task<(int ExitCode, string StdOut, string StdErr)> InvokeAsync(
+        string args, IBuildRunner? buildRunner = null)
+    {
+        var runner  = buildRunner ?? new StubBuildRunner(BuildResult.Completed(string.Empty, 0));
+        var command = MigrateVerifyCommand.Create(runner);
+
+        var previousOut      = Console.Out;
+        var previousErr      = Console.Error;
+        var previousExitCode = Environment.ExitCode;
+        using var stdOut = new StringWriter();
+        using var stdErr = new StringWriter();
+
+        try
+        {
+            Console.SetOut(stdOut);
+            Console.SetError(stdErr);
+            Environment.ExitCode = 0;
+
+            var code = await command.InvokeAsync(args);
+            var effectiveCode = Environment.ExitCode == 0 ? code : Environment.ExitCode;
+            return (effectiveCode, stdOut.ToString(), stdErr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousErr);
+            Environment.ExitCode = previousExitCode;
+        }
+    }
+
+    // ── Fixture helpers ──────────────────────────────────────────────────────
+
+    private static string CreateTempDir()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"wrapgod-verify-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void SafeDelete(string path)
+    {
+        try { Directory.Delete(path, recursive: true); } catch { /* best-effort */ }
+    }
+
+    /// <summary>Creates a minimal schema file and returns its path.</summary>
+    private static async Task<string> WriteSchemaAsync(string dir, string name = "schema.wrapgod-migration.json")
+    {
+        var path = Path.Combine(dir, name);
+        await File.WriteAllTextAsync(path, """
+            {
+              "schema": "wrapgod-migration/1.0",
+              "library": "TestLib",
+              "from": "1.0.0",
+              "to": "2.0.0",
+              "rules": []
+            }
+            """);
+        return path;
+    }
+
+    /// <summary>Saves a state file sibling to the given schema and returns the schema path.</summary>
+    private static async Task<string> WriteStateAsync(
+        string dir,
+        MigrationState state,
+        string name = "schema.wrapgod-migration.json")
+    {
+        var schemaPath = await WriteSchemaAsync(dir, name);
+        MigrationStateStore.Save(schemaPath, state);
+        return schemaPath;
+    }
+
+    private static MigrationState BuildState(IEnumerable<AppliedRewrite>? applied = null)
+    {
+        var a = (applied ?? []).ToList();
+        return new MigrationState
+        {
+            Schema     = "schema.wrapgod-migration.json",
+            SchemaHash = "sha256:aabbccdd",
+            StartedAt  = DateTimeOffset.UtcNow,
+            LastRunAt  = DateTimeOffset.UtcNow,
+            Summary    = new MigrationStateSummary
+            {
+                TotalRules = a.Count,
+                Applied    = a.Count,
+            },
+            Applied = a,
+        };
+    }
+
+    /// <summary>
+    /// Formats a compiler diagnostic line in Roslyn/MSBuild format:
+    /// <c>file(line,col): severity CODE: message</c>
+    /// </summary>
+    private static string DiagLine(
+        string file, int line, int col, string severity, string code, string message) =>
+        $"{file}({line},{col}): {severity} {code}: {message}";
+
+    // ── Scenario 1: Help text lists all flags ────────────────────────────────
+
+    [Scenario("Verify --help lists all registered option flags")]
+    [Fact]
+    public async Task Verify_Help_ListsAllFlags()
+    {
+        var (_, stdout, _) = await InvokeAsync("--help");
+
+        Assert.Contains("--schema",       stdout);
+        Assert.Contains("--no-build",     stdout);
+        Assert.Contains("--json",         stdout);
+        Assert.Contains("--verbose",      stdout);
+        Assert.Contains("--build-config", stdout);
+        Assert.Contains("--baseline",     stdout);
+    }
+
+    // ── Scenario 2: Diagnostic within ±3 lines is attributed ────────────────
+
+    [Scenario("A compiler error within 3 lines of an applied rewrite is attributed to that rule")]
+    [Fact]
+    public async Task Verify_AttributesDiagnosticWithin3Lines()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            // Rewrite at line 14; diagnostic at line 16 (delta = 2, within ±3)
+            var applied    = new AppliedRewrite("R-001", "Foo.cs", 14, "OldWidget", "NewWidget");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+
+            // Use the same path that will normalise to "Foo.cs"
+            var diagLine = DiagLine("Foo.cs", 16, 5, "error", "CS0103", "X does not exist");
+            var stub = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);                               // verify is non-gating
+            Assert.Contains("R-001", stdout);                        // attribution visible
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 3: Diagnostic beyond ±3 lines is NOT attributed ────────────
+
+    [Scenario("A compiler error more than 3 lines away from any rewrite is not attributed")]
+    [Fact]
+    public async Task Verify_DoesNotAttributeBeyond3Lines()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            // Rewrite at line 10; diagnostic at line 18 (delta = 8, outside ±3)
+            var applied    = new AppliedRewrite("R-001", "Foo.cs", 10, "OldWidget", "NewWidget");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+
+            var diagLine = DiagLine("Foo.cs", 18, 1, "error", "CS0103", "X missing");
+            var stub = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Unattributed", stdout, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 4: Baseline subtracts pre-existing diagnostics ─────────────
+
+    [Scenario("Diagnostics present in the baseline are classified as pre-existing")]
+    [Fact]
+    public async Task Verify_BaselineSubtractsPreExisting()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            const string file = "Foo.cs";
+            var applied    = new AppliedRewrite("R-001", file, 14, "OldWidget", "NewWidget");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+
+            var diagLine = DiagLine(file, 16, 5, "error", "CS0103", "X missing");
+
+            // Write baseline JSON with the same diagnostic
+            var baselineJson = JsonSerializer.Serialize(new[]
+            {
+                new { filePath = file, line = 16, column = 5, severity = "error", code = "CS0103", message = "X missing" },
+            });
+            var baselinePath = Path.Combine(dir, "baseline.json");
+            await File.WriteAllTextAsync(baselinePath, baselineJson);
+
+            var stub = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\" --baseline \"{baselinePath}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("re-existing", stdout, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 5: Zero-error build → clean report ──────────────────────────
+
+    [Scenario("A successful build with zero errors produces a clean zero-errors report")]
+    [Fact]
+    public async Task Verify_BuildSucceeds_ReportsZeroErrors()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var schemaPath = await WriteStateAsync(dir, BuildState());
+            var stub = new StubBuildRunner(BuildResult.Completed("Build succeeded.", 0));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("0 error", stdout, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 6: dotnet build not on PATH → graceful skip ────────────────
+
+    [Scenario("When dotnet build cannot be launched the command exits 0 with a skip note")]
+    [Fact]
+    public async Task Verify_BuildNotOnPath_SkipsGracefully()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var schemaPath = await WriteStateAsync(dir, BuildState());
+            var stub = new StubBuildRunner(BuildResult.LaunchFailed("dotnet not found on PATH"));
+
+            var (exitCode, _, stdErr) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("dotnet build not found", stdErr, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 7: No state file → graceful skip ────────────────────────────
+
+    [Scenario("When no migration state file exists the command exits 0 with an explanatory message")]
+    [Fact]
+    public async Task Verify_NoStateFile_SkipsGracefully()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            // Write schema but NO state file
+            var schemaPath = await WriteSchemaAsync(dir);
+            var stub = new StubBuildRunner(BuildResult.Completed(string.Empty, 0));
+
+            var (exitCode, _, stdErr) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("no migration state", stdErr, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 8: Unparseable diagnostic line is skipped ──────────────────
+
+    [Scenario("An unparseable line in dotnet build output does not crash the command")]
+    [Fact]
+    public async Task Verify_UnparseableDiagnostic_Skipped()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var schemaPath = await WriteStateAsync(dir, BuildState());
+            const string gibberish =
+                "   MSBuild: some internal message that is not a diagnostic\n" +
+                "   Restore complete.\n";
+            var stub = new StubBuildRunner(BuildResult.Completed(gibberish, 0));
+
+            var (exitCode, _, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode); // no crash
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 9: Baseline file missing → exit 1 ───────────────────────────
+
+    [Scenario("When --baseline points to a missing file the command exits 1 with an error")]
+    [Fact]
+    public async Task Verify_BaselineMissing_Fails()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var schemaPath    = await WriteStateAsync(dir, BuildState());
+            var missingBaseline = Path.Combine(dir, "does-not-exist.json");
+
+            var (exitCode, _, stdErr) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\" --baseline \"{missingBaseline}\"");
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("baseline file not found", stdErr, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 10: Tiebreak — two rewrites equidistant, latest index wins ──
+
+    [Scenario("When two rewrites are equidistant the one appearing later in the state (latest applied) wins")]
+    [Fact]
+    public async Task Verify_TwoRulesEquidistant_PicksLatest()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            const string file = "Foo.cs";
+            // Two rewrites: R-001 at line 10, R-002 at line 14. Diagnostic at line 12.
+            // |12 - 10| = 2 == |12 - 14| = 2. Tie → latest by index wins → R-002.
+            var r1 = new AppliedRewrite("R-001", file, 10, "A", "B");
+            var r2 = new AppliedRewrite("R-002", file, 14, "C", "D");
+            var schemaPath = await WriteStateAsync(dir, BuildState([r1, r2]));
+
+            var diagLine = DiagLine(file, 12, 1, "error", "CS0001", "msg");
+            var stub = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("R-002", stdout); // tiebreak: later index wins
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 11: Case-insensitive path matching ──────────────────────────
+
+    [Scenario("Path matching is case-insensitive on Windows")]
+    [Fact]
+    public async Task Verify_PathCaseInsensitiveMatch()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            const string upperFile = "Foo.cs";
+            var lowerFile = upperFile.ToLowerInvariant(); // "foo.cs"
+
+            // Rewrite recorded with the uppercase variant
+            var applied    = new AppliedRewrite("R-001", upperFile, 5, "A", "B");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+
+            // Diagnostic comes in with the lowercase variant
+            var diagLine = DiagLine(lowerFile, 6, 1, "error", "CS0001", "msg");
+            var stub = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("R-001", stdout); // matched despite case difference
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 12: JSON output has required keys ───────────────────────────
+
+    [Scenario("--json output is parseable JSON containing build, attribution, and unattributed keys")]
+    [Fact]
+    public async Task Verify_Json_ParsesAsJson()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var schemaPath = await WriteStateAsync(dir, BuildState());
+            var stub = new StubBuildRunner(BuildResult.Completed(string.Empty, 0));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\" --json", stub);
+
+            Assert.Equal(0, exitCode);
+            var doc = JsonDocument.Parse(stdout); // throws if not valid JSON
+            Assert.True(doc.RootElement.TryGetProperty("build",         out _), "must have 'build'");
+            Assert.True(doc.RootElement.TryGetProperty("attribution",   out _), "must have 'attribution'");
+            Assert.True(doc.RootElement.TryGetProperty("unattributed",  out _), "must have 'unattributed'");
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 13: --no-build skips build, reports state summary only ──────
+
+    [Scenario("--no-build skips the dotnet build invocation and reports state summary")]
+    [Fact]
+    public async Task Verify_NoBuild_ReportsStateSummaryOnly()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var applied    = new AppliedRewrite("R-001", "Foo.cs", 10, "A", "B");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+
+            // Stub would return errors; --no-build should prevent it being called
+            var neverCalledStub = new StubBuildRunner(BuildResult.Completed(
+                DiagLine("Foo.cs", 10, 1, "error", "CS0001", "should not appear"), 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\" --no-build", neverCalledStub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("SKIPPED", stdout, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("CS0001", stdout); // build was not run
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 14: All errors unattributed when state has 0 applied ────────
+
+    [Scenario("When the state file has no applied rewrites all build errors are unattributed")]
+    [Fact]
+    public async Task Verify_ZeroApplied_AllErrorsUnattributed()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var schemaPath = await WriteStateAsync(dir, BuildState()); // no applied rewrites
+            var diagLine   = DiagLine("Foo.cs", 10, 1, "error", "CS0001", "msg");
+            var stub       = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Unattributed", stdout, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 15: Diagnostic with no file path (MSBuild-level) ────────────
+
+    [Scenario("An MSBuild-level error without a file reference does not crash the command")]
+    [Fact]
+    public async Task Verify_DiagnosticWithNoFilePath_DoesNotCrash()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var applied    = new AppliedRewrite("R-001", "Foo.cs", 10, "A", "B");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+
+            // MSBuild-level error — no (line,col), so the diagnostic parser won't parse it
+            const string msBuildError = "error MSB3001: some project-level error without file reference\n";
+            var stub = new StubBuildRunner(BuildResult.Completed(msBuildError, 1));
+
+            var (exitCode, _, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode); // non-fatal
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 16: Warnings only → exit 0 with 0 errors ───────────────────
+
+    [Scenario("A build with only warnings exits 0 and reports 0 errors")]
+    [Fact]
+    public async Task Verify_BuildWithOnlyWarnings_ExitsZeroNoErrors()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var schemaPath = await WriteStateAsync(dir, BuildState());
+            var warnLine   = DiagLine("Foo.cs", 5, 1, "warning", "CS0618", "deprecated usage");
+            var stub       = new StubBuildRunner(BuildResult.Completed(warnLine, 0));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("0 error", stdout, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 17: Schema hash mismatch → warning but proceed ─────────────
+
+    [Scenario("A schema hash mismatch produces a warning but the command still exits 0")]
+    [Fact]
+    public async Task Verify_SchemaHashMismatch_WarnAndProceed()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var schemaPath = await WriteStateAsync(dir, BuildState());
+
+            // Mutate the schema AFTER saving state → current hash will differ from stored hash
+            await File.AppendAllTextAsync(schemaPath, "\n// mutated");
+
+            var stub = new StubBuildRunner(BuildResult.Completed(string.Empty, 0));
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("schema has changed", stdout, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 18: Three errors, two attributed, one not ──────────────────
+
+    [Scenario("Three errors: two near applied rules (attributed), one far away (unattributed)")]
+    [Fact]
+    public async Task Verify_ThreeErrors_TwoAttributedOneUnattributed()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            const string file = "Foo.cs";
+            var r1 = new AppliedRewrite("R-001", file, 10, "A", "B");
+            var r2 = new AppliedRewrite("R-002", file, 30, "C", "D");
+            var schemaPath = await WriteStateAsync(dir, BuildState([r1, r2]));
+
+            // Error at 11 → near R-001 (delta 1)
+            // Error at 31 → near R-002 (delta 1)
+            // Error at 50 → no rewrite within ±3 → unattributed
+            var buildOutput =
+                DiagLine(file, 11, 1, "error", "CS0001", "near R-001") + "\n" +
+                DiagLine(file, 31, 1, "error", "CS0002", "near R-002") + "\n" +
+                DiagLine(file, 50, 1, "error", "CS0003", "far away")   + "\n";
+
+            var stub = new StubBuildRunner(BuildResult.Completed(buildOutput, 1));
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\"", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("R-001", stdout);
+            Assert.Contains("R-002", stdout);
+            Assert.Contains("Unattributed", stdout, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 19: JSON output with attributed errors ──────────────────────
+
+    [Scenario("--json output with an attributed error contains a non-empty attribution array with the ruleId")]
+    [Fact]
+    public async Task Verify_Json_WithAttributedError_HasAttributionEntries()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            const string file = "Foo.cs";
+            var applied    = new AppliedRewrite("R-005", file, 20, "A", "B");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+
+            var diagLine = DiagLine(file, 21, 1, "error", "CS1501", "no overload");
+            var stub     = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\" --json", stub);
+
+            Assert.Equal(0, exitCode);
+            var doc        = JsonDocument.Parse(stdout);
+            var attrArray  = doc.RootElement.GetProperty("attribution");
+            Assert.NotEqual(0, attrArray.GetArrayLength());
+            var firstEntry = attrArray.EnumerateArray().First();
+            Assert.Equal("R-005", firstEntry.GetProperty("ruleId").GetString());
+        }
+        finally { SafeDelete(dir); }
+    }
+
+    // ── Scenario 20: --verbose lists per-diagnostic details ─────────────────
+
+    [Scenario("--verbose lists per-diagnostic file/line/code details for attributed errors")]
+    [Fact]
+    public async Task Verify_Verbose_ListsPerDiagnosticDetails()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            const string file = "Bar.cs";
+            var applied    = new AppliedRewrite("R-010", file, 7, "X", "Y");
+            var schemaPath = await WriteStateAsync(dir, BuildState([applied]));
+
+            var diagLine = DiagLine(file, 8, 3, "error", "CS0200", "read-only property");
+            var stub     = new StubBuildRunner(BuildResult.Completed(diagLine, 1));
+
+            var (exitCode, stdout, _) = await InvokeAsync(
+                $"--schema \"{schemaPath}\" --project-dir \"{dir}\" --verbose", stub);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("CS0200", stdout);
+        }
+        finally { SafeDelete(dir); }
+    }
+}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -22,6 +22,7 @@ wrap-god [command] [options]
 - [`migrate generate`](#migrate-generate) -- Generate a draft migration schema from two library versions
 - [`migrate apply`](#migrate-apply) -- Apply a migration schema to a codebase (with --dry-run support)
 - [`migrate status`](#migrate-status) -- Report migration progress from the state file
+- [`migrate verify`](#migrate-verify) -- Optionally build the project and correlate compiler diagnostics to migration rules
 - [`ci bootstrap`](#ci-bootstrap) -- Generate recommended CI workflow files
 - [`ci parity`](#ci-parity) -- Compare CI config against the recommended baseline
 
@@ -811,6 +812,139 @@ Manual rules (require human intervention):
 ```
 
 > **See also:** [Migration state file format](../migration/state.md)
+
+---
+
+### `migrate verify`
+
+**Synopsis:** Optionally build the migrated project and correlate compiler diagnostics back to migration rules via ±3-line proximity. Always informational — never blocks `migrate apply`.
+
+**Usage:**
+```
+wrap-god migrate verify [options]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--schema`, `-s` | Path to the migration schema JSON. The state file is the sibling `<schema>.state.json`. When omitted, auto-detected from `--project-dir`. | Auto-detected |
+| `--project-dir`, `-p` | Project root directory for build and auto-detection | Current directory |
+| `--no-build` | Skip `dotnet build`; only report state-file summary | `false` |
+| `--json` | Emit output as JSON instead of human-readable text | `false` |
+| `--verbose`, `-v` | Include per-diagnostic details in human-readable mode | `false` |
+| `--build-config` | Build configuration passed to `dotnet build` | `Debug` |
+| `--baseline` | Pre-migration diagnostic snapshot JSON for net-new computation | (none) |
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| `0` | Verify ran (even when attributed errors exist — verify is non-gating) |
+| `1` | IO error (baseline file not found, etc.) |
+| `2` | Bad arguments |
+
+**Behavior:**
+
+1. Locates the state file (sibling of `--schema`, or auto-detected via `*.wrapgod-migration.json.state.json` in `--project-dir`). If absent, exits 0 with a note.
+2. Checks the schema hash and warns when the schema has changed since the last `apply` run.
+3. (Unless `--no-build`) Spawns `dotnet build --nologo --no-restore` and captures combined stdout + stderr.
+4. Parses diagnostics using the Roslyn/MSBuild format: `path(line,col): error|warning CODE: message`.
+5. Attributes each diagnostic to the nearest `AppliedRewrite` in the state file within ±3 lines of the same file. Tiebreak: smallest distance; if equal, the rewrite appearing latest in the state wins.
+6. Loads `--baseline` (if provided) and classifies matching diagnostics as pre-existing.
+7. Reports: attributed errors per rule, unattributed errors, and pre-existing counts.
+
+**Graceful degradation:**
+- `dotnet` not on PATH → exits 0 with stderr note; no build attempted.
+- No state file found → exits 0 with "no migration state; nothing to verify".
+- `--baseline` path does not exist → exits 1 with error.
+
+**Attribution algorithm:**
+
+A diagnostic at `(file F, line L)` is attributed to rewrite `R` when:
+- `R.File == F` (case-insensitive on Windows), AND
+- `|R.Line - L| ≤ 3`
+
+When multiple rewrites match, the one closest to the diagnostic line wins; ties are broken by the rewrite appearing later in the state file (i.e. most recently applied).
+
+**Examples:**
+
+```bash
+# Human-readable verification (auto-detects schema from project dir)
+wrap-god migrate verify --project-dir ./src
+
+# Explicit schema + verbose per-diagnostic listing
+wrap-god migrate verify \
+  --schema mudblazor.6.0-to-7.0.wrapgod-migration.json \
+  --verbose
+
+# JSON output for CI tooling
+wrap-god migrate verify \
+  --schema mudblazor.6.0-to-7.0.wrapgod-migration.json \
+  --json
+
+# Skip build (build ran as a separate CI job)
+wrap-god migrate verify \
+  --schema mudblazor.6.0-to-7.0.wrapgod-migration.json \
+  --no-build
+
+# Compute net-new errors vs. a pre-migration baseline snapshot
+wrap-god migrate verify \
+  --schema mudblazor.6.0-to-7.0.wrapgod-migration.json \
+  --baseline pre-migration-diagnostics.json
+```
+
+**Output (human-readable):**
+
+```
+WrapGod migrate verify
+----------------------
+Project:  ./src
+Schema:   mudblazor.6.0-to-7.0.wrapgod-migration.json
+Baseline: (none)
+
+Build:    FAILED (50 error(s), 3 warning(s))
+
+Attribution:
+  MUD-003   38 error(s), 0 warning(s)
+  MUD-017   12 error(s), 0 warning(s)
+  Unattributed: 0 error(s), 3 warning(s) (likely pre-existing or unrelated)
+```
+
+**Output (`--json`):**
+
+```json
+{
+  "schema": "mudblazor.6.0-to-7.0.wrapgod-migration.json",
+  "projectDir": "./src",
+  "schemaChanged": false,
+  "noBuild": false,
+  "build": { "exitCode": 1, "launched": true, "errors": 50, "warnings": 3 },
+  "baselineDiagnosticsLoaded": 0,
+  "state": { "applied": 47, "skipped": 6, "manual": 3 },
+  "attribution": [
+    {
+      "ruleId": "MUD-003",
+      "errors": 38,
+      "warnings": 0,
+      "diagnostics": [
+        { "file": "src/Dialogs/ConfirmDialog.cs", "line": 42, "code": "CS1501", "message": "...", "severity": "error" }
+      ]
+    }
+  ],
+  "unattributed": [
+    { "file": "src/Other.cs", "line": 100, "code": "CS0618", "message": "deprecated", "severity": "warning" }
+  ]
+}
+```
+
+**Common gotchas:**
+
+- **`--no-restore`**: `verify` passes `--no-restore` to `dotnet build`, so a `dotnet restore` must have been run previously. In fresh CI checkouts, add a restore step before `verify`.
+- **Schema drift**: If you edit the schema after `apply`, the attribution results may not align. The command warns when it detects this.
+- **Case-sensitive paths on Linux**: The ±3-line match is case-insensitive on Windows but case-sensitive on Linux/macOS. Ensure paths in the state file match the actual filesystem casing.
+
+> **See also:** [Attribution semantics](../migration/verifying.md) · [State file format](../migration/state.md)
 
 ---
 

--- a/docs/migration/state.md
+++ b/docs/migration/state.md
@@ -190,3 +190,5 @@ representative state file.
 - [Migration Engine](engine.md) — `MigrationEngine`, `IRuleRewriter`, `RewriteContext`
 - [Migration Schema](schema.md) — schema model and rule kinds
 - [`migrate status` CLI command](../guide/cli.md#migrate-status) — read-only progress report from the state file
+- [`migrate verify` CLI command](../guide/cli.md#migrate-verify) — build + diagnostic attribution using state file data
+- [Verifying a migration](verifying.md) — attribution algorithm, baseline workflow, graceful degradation

--- a/docs/migration/verifying.md
+++ b/docs/migration/verifying.md
@@ -183,9 +183,18 @@ WARNING: Schema has changed since last apply. Attribution may be inaccurate.
 
 Re-run `migrate apply` to regenerate the state before running `verify` again.
 
-### Case-sensitive paths on Linux
+### Platform-aware path casing
 
-The ±3-line match normalises path separators (`\` → `/`) and uses case-insensitive comparison on Windows. On Linux and macOS the comparison is case-sensitive. Ensure the paths recorded in the state file match the actual filesystem casing — this is most commonly an issue when the schema was authored on Windows and the build runs on Linux.
+The ±3-line attribution match normalises path separators (`\` → `/`) and then compares paths using **platform-native** filesystem semantics:
+
+| Platform | Comparison | Rationale |
+|----------|------------|-----------|
+| Windows | Case-insensitive (`OrdinalIgnoreCase`) | Matches NTFS behavior: `Foo.cs` and `foo.cs` refer to the same file. |
+| Linux / macOS | Case-sensitive (`Ordinal`) | Matches POSIX behavior: `Foo.cs` and `foo.cs` are distinct files. |
+
+**Implication:** A state file authored on Windows whose `Applied` entries record paths like `src/Foo.cs` will *not* attribute diagnostics emitted as `src/foo.cs` when verified on Linux CI. Ensure the casing recorded in the state file matches the actual filesystem casing on every platform where `verify` runs. The safest convention is to record paths exactly as the compiler emits them — i.e. as they appear in the build output.
+
+If your project must support cross-platform development with mixed-case paths, normalize file paths to a canonical form (typically all-lowercase or as-they-appear-on-disk) before committing the state file to source control.
 
 ---
 

--- a/docs/migration/verifying.md
+++ b/docs/migration/verifying.md
@@ -1,0 +1,192 @@
+# Verifying a Migration
+
+After running `migrate apply`, the `migrate verify` command optionally compiles the migrated project and correlates each compiler diagnostic back to the migration rule that most likely caused it.
+
+Verification is always **informational** — it never blocks `apply` and never modifies any file.
+
+> **See also:** [CLI reference: migrate verify](../guide/cli.md#migrate-verify)
+
+---
+
+## When to Run Verify
+
+Run `verify` after a successful `apply` when:
+
+- You want to know whether the migration introduced any new compiler errors.
+- You need to decide which rules still need manual remediation.
+- You are in a CI pipeline and want a structured JSON report of migration health.
+
+You can safely skip `verify` if your build already passes; it adds the attribution layer on top of a build you would run anyway.
+
+---
+
+## Attribution Algorithm
+
+A compiler diagnostic at `(file F, line L)` is **attributed** to a migration rewrite `R` when:
+
+1. `R.File == F` (case-insensitive comparison on Windows; case-sensitive on Linux/macOS), AND
+2. `|R.Line − L| ≤ 3`
+
+This ±3 line window accounts for the fact that a rewrite shifts surrounding lines slightly and that the compiler may report the error on a nearby line rather than the exact rewrite location.
+
+### Tiebreak
+
+When multiple rewrites fall within 3 lines of the same diagnostic:
+
+1. The one with the **smallest absolute distance** wins.
+2. If two rewrites are equidistant, the one appearing **later** in the state file (i.e. most recently applied) wins.
+
+### Unattributed diagnostics
+
+Diagnostics that do not match any applied rewrite within ±3 lines are reported as **unattributed**. These are likely:
+
+- Pre-existing errors that existed before the migration.
+- Errors caused by something outside the scope of the applied rules.
+
+### Pre-existing diagnostics (baseline)
+
+Pass `--baseline <path>` with a JSON file capturing diagnostics from a pre-migration build. Any diagnostic that matches the baseline by `(file, line, code)` tuple is classified as **pre-existing** and excluded from the attribution counts.
+
+---
+
+## Baseline Workflow
+
+1. **Before** running `migrate apply`, capture the current build diagnostics:
+
+   ```bash
+   dotnet build --nologo 2>&1 | grep -E '\(([0-9]+),[0-9]+\): (error|warning)' > pre-migration.txt
+   ```
+
+   Or, if your tooling produces Cobertura/SARIF, export that instead. The `--baseline` flag expects a JSON array with the shape:
+
+   ```json
+   [
+     { "filePath": "src/Foo.cs", "line": 42, "column": 5, "severity": "error", "code": "CS0103", "message": "..." },
+     ...
+   ]
+   ```
+
+2. Apply the migration:
+
+   ```bash
+   wrap-god migrate apply --schema schema.json --project-dir ./src
+   ```
+
+3. Verify with the baseline:
+
+   ```bash
+   wrap-god migrate verify \
+     --schema schema.json \
+     --project-dir ./src \
+     --baseline pre-migration.json
+   ```
+
+   Diagnostics present in both the current build and the baseline are reported as **pre-existing** rather than attributed to a rule.
+
+---
+
+## `--no-build` Mode
+
+Pass `--no-build` to skip the `dotnet build` invocation entirely. In this mode, `verify` only reports the state-file summary (applied / skipped / manual counts) without any diagnostic correlation.
+
+This is useful in CI pipelines where the build runs as a dedicated parallel job and you want the verify step to remain cheap.
+
+---
+
+## Graceful Degradation
+
+| Situation | Behaviour |
+|-----------|-----------|
+| `dotnet` not on PATH | Exits 0; stderr note: "dotnet build not found; skipping verify." |
+| No state file found | Exits 0; stderr note: "No migration state; nothing to verify." |
+| `--baseline` path does not exist | Exits 1 with error message. |
+| Project does not compile at all | Exits 0; reports the full diagnostic list with whatever attribution is possible. |
+| Schema has changed since last apply | Prints a warning banner; continues with attribution using current state. |
+
+---
+
+## JSON Output
+
+Pass `--json` to emit a machine-readable report:
+
+```json
+{
+  "schema": "mudblazor.6.0-to-7.0.wrapgod-migration.json",
+  "projectDir": "./src",
+  "schemaChanged": false,
+  "noBuild": false,
+  "build": {
+    "exitCode": 1,
+    "launched": true,
+    "errors": 50,
+    "warnings": 3
+  },
+  "baselineDiagnosticsLoaded": 0,
+  "state": {
+    "applied": 47,
+    "skipped": 6,
+    "manual": 3
+  },
+  "attribution": [
+    {
+      "ruleId": "MUD-003",
+      "errors": 38,
+      "warnings": 0,
+      "diagnostics": [
+        {
+          "file": "src/Dialogs/ConfirmDialog.cs",
+          "line": 42,
+          "code": "CS1501",
+          "message": "No overload for method 'Show' takes 2 arguments",
+          "severity": "error"
+        }
+      ]
+    }
+  ],
+  "unattributed": [
+    {
+      "file": "src/Other.cs",
+      "line": 100,
+      "code": "CS0618",
+      "message": "deprecated",
+      "severity": "warning"
+    }
+  ]
+}
+```
+
+### Key fields
+
+| Field | Description |
+|-------|-------------|
+| `build.exitCode` | Raw `dotnet build` exit code (0 = success) |
+| `attribution[]` | Errors/warnings grouped by the rule that likely caused them |
+| `attribution[].diagnostics[]` | Per-diagnostic details for `--verbose`-level inspection |
+| `unattributed[]` | Diagnostics not matched to any rewrite within ±3 lines |
+| `baselineDiagnosticsLoaded` | Count of pre-existing diagnostics loaded from `--baseline` |
+
+---
+
+## Common Gotchas
+
+### `--no-restore` assumption
+
+`verify` passes `--no-restore` to `dotnet build` to keep the invocation fast. In a fresh CI checkout, ensure a `dotnet restore` step runs before `verify`.
+
+### Schema drift
+
+If you edit the schema JSON after running `apply`, the stored state file's hash will no longer match. `verify` warns about this with:
+
+```
+WARNING: Schema has changed since last apply. Attribution may be inaccurate.
+```
+
+Re-run `migrate apply` to regenerate the state before running `verify` again.
+
+### Case-sensitive paths on Linux
+
+The ±3-line match normalises path separators (`\` → `/`) and uses case-insensitive comparison on Windows. On Linux and macOS the comparison is case-sensitive. Ensure the paths recorded in the state file match the actual filesystem casing — this is most commonly an issue when the schema was authored on Windows and the build runs on Linux.
+
+---
+
+> **Back to:** [Migration index](./index.md) · [State file format](./state.md) · [CLI reference](../guide/cli.md#migrate-verify)


### PR DESCRIPTION
## Summary

Implements #201. Adds `wrap-god migrate verify` command that optionally invokes `dotnet build`, parses compiler diagnostics, and correlates each back to the nearest applied migration rule via +-3-line proximity.

- `IBuildRunner` abstraction (`DotnetBuildRunner` + `StubBuildRunner` for tests) -- avoids real subprocess in unit tests
- `DiagnosticParser` uses `[GeneratedRegex]` to parse Roslyn/MSBuild output format
- `RuleAttributor` performs +-3-line proximity matching; tiebreak by latest rewrite in state
- Reports: attributed errors (per rule), unattributed (pre-existing/unrelated), pre-existing from `--baseline`
- Flags: `--no-build`, `--json`, `--verbose`, `--build-config`, `--baseline`
- Never blocks `apply`; informational only; always exits 0 unless IO error or bad args
- `DotnetBuildRunner` excluded from coverage (`[ExcludeFromCodeCoverage]` -- real subprocess, CI-only)

## Test plan

- [x] 20 TinyBDD scenarios in `MigrateVerifyCliTests.cs`: happy (5), sad (4), edge (11)
- [x] `CliCommandTests` updated: `ExpectedMigrateCommands` now includes `"verify"`
- [x] Full solution build clean: `dotnet build WrapGod.slnx -c Release -warnaserror` -- 0 errors, 0 warnings
- [x] Full test suite: 889 passed, 1 skipped (pre-existing network test), 0 failed
- [x] `docs/guide/cli.md` -- new `migrate verify` section with full options, exit codes, examples, gotchas
- [x] `docs/migration/verifying.md` -- new page: attribution algorithm, baseline workflow, graceful degradation
- [x] `docs/migration/state.md` -- cross-linked to verifying.md

Closes #201

Generated with Claude Code