### PR TITLE
docs(migration): #204 full migration documentation suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,41 @@ For the full walkthrough — extracting manifests, configuring rules, running an
 | `wrap-god diff` | Compare two manifest versions and report breaking changes |
 | `wrap-god merge` | Merge multiple version manifests into one |
 | `wrap-god migrate generate` | Generate a draft migration schema from two library versions (NuGet or local DLLs) |
+| `wrap-god migrate apply` | Apply a migration schema to a codebase (supports `--dry-run`) |
+| `wrap-god migrate status` | Report migration progress from the state file |
+| `wrap-god migrate verify` | Build the project and correlate compiler diagnostics to migration rules |
 
 Install: `dotnet tool install -g WrapGod.Cli`
 
 See [CLI Reference](docs/guide/cli.md) for full usage and options.
+
+## Migration Engine
+
+When a library you depend on ships breaking changes, WrapGod can automate the bulk of the upgrade work. The Migration Engine takes a [migration schema](docs/migration/schema.md) — a JSON file describing what changed (renames, moves, removals, restructurings) — and applies it to your codebase using Roslyn syntax rewriting. No compilation required: it handles broken code, preserves whitespace and comments, and records everything it touched so re-runs are safe.
+
+```bash
+# Generate a draft schema from two NuGet versions
+wrap-god migrate generate --package MudBlazor --from 6.0.0 --to 7.0.0
+
+# Preview changes (dry-run)
+wrap-god migrate apply \
+  --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json \
+  --project-dir ./src \
+  --dry-run
+
+# Apply for real
+wrap-god migrate apply \
+  --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json \
+  --project-dir ./src
+
+# Correlate any build errors to the rules that caused them
+wrap-god migrate verify \
+  --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json
+```
+
+The engine supports 11 rule kinds covering everything from simple renames to method splits, parameter-object extractions, and static member moves. Library authors can ship migration schemas alongside their NuGet packages so consumers can upgrade with a single command.
+
+See [Migration Engine documentation](docs/migration/index.md) for the full guide.
 
 ## The Pipeline
 
@@ -125,6 +156,11 @@ See [examples/README.md](examples/README.md) for the full catalog.
 - [Configuration Guide](docs/guide/configuration.md) — JSON, attributes, fluent DSL, merge precedence
 - [Compatibility Modes](docs/guide/compatibility.md) — LCD, Targeted, and Adaptive modes
 - [Analyzer Diagnostics](docs/guide/analyzers.md) — WG2001, WG2002, code fixes, suppression
+- [Migration Engine](docs/migration/index.md) — automated code migration: all 11 rule kinds, consumer workflow, authoring guide
+  - [Applying Migrations](docs/migration/applying.md) — consumer workflow: dry-run, apply, status, verify
+  - [Authoring a Migration Schema](docs/migration/authoring.md) — guide for library maintainers
+  - [Migration Schema Reference](docs/migration/schema.md) — JSON format and all rule kinds
+  - [Migration Engine Internals](docs/migration/engine.md) — architecture, lifecycle, extension points
 - [Migration Playbook](docs/migration/playbook.md) — strategy selection, authoring mappings, safety model
 - [Architecture](docs/guide/architecture.md) — pipeline internals and design decisions
 - [Engineering](docs/engineering/engineering.md) — SDK, build conventions, contribution guidelines

--- a/WrapGod.Tests/MigrationDocsCoverageTests.cs
+++ b/WrapGod.Tests/MigrationDocsCoverageTests.cs
@@ -115,6 +115,58 @@ public sealed class MigrationDocsCoverageTests
         Assert.Contains(page, doc, StringComparison.OrdinalIgnoreCase);
     }
 
+    // ── JSON shape drift test ──────────────────────────────────────────────
+
+    /// <summary>
+    /// For every <see cref="MigrationRuleKind"/>, reflects on the corresponding
+    /// <c>{Kind}Rule</c> record/class in <c>WrapGod.Migration</c> and verifies
+    /// that each public property name appears (in camelCase) somewhere in
+    /// <c>authoring.md</c>. Catches schema-model drift where a property is
+    /// renamed in the C# model but the documentation still references the old
+    /// name.
+    /// </summary>
+    [Fact]
+    public void AuthoringDoc_HasMatchingJsonFieldsForEveryRuleKind()
+    {
+        var doc = File.ReadAllText(MigrationDocPath("authoring.md"));
+        var migrationAsm = typeof(MigrationRule).Assembly;
+
+        // Properties present on the base MigrationRule type (Id, Kind, Confidence, Note)
+        // are documented in the "Rule object skeleton" section and need not appear in
+        // every per-kind section.
+        var baseProps = typeof(MigrationRule)
+            .GetProperties()
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = new List<string>();
+
+        foreach (var kindName in Enum.GetNames<MigrationRuleKind>())
+        {
+            var ruleType = migrationAsm.GetType($"WrapGod.Migration.{kindName}Rule");
+            if (ruleType is null)
+                continue; // Skip if the per-kind class isn't named {Kind}Rule.
+
+            foreach (var prop in ruleType.GetProperties())
+            {
+                if (baseProps.Contains(prop.Name))
+                    continue;
+
+                var camelCase = char.ToLowerInvariant(prop.Name[0]) + prop.Name[1..];
+                if (!doc.Contains(camelCase, StringComparison.Ordinal))
+                {
+                    missing.Add($"{kindName}Rule.{prop.Name} → '{camelCase}'");
+                }
+            }
+        }
+
+        Assert.True(
+            missing.Count == 0,
+            "authoring.md is missing documentation for the following rule property fields " +
+            "(model has them but docs do not mention them in camelCase):\n  " +
+            string.Join("\n  ", missing));
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/WrapGod.Tests/MigrationDocsCoverageTests.cs
+++ b/WrapGod.Tests/MigrationDocsCoverageTests.cs
@@ -1,0 +1,132 @@
+using System.Text.RegularExpressions;
+using WrapGod.Migration;
+
+namespace WrapGod.Tests;
+
+/// <summary>
+/// Static-text coverage tests for the migration documentation suite.
+/// Verifies that every <see cref="MigrationRuleKind"/> value is mentioned in
+/// the relevant documentation pages and that the CLI reference lists all four
+/// migrate subcommands.
+///
+/// These tests are intentionally mechanical — they catch documentation drift
+/// when new rule kinds or commands are added to the engine.
+/// </summary>
+public sealed class MigrationDocsCoverageTests
+{
+    // Locate the repo root relative to the test DLL output directory.
+    // The DLL lives at WrapGod.Tests/bin/{config}/{tfm}/
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "WrapGod.slnx")))
+            dir = dir.Parent;
+
+        if (dir == null)
+            throw new InvalidOperationException(
+                "Could not locate WrapGod.slnx from test output directory. " +
+                "Ensure the test is run from within the WrapGod repository.");
+
+        return dir.FullName;
+    }
+
+    private static string MigrationDocPath(string fileName) =>
+        Path.Combine(RepoRoot, "docs", "migration", fileName);
+
+    private static string GuideCLIDocPath() =>
+        Path.Combine(RepoRoot, "docs", "guide", "cli.md");
+
+    private static string ReadmeDocPath() =>
+        Path.Combine(RepoRoot, "README.md");
+
+    // ── authoring.md ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void AuthoringDoc_MentionsEveryRuleKind()
+    {
+        var doc = File.ReadAllText(MigrationDocPath("authoring.md"));
+
+        foreach (var kind in Enum.GetValues<MigrationRuleKind>())
+        {
+            // Each kind should appear as its camelCase JSON discriminator value
+            // e.g., RenameType → "renameType"
+            var camelCase = ToCamelCase(kind.ToString());
+            Assert.Contains(camelCase, doc, StringComparison.Ordinal);
+        }
+    }
+
+    // ── schema.md ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SchemaDoc_HasJsonExamplePerRuleKind()
+    {
+        var doc = File.ReadAllText(MigrationDocPath("schema.md"));
+
+        foreach (var kind in Enum.GetValues<MigrationRuleKind>())
+        {
+            var camelCase = ToCamelCase(kind.ToString());
+            // Each kind's JSON example should contain: "kind": "camelCaseValue"
+            var pattern = $@"""kind""\s*:\s*""{Regex.Escape(camelCase)}""";
+            Assert.Matches(pattern, doc);
+        }
+    }
+
+    // ── cli.md ─────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("migrate generate")]
+    [InlineData("migrate apply")]
+    [InlineData("migrate status")]
+    [InlineData("migrate verify")]
+    public void CliDoc_ListsAllMigrateSubcommands(string subcommand)
+    {
+        var doc = File.ReadAllText(GuideCLIDocPath());
+        Assert.Contains(subcommand, doc, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── README.md ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("migrate generate")]
+    [InlineData("migrate apply")]
+    [InlineData("migrate status")]
+    [InlineData("migrate verify")]
+    public void ReadmeCliTable_ListsMigrateCommands(string command)
+    {
+        var doc = File.ReadAllText(ReadmeDocPath());
+        Assert.Contains(command, doc, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── index.md ───────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("authoring.md")]
+    [InlineData("applying.md")]
+    [InlineData("schema.md")]
+    [InlineData("engine.md")]
+    [InlineData("rewriters.md")]
+    [InlineData("state.md")]
+    [InlineData("verifying.md")]
+    public void IndexDoc_LinksToSubpages(string page)
+    {
+        var doc = File.ReadAllText(MigrationDocPath("index.md"));
+        Assert.Contains(page, doc, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Converts a PascalCase enum name to camelCase, matching the JSON
+    /// discriminator convention used in migration schemas.
+    /// E.g., "RenameType" → "renameType".
+    /// </summary>
+    private static string ToCamelCase(string pascalCase)
+    {
+        if (string.IsNullOrEmpty(pascalCase))
+            return pascalCase;
+
+        return char.ToLowerInvariant(pascalCase[0]) + pascalCase[1..];
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -12,6 +12,9 @@
 - `wrap-god explain` – explain compatibility mode behavior for a manifest
 - `wrap-god migrate init` – analyze project usage and bootstrap migration plan assets
 - `wrap-god migrate generate` – generate a draft migration schema from two library versions (NuGet or local DLLs)
+- `wrap-god migrate apply` – apply a migration schema to a codebase (supports `--dry-run`)
+- `wrap-god migrate status` – read-only progress report from the state file
+- `wrap-god migrate verify` – optionally build the project and correlate compiler diagnostics to migration rules
 - `wrap-god ci bootstrap` – CI helper setup
 - `wrap-god ci parity` – CI parity report generation
 
@@ -39,6 +42,24 @@
 - `0` schema written successfully (0-rule schema emits a warning but still exits 0)
 - `1` runtime failure (missing files, network error, invalid version string, output file already exists)
 - `2` input validation error (conflicting modes, missing required mode flags)
+
+### `migrate apply`
+
+- `0` success — all applicable rules processed
+- `1` runtime error (schema not found, parse error, IO failure)
+- `2` bad arguments (required flag absent)
+
+### `migrate status`
+
+- `0` state file exists with no manual-confidence entries (or state file is missing)
+- `1` schema file not found, or state file is corrupt
+- `2` state has manual-confidence entries present — human review required
+
+### `migrate verify`
+
+- `0` verify ran (informational — even when attributed errors exist)
+- `1` IO error (baseline file not found, etc.)
+- `2` bad arguments
 
 ## Common examples
 

--- a/docs/migration/applying.md
+++ b/docs/migration/applying.md
@@ -4,12 +4,112 @@
 rewrites matching source files, and persists run state so that subsequent invocations are
 idempotent.
 
+> **Authoring a schema?** See [Authoring a Migration Schema](authoring.md). This page is for consumers.
+
+---
+
+## Consumer Workflow
+
+The recommended end-to-end workflow is:
+
+```
+migrate generate → review schema → migrate apply --dry-run → migrate apply → migrate status → migrate verify
+```
+
+### Step 1 — Obtain or generate a schema
+
+If the library author shipped a migration schema (as a file download, NuGet content package, or in their repository), download it. Otherwise, generate a draft:
+
+```bash
+wrap-god migrate generate \
+  --package MudBlazor \
+  --from 6.0.0 --to 7.0.0 \
+  --output mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json
+```
+
+See [CLI Reference: migrate generate](../guide/cli.md#migrate-generate) for all options.
+
+### Step 2 — Review the schema
+
+Open the schema JSON and check:
+
+- Are the rule IDs meaningful? (Rename them if the auto-generated names are not descriptive.)
+- Do any `manual` rules have a useful `note` explaining what to do? If not, add one before running.
+- Are there spurious `auto` rules that look risky? Downgrade them to `manual` or delete them.
+
+### Step 3 — Dry run
+
+Preview what would change without writing any files:
+
+```bash
+wrap-god migrate apply \
+  --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json \
+  --project-dir ./src \
+  --dry-run
+```
+
+The output shows:
+- Which files would be modified
+- A unified-diff preview for each file (truncated at 20 lines; full diff written to `.wrapgod/dryrun-<timestamp>.diff`)
+- Any `SkippedRewrite` entries that represent ambiguous matches
+- Any `Manual` rules that list the files they matched
+
+Review skipped rules: if a rule you expected to apply was skipped, check the reason and either fix the schema or note it for manual remediation.
+
+### Step 4 — Apply
+
+```bash
+wrap-god migrate apply \
+  --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json \
+  --project-dir ./src
+```
+
+Files are rewritten atomically. A state file is written next to the schema recording all applied, skipped, and manual entries.
+
+**Tip:** Run this with `--verbose` to see per-file rewrite details.
+
+### Step 5 — Handle manual rules
+
+After `apply`, check the output for `Manual:` entries. These are rules that the engine identified matching files for but never applied automatically. For each:
+
+1. Open the listed files.
+2. Read the rule's `note` field for guidance.
+3. Make the change by hand.
+4. Re-run `migrate apply` — the manual rule will again list its matched files until you've addressed them (manual rules are never auto-applied).
+
+### Step 6 — Check status
+
+```bash
+wrap-god migrate status \
+  --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json
+```
+
+This reads the state file and shows progress: how many rules have been applied, how many were skipped, and which manual rules remain.
+
+Exit code `2` means manual-confidence rules are still present. Exit code `0` means no manual rules remain (or no state file exists).
+
+### Step 7 — Verify
+
+```bash
+wrap-god migrate verify \
+  --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json \
+  --project-dir ./src
+```
+
+This optionally builds the project and correlates each compiler diagnostic back to the migration rule that most likely caused it. Use this to triage build errors after the migration.
+
+See [Verifying a Migration](verifying.md) for details.
+
+---
+
 ## Prerequisites
 
-1. A schema JSON file produced by [`wrap-god migrate generate`](../guide/cli.md#migrate-generate).
+1. A schema JSON file produced by [`wrap-god migrate generate`](../guide/cli.md#migrate-generate) or provided by the library author.
 2. The target project directory containing `.cs` source files.
 
-## Basic usage
+---
+
+## Basic Usage
 
 ```bash
 # Preview what would change (no files written, no state saved)
@@ -24,7 +124,9 @@ wrap-god migrate apply \
   --project-dir ./src
 ```
 
-## Options reference
+---
+
+## Options Reference
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
@@ -36,7 +138,9 @@ wrap-god migrate apply \
 | `--json` | No | `false` | Emit JSON summary instead of human-readable text |
 | `--verbose`, `-v` | No | `false` | Extra diagnostic output |
 
-## Exit codes
+---
+
+## Exit Codes
 
 | Code | Meaning |
 |------|---------|
@@ -44,10 +148,11 @@ wrap-god migrate apply \
 | `1` | Runtime error (schema not found, parse error, IO failure) |
 | `2` | Bad arguments (required flag missing) |
 
-## Glob filtering
+---
 
-Files are discovered using `Microsoft.Extensions.FileSystemGlobbing`. The defaults
-include all `.cs` files while excluding build output:
+## Glob Filtering
+
+Files are discovered using `Microsoft.Extensions.FileSystemGlobbing`. The defaults include all `.cs` files while excluding build output:
 
 ```bash
 # Include only files under a specific directory
@@ -71,7 +176,11 @@ wrap-god migrate apply \
   --exclude "**/Generated/**"
 ```
 
-## Idempotent re-runs
+**Tip:** Start with a narrow `--include` filter (e.g., one subdirectory) to validate the schema on a subset of your codebase before running on the whole project.
+
+---
+
+## Idempotent Re-runs
 
 The command is designed to be run multiple times safely. After each successful run, a
 state file is written next to the schema:
@@ -92,7 +201,9 @@ de-duplicated; entries that no longer match are dropped.
 **Recommended workflow:** Commit the state file alongside the schema so your team has
 visibility into which rules have been applied and which remain.
 
-## Manual rules
+---
+
+## Handling Manual Rules
 
 Rules with `confidence: "manual"` are **never applied automatically**. They are collected
 and shown in the output as requiring human intervention:
@@ -103,9 +214,42 @@ Manual:
     matched in: src/Dialogs/Confirm.cs, src/Dialogs/Edit.cs
 ```
 
-Use this information to guide manual edits after the automated apply step.
+Use this information to guide manual edits after the automated apply step. Re-running `migrate apply` will re-list the same manual rules until you've removed the matching patterns (or explicitly deleted the rule from the schema).
 
-## State file corruption recovery
+---
+
+## Handling Skipped Rules
+
+A `SkippedRewrite` means a rule was evaluated but not applied:
+
+```
+Skipped:
+  MUD-017 src/Dialogs/Confirm.cs:42  Ambiguous: two overloads of Show() in scope
+```
+
+Common skip reasons:
+
+| Reason | What it means | What to do |
+|--------|---------------|-----------|
+| `Ambiguous: …` | Receiver type could not be inferred syntactically | Add explicit type annotation at the call site, or change the rule to `confidence: "manual"` |
+| `no rewriter for kind '…'` | Rule kind not recognized by the engine version | Update to a version of WrapGod that supports the rule kind |
+| `type change requires semantic conversion` | `changeParameter` found a type-change that requires value conversion | Handle manually |
+| Return value consumed | `splitMethod` call site returns a value | Handle manually |
+| Chained call | `splitMethod` or `moveMember` call is chained | Handle manually |
+
+---
+
+## State File Lifecycle
+
+The state file records a history of applied rewrites. Key behaviors:
+
+- **`applied` list** — append-only, de-duplicated by `(ruleId, file)`. Persists across runs.
+- **`skipped` list** — replaced wholesale on each run. Reflects the most recent run only.
+- **`manual` list** — replaced wholesale on each run. Reflects the current schema's manual rules.
+
+See [Migration State](state.md) for the full state file format and hash semantics.
+
+### State file corruption recovery
 
 If the state file contains invalid JSON (e.g., was truncated by an interrupted write), the
 command automatically archives it to `{statePath}.bak` and performs a full re-run. The
@@ -122,7 +266,9 @@ WARNING: Prior state file was corrupt.
 In `--json` mode the recovery appears as a top-level `stateRecovered` object with an
 `archivedTo` field — CI consumers can act on it without parsing the skipped array.
 
-## JSON output mode
+---
+
+## JSON Output Mode
 
 Pass `--json` to get a machine-readable summary suitable for CI reporting:
 
@@ -148,7 +294,9 @@ Pass `--json` to get a machine-readable summary suitable for CI reporting:
 }
 ```
 
-## Dry-run diff preview
+---
+
+## Dry-run Diff Preview
 
 When `--dry-run` is set, the human-readable output prints a unified-diff-style preview for
 every file that would be modified:
@@ -168,9 +316,48 @@ references it.
 > precise diffs, point your favorite diff tool at the dump file. A follow-up issue tracks
 > upgrading to a richer hunked diff format.
 
-## See also
+---
+
+## CI Integration
+
+```yaml
+# Example GitHub Actions snippet — dry-run check
+- name: Check migration (dry-run)
+  run: |
+    wrap-god migrate apply \
+      --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json \
+      --project-dir ./src \
+      --dry-run \
+      --json > migration-result.json
+    cat migration-result.json
+
+- name: Fail if manual rules remain
+  run: |
+    MANUAL=$(jq '.manual' migration-result.json)
+    if [ "$MANUAL" -gt "0" ]; then
+      echo "Manual rules remain — human intervention required"
+      exit 1
+    fi
+```
+
+For CI pipelines where you want to apply the migration and verify the build:
+
+```yaml
+- name: Apply migration
+  run: wrap-god migrate apply --schema schema.json --project-dir ./src
+
+- name: Verify migration
+  run: wrap-god migrate verify --schema schema.json --project-dir ./src --json
+```
+
+---
+
+## See Also
 
 - [Migration Schema](schema.md) — schema model and rule kinds
+- [Authoring a Migration Schema](authoring.md) — for library maintainers
 - [Migration State](state.md) — state file format and hash semantics
+- [Verifying a Migration](verifying.md) — post-apply build correlation
 - [CLI Reference: migrate apply](../guide/cli.md#migrate-apply) — full flag reference
 - [CLI Reference: migrate generate](../guide/cli.md#migrate-generate) — how to produce the schema
+- [Back to Migration index](./index.md)

--- a/docs/migration/applying.md
+++ b/docs/migration/applying.md
@@ -86,7 +86,7 @@ wrap-god migrate status \
 
 This reads the state file and shows progress: how many rules have been applied, how many were skipped, and which manual rules remain.
 
-Exit code `2` means manual-confidence rules are still present. Exit code `0` means no manual rules remain (or no state file exists).
+When inspecting the result via `migrate status`, exit code `2` indicates manual-confidence rules are still present. Exit code `0` means no manual rules remain (or no state file exists). Note that `migrate apply` itself uses a different exit-code scheme (see [Exit Codes](#exit-codes) below — code 2 there means "bad arguments", not "manual rules present").
 
 ### Step 7 — Verify
 
@@ -141,6 +141,8 @@ wrap-god migrate apply \
 ---
 
 ## Exit Codes
+
+> **Note:** `migrate apply` exit codes differ from those of `migrate status`. For `migrate apply`, code `2` means "bad arguments". For `migrate status` (see [its CLI reference](../guide/cli.md#migrate-status)), code `2` means "manual-confidence rules are still present".
 
 | Code | Meaning |
 |------|---------|

--- a/docs/migration/authoring.md
+++ b/docs/migration/authoring.md
@@ -537,15 +537,40 @@ btn.Disabled = true;
 btn.SetDisabled(true);
 ```
 
-**Before / After (read, separate getter method):**
+**Before / After (read):**
 
 ```csharp
 // Before
 var b = btn.Disabled;
 
 // After
-var b = btn.GetDisabled();  // if newMethodName = "GetDisabled" on a separate read rule
+var b = btn.SetDisabled();  // same NewMethodName used in both contexts
 ```
+
+> **Note — single `NewMethodName` field:** `PropertyToMethodRule` has only one `NewMethodName` field, which the rewriter uses for both read and write contexts. The rewriter dispatches based on whether the property appears on the left-hand side of an assignment (write) or elsewhere (read), but it does NOT pick a different method name per context.
+>
+> **Need separate getter and setter method names?** Define **two rules** — one with the getter name and one with the setter name — both targeting the same property. The rewriter applies them in schema order:
+>
+> ```json
+> // Rule 1 — handles the write context (assignment LHS)
+> {
+>   "id": "MUD-010a",
+>   "kind": "propertyToMethod",
+>   "typeName": "MudBlazor.MudButton",
+>   "oldPropertyName": "Disabled",
+>   "newMethodName": "SetDisabled"
+> },
+> // Rule 2 — handles the read context (every other usage)
+> {
+>   "id": "MUD-010b",
+>   "kind": "propertyToMethod",
+>   "typeName": "MudBlazor.MudButton",
+>   "oldPropertyName": "Disabled",
+>   "newMethodName": "GetDisabled"
+> }
+> ```
+>
+> Because the rewriter rewrites writes to `Set...(value)` and reads to `Set...()` for a single rule, achieving distinct getter/setter names today requires deciding which name should appear in each context. A future rule kind may add separate `ReadMethodName`/`WriteMethodName` fields.
 
 **Skipped cases:** Compound-assignment expressions (`btn.Disabled++`, `btn.Disabled += 1`) are skipped.
 

--- a/docs/migration/authoring.md
+++ b/docs/migration/authoring.md
@@ -1,0 +1,784 @@
+# Authoring a Migration Schema
+
+This guide is for **library maintainers** who need to write a `MigrationSchema` so their users can upgrade between breaking versions — for example, providing a migration pack that helps consumers move from `MyLibrary 2.x` to `3.x`.
+
+> **Just consuming a migration?** See [Applying Migrations](applying.md) instead.
+
+---
+
+## When to Author a Pack (vs. Relying on `migrate generate`)
+
+`migrate generate` automatically builds a draft schema from two NuGet versions:
+
+```bash
+wrap-god migrate generate \
+  --package MyLibrary \
+  --from 2.0.0 --to 3.0.0
+```
+
+This covers the **boring 80%** — type renames, namespace moves, simple member renames. It is always your starting point.
+
+You need to author (or hand-tune) rules when:
+
+| Situation | What to do |
+|-----------|-----------|
+| A method was split into two methods | Add a `splitMethod` rule (cannot be generated) |
+| Parameters were restructured into a new options object | Add an `extractParameterObject` rule |
+| A property became a method | Add a `propertyToMethod` rule |
+| A member moved to a different type | Add a `moveMember` rule |
+| Auto-generated confidence is wrong | Promote/demote `confidence` by hand |
+| A removal needs a human note | Set the `note` field on `removeMember` |
+| You want to suppress a noisy auto-rule | Delete it from the JSON |
+
+---
+
+## Schema File Structure
+
+A migration schema is a UTF-8 JSON file. The recommended filename convention is:
+
+```
+{library}.{fromVersion}-to-{toVersion}.wrapgod-migration.json
+```
+
+Example: `mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json`
+
+### Top-level fields
+
+```json
+{
+  "schema": "wrapgod-migration/1.0",
+  "library": "MudBlazor",
+  "from": "6.0.0",
+  "to": "7.0.0",
+  "generatedFrom": "manifest-diff",
+  "lastEdited": "2026-04-01T00:00:00Z",
+  "rules": [ /* array of rule objects — see below */ ]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `schema` | Yes | Always `"wrapgod-migration/1.0"`. Enables forward-compatible parsing. |
+| `library` | Yes | NuGet package ID, e.g. `"MudBlazor"`. |
+| `from` | Yes | Old (source) version string, e.g. `"6.0.0"`. |
+| `to` | Yes | New (target) version string, e.g. `"7.0.0"`. |
+| `generatedFrom` | No | Informational provenance: `"manifest-diff"`, `"manual"`, etc. |
+| `lastEdited` | No | ISO-8601 timestamp of last manual edit. |
+| `rules` | Yes | Array of rule objects. May be empty; the schema is still valid. |
+
+### Rule object skeleton
+
+Every rule shares a common set of fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique identifier within the schema, e.g. `"MUD-001"`. Stable across edits — never reuse a retired ID. |
+| `kind` | Yes | Rule discriminator (camelCase). Determines the rule's shape and which rewriter handles it. |
+| `confidence` | No | `"auto"`, `"verified"`, or `"manual"`. Defaults to `"auto"` when omitted. See [Rule Confidence](#rule-confidence). |
+| `note` | No | Human-readable description of why this rule exists or what a `manual` rule requires. Shown in `migrate apply` output. |
+
+Additional fields depend on `kind` — documented for each kind below.
+
+### JSON comments
+
+The serializer accepts `//`-style line comments:
+
+```jsonc
+{
+  "schema": "wrapgod-migration/1.0",
+  "library": "MudBlazor",
+  // Bump after every manual edit
+  "lastEdited": "2026-04-15T10:00:00Z",
+  "rules": [
+    // Renamed in MudBlazor 7 RC1
+    {
+      "id": "MUD-001",
+      "kind": "renameType",
+      "oldName": "MudBlazor.Button",
+      "newName": "MudBlazor.MudButton"
+    }
+  ]
+}
+```
+
+---
+
+## Rule Kinds
+
+### `renameType`
+
+A type was renamed (optionally including a namespace change). The rewriter rewrites identifier nodes and fully-qualified names wherever the old name appears in a type position.
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-001",
+  "kind": "renameType",
+  "confidence": "auto",
+  "oldName": "MudBlazor.Button",
+  "newName": "MudBlazor.MudButton"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `oldName` | Yes | Fully-qualified old type name. |
+| `newName` | Yes | Fully-qualified new type name. |
+
+**Before / After:**
+
+```csharp
+// Before
+Button btn = new Button();
+Button[] btns = GetButtons();
+
+// After
+MudButton btn = new MudButton();
+MudButton[] btns = GetButtons();
+```
+
+**When to use:** Type was renamed or moved to a different namespace. If an entire namespace moved (multiple types), prefer `renameNamespace` to avoid generating dozens of individual rules.
+
+**Confidence guideline:** `auto` for generator-detected renames (similarity ≥ 0.65). `verified` if you have manually confirmed the rename is 1-to-1. `manual` only if human review is needed at each call site.
+
+---
+
+### `renameNamespace`
+
+A group of types moved from one namespace to another. The rewriter updates `using` directives and qualified names that have `OldNamespace` as a prefix.
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-002",
+  "kind": "renameNamespace",
+  "confidence": "auto",
+  "oldNamespace": "MudBlazor.Components",
+  "newNamespace": "MudBlazor"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `oldNamespace` | Yes | Old namespace prefix. Only exact-prefix matches are rewritten (followed by `.` or end-of-name). |
+| `newNamespace` | Yes | Replacement namespace prefix. |
+
+**Before / After:**
+
+```csharp
+// Before
+using MudBlazor.Components;
+using MudBlazor.Components.Dialog;
+
+// After
+using MudBlazor;
+using MudBlazor.Dialog;
+```
+
+**When to use:** When 2+ types relocated from one namespace tree to another. The generator collapses per-type renames into a single namespace rule when ≥2 types share the same relocation pattern. Prefer this over many individual `renameType` rules for bulk relocations.
+
+**Confidence guideline:** `auto` when generated from a diff showing ≥2 type moves in the same namespace. `verified` after checking that no unrelated types share the old namespace prefix.
+
+---
+
+### `renameMember`
+
+A method, property, field, or event was renamed on its declaring type.
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-003",
+  "kind": "renameMember",
+  "confidence": "verified",
+  "typeName": "MudBlazor.MudButton",
+  "oldMemberName": "Color",
+  "newMemberName": "ButtonColor"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `typeName` | Yes | Declaring type (short name or fully-qualified). |
+| `oldMemberName` | Yes | Old member name. |
+| `newMemberName` | Yes | New member name. |
+
+**Before / After:**
+
+```csharp
+// Before
+MudButton btn = new MudButton();
+btn.Color = MudColor.Primary;
+var c = btn.Color;
+
+// After
+MudButton btn = new MudButton();
+btn.ButtonColor = MudColor.Primary;
+var c = btn.ButtonColor;
+```
+
+**When to use:** A method or property on a specific type was renamed. The rewriter infers the receiver type syntactically from local variable declarations and parameter types. When the receiver type cannot be determined (e.g., a chained call result), the rewrite is skipped and recorded as a `SkippedRewrite`.
+
+**Confidence guideline:** `auto` for high-similarity generator matches. `verified` after manual confirmation the rename is safe. `manual` if receiver type inference might produce false positives in your library's usage patterns.
+
+---
+
+### `changeParameter`
+
+A method parameter was renamed, or its type changed in a way that only the label needs updating (named argument site).
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-004",
+  "kind": "changeParameter",
+  "confidence": "auto",
+  "typeName": "MudBlazor.MudButton",
+  "methodName": "SetSize",
+  "oldParameterName": "size",
+  "newParameterName": "buttonSize",
+  "oldParameterType": "int",
+  "newParameterType": "MudBlazor.Size"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `typeName` | Yes | Declaring type. |
+| `methodName` | Yes | Method whose parameter changed. |
+| `oldParameterName` | Yes | Old parameter name. |
+| `newParameterName` | Yes | New parameter name. |
+| `oldParameterType` | No | Old parameter type (informational). |
+| `newParameterType` | No | New parameter type (informational). |
+
+**Before / After (named argument rename):**
+
+```csharp
+// Before
+btn.SetSize(size: 42);
+
+// After
+btn.SetSize(buttonSize: 42);
+```
+
+**When to use:** When a named argument label changed. The rewriter only updates the label — it does NOT convert the argument value. For type conversions (e.g., `int` → `MyEnum`), the rule records a `SkippedRewrite` because value conversion is semantic, not syntactic. Use `confidence: "manual"` when the type also changed and human conversion is needed.
+
+**Confidence guideline:** `auto` for pure renames (same type, different name). `manual` when the parameter type changes and the argument value needs conversion.
+
+---
+
+### `removeMember`
+
+A member was removed with no direct automated replacement. Every call site is annotated with a `MIGRATION` comment containing the original text and the rule's `note`.
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-005",
+  "kind": "removeMember",
+  "confidence": "manual",
+  "note": "Use NewApi.Process() instead.",
+  "typeName": "MudBlazor.MudButton",
+  "memberName": "Deprecated"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `typeName` | Yes | Declaring type. |
+| `memberName` | Yes | Removed member name. |
+| `note` | No (but strongly recommended) | Human-readable guidance for what to do instead. Shown in the comment and in `migrate apply` output. |
+
+**Before / After:**
+
+```csharp
+// Before
+void M(MudButton btn)
+{
+    btn.Deprecated();
+    var x = 1;
+}
+
+// After
+void M(MudButton btn)
+{
+    // MIGRATION: MUD-005 removed — Use NewApi.Process() instead.: btn.Deprecated();
+    var x = 1;
+}
+```
+
+**When to use:** Member was removed with no safe automated replacement. The rewriter always removes the call statement and adds an annotated comment so developers know where to look. Set `confidence: "manual"` to prevent auto-application — the default for generated `removeMember` rules.
+
+**Confidence guideline:** `manual` in almost all cases. Use `auto` only if deleting the call site is definitively safe (e.g., a no-op method being removed).
+
+---
+
+### `addRequiredParameter`
+
+A required parameter was added to an existing method. The rewriter inserts a placeholder (`null` for reference types, `default` for value types) with a `TODO MIGRATION` comment.
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-006",
+  "kind": "addRequiredParameter",
+  "confidence": "manual",
+  "typeName": "MudBlazor.MudThemeProvider",
+  "methodName": "Apply",
+  "parameterName": "theme",
+  "parameterType": "MudBlazor.MudTheme",
+  "position": 0
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `typeName` | Yes | Declaring type. |
+| `methodName` | Yes | Method that gained the parameter. |
+| `parameterName` | Yes | New parameter name (used in the TODO comment). |
+| `parameterType` | Yes | New parameter type (determines `null` vs `default` placeholder). |
+| `position` | Yes | Zero-based insertion index. |
+
+**Before / After:**
+
+```csharp
+// Before
+provider.Apply();
+
+// After (reference type → null placeholder)
+provider.Apply(null /* TODO MIGRATION: MUD-006 required arg 'theme' (MudTheme) added */);
+
+// After (value type → default placeholder)
+provider.Apply(default /* TODO MIGRATION: MUD-006 required arg 'size' (int) added */);
+```
+
+**When to use:** A new required parameter was added. The inserted placeholder ensures the code compiles after the migration; developers must replace it with the real value.
+
+**Confidence guideline:** `manual` almost always — the correct value to pass depends on context that the rewriter cannot infer.
+
+---
+
+### `changeTypeReference`
+
+A type reference (short name or fully-qualified) was replaced across the API surface. The rewriter targets syntactic type positions: field declarations, method return types, parameter types, cast expressions, `typeof()`, generic type arguments, base lists, and object creation expressions.
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-007",
+  "kind": "changeTypeReference",
+  "confidence": "auto",
+  "oldType": "System.Collections.Generic.IList`1",
+  "newType": "System.Collections.Generic.IReadOnlyList`1"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `oldType` | Yes | Old type name (short or fully-qualified). Use the backtick-arity suffix for generics (e.g., `IList\`1`). |
+| `newType` | Yes | New type name. |
+
+**Before / After:**
+
+```csharp
+// Before
+IList<string> items;
+var t = typeof(IList<int>);
+
+// After
+IReadOnlyList<string> items;
+var t = typeof(IReadOnlyList<int>);
+```
+
+**When to use:** An interface or class was renamed at the type-reference level (rather than the identifier level, which `renameType` handles). Also used when a library switched from one base type to another across its API surface (e.g., `List<T>` → `IReadOnlyList<T>` in return types).
+
+**Confidence guideline:** `auto` when the replacement is always safe. `verified` when the new type is a drop-in replacement that you have confirmed. `manual` if not all usages can be safely replaced without semantic analysis.
+
+---
+
+### `splitMethod`
+
+One method was replaced by two or more methods. The rewriter substitutes the original call statement with the sequence of new calls, leaving the original as a `MIGRATION` comment.
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-008",
+  "kind": "splitMethod",
+  "confidence": "manual",
+  "typeName": "MudBlazor.MudCard",
+  "oldMethodName": "Render",
+  "newMethodNames": ["RenderHeader", "RenderBody", "RenderFooter"]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `typeName` | Yes | Declaring type. |
+| `oldMethodName` | Yes | Method being replaced. |
+| `newMethodNames` | Yes | Ordered list of replacement method names. Must have ≥2 entries. |
+
+**Before / After:**
+
+```csharp
+// Before
+card.Render();
+
+// After
+// MIGRATION: MUD-008 split-method — original: card.Render();
+card.RenderHeader();
+card.RenderBody();
+card.RenderFooter();
+```
+
+**Skipped cases:** The rewriter only handles statement-level calls. Call sites where the return value is consumed or where the call is chained are skipped with a descriptive reason:
+
+```csharp
+// Return value consumed → SkippedRewrite
+var html = card.Render();
+
+// Chained call → SkippedRewrite
+card.Render().ToString();
+```
+
+**Confidence guideline:** `manual` in most cases — the rewriter cannot verify that the sequence of new calls is equivalent to the old call for all inputs.
+
+---
+
+### `extractParameterObject`
+
+Several individually-named parameters were consolidated into a parameter object. The rewriter collapses matching named arguments into a `new {ParameterObjectType} { ... }` argument.
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-009",
+  "kind": "extractParameterObject",
+  "confidence": "manual",
+  "typeName": "MudBlazor.MudDialog",
+  "methodName": "ShowAsync",
+  "parameterObjectType": "MudBlazor.DialogParameters",
+  "extractedParameters": ["title", "content"]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `typeName` | Yes | Declaring type. |
+| `methodName` | Yes | Method whose parameters were consolidated. |
+| `parameterObjectType` | Yes | New parameter object type name. |
+| `extractedParameters` | Yes | Names of the parameters that moved into the object. Order within the object is alphabetical by property name. |
+
+**Before / After:**
+
+```csharp
+// Before (named args matching extractedParameters)
+dlg.ShowAsync(title: "Hello", content: "World");
+
+// After
+dlg.ShowAsync(new DialogParameters { Title = "Hello", Content = "World" });
+```
+
+Non-extracted arguments are preserved alongside the new object:
+
+```csharp
+// Before
+dlg.ShowAsync(title: "Hello", content: "World", callback: cb);
+
+// After
+dlg.ShowAsync(callback: cb, new DialogParameters { Title = "Hello", Content = "World" });
+```
+
+**Skipped cases:** Positional-only call sites where arguments cannot be unambiguously mapped to named parameters are skipped.
+
+**Confidence guideline:** `manual` — the property name casing convention (`Title` vs `title`) may vary.
+
+---
+
+### `propertyToMethod`
+
+A property was converted to a method (reads → no-arg call; writes → single-arg call).
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-010",
+  "kind": "propertyToMethod",
+  "confidence": "auto",
+  "typeName": "MudBlazor.MudButton",
+  "oldPropertyName": "Disabled",
+  "newMethodName": "SetDisabled"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `typeName` | Yes | Declaring type. |
+| `oldPropertyName` | Yes | Old property name. |
+| `newMethodName` | Yes | Replacement method name. Used for both read and write contexts. |
+
+**Before / After (write):**
+
+```csharp
+// Before
+btn.Disabled = true;
+
+// After
+btn.SetDisabled(true);
+```
+
+**Before / After (read, separate getter method):**
+
+```csharp
+// Before
+var b = btn.Disabled;
+
+// After
+var b = btn.GetDisabled();  // if newMethodName = "GetDisabled" on a separate read rule
+```
+
+**Skipped cases:** Compound-assignment expressions (`btn.Disabled++`, `btn.Disabled += 1`) are skipped.
+
+**Confidence guideline:** `auto` when the read→write transformation is a simple substitution. `manual` if side-effects differ between the old property and the new method.
+
+---
+
+### `moveMember`
+
+A static member was relocated from one type to another. The rewriter redirects `OldType.Member` references to `NewType.Member`.
+
+**JSON shape:**
+
+```json
+{
+  "id": "MUD-011",
+  "kind": "moveMember",
+  "confidence": "verified",
+  "oldTypeName": "MudBlazor.Utilities",
+  "newTypeName": "MudBlazor.MudHelpers",
+  "memberName": "GetColor"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `oldTypeName` | Yes | Type being moved from (short name or fully-qualified). |
+| `newTypeName` | Yes | Type to move to. |
+| `memberName` | Yes | Member name (must be the same in both types). |
+
+**Before / After:**
+
+```csharp
+// Before
+var h = Utilities.GetColor();
+
+// After
+var h = MudHelpers.GetColor();
+```
+
+**Skipped cases:** Instance calls where the receiver is inferred to be a variable of a different type, and lowercase unresolvable identifiers (assumed to be instance variables), are skipped.
+
+**Confidence guideline:** `verified` if you have confirmed the moved member has identical semantics at the new location. `manual` if the behavior changed.
+
+---
+
+## Rule Confidence
+
+| Value | Applied automatically? | Meaning |
+|-------|------------------------|---------|
+| `auto` | Yes | The rewriter will apply this rule without prompting. Use when the transformation is syntactically unambiguous and semantically safe. |
+| `verified` | Yes | Same as `auto` — applied automatically. The label signals that a human has manually reviewed and approved the rule. |
+| `manual` | No | The engine performs a read-only scan to find matching files, but never applies the change. The output shows matched files so developers know where to look. |
+
+When in doubt, prefer `manual` over `auto`. A migration that leaves `manual` annotations is safer than one that applies a wrong automated change.
+
+### Escalation path
+
+The generator assigns initial confidence. You can escalate or de-escalate:
+
+- `auto` → `verified`: You have tested the rule on a representative codebase and it is correct.
+- `auto` → `manual`: The rule is risky in your library's context (e.g., a member with a common name appears on many unrelated types).
+- `manual` → `auto`: You have added enough type qualification to make the rule safe.
+
+---
+
+## Similarity Tuning for Generation
+
+`migrate generate` uses Jaro-Winkler similarity to detect renames:
+
+| Threshold | Default | Effect |
+|-----------|---------|--------|
+| `--rename-similarity-threshold` | `0.65` | Minimum similarity for a remove+add pair to be treated as a rename |
+| `--verified-similarity-threshold` | `0.85` | Similarity at which confidence is promoted from `auto` to `verified` |
+
+Increase `--rename-similarity-threshold` if the draft schema contains spurious renames (unrelated types with similar names). Decrease it if genuine renames are being emitted as `manual` removals.
+
+```bash
+# Stricter rename detection
+wrap-god migrate generate \
+  --package MudBlazor --from 6.0.0 --to 7.0.0 \
+  --rename-similarity-threshold 0.80
+
+# Disable rename detection entirely (every removal becomes manual)
+wrap-god migrate generate \
+  --package MudBlazor --from 6.0.0 --to 7.0.0 \
+  --no-rename-detection
+```
+
+---
+
+## The Authoring Workflow
+
+The recommended process for shipping a migration pack:
+
+### Step 1 — Generate a draft
+
+```bash
+wrap-god migrate generate \
+  --package MyLibrary \
+  --from 2.0.0 --to 3.0.0 \
+  --rule-id-prefix MYLIB \
+  --output mylib.2.0-to-3.0.wrapgod-migration.json
+```
+
+Open the output JSON. Expect:
+- `auto` rules for straightforward renames and namespace moves
+- `manual` rules for removals and complex restructurings
+
+### Step 2 — Review and enrich
+
+Work through each `manual` rule:
+
+- Is the removal actually safe to automate? → change to `auto` and pick the right kind
+- Is there a good replacement pattern? → replace the `removeMember` rule with a more specific rule kind
+- Is human intervention genuinely required? → write a clear `note` explaining what the developer must do
+
+Promote `auto` rules to `verified` once you have tested them on at least one real consumer project.
+
+### Step 3 — Add hand-authored rules
+
+For B-level structural changes (split methods, extracted parameter objects, moved members), add rules manually. The generator cannot produce these from a diff.
+
+```json
+{
+  "id": "MYLIB-042",
+  "kind": "splitMethod",
+  "confidence": "manual",
+  "note": "Process() split into ProcessSync() and ProcessAsync(). Choose the appropriate variant.",
+  "typeName": "MyLibrary.Processor",
+  "oldMethodName": "Process",
+  "newMethodNames": ["ProcessSync", "ProcessAsync"]
+}
+```
+
+### Step 4 — Test on a sample project
+
+Use the synthetic before/after fixture pattern:
+
+1. Create a `Before.cs` with representative usages of the old API.
+2. Run `migrate apply --dry-run` and inspect the diff.
+3. Verify the diff matches your expected `After.cs`.
+4. Commit both fixtures alongside the schema as integration test evidence.
+
+See the [examples directory](../migration/examples/) for a Serilog v2→v3 example that follows this pattern.
+
+### Step 5 — Publish
+
+Distribute the schema alongside your library. Options:
+
+| Distribution method | When to use |
+|--------------------|-------------|
+| **Standalone file** (GitHub release attachment, documentation page download) | Simplest; works for all consumers |
+| **NuGet content package** (content files shipped in the `.nupkg`) | Enables tooling integrations to discover the schema automatically from the package |
+| **In-repo** (checked into the library repo, linked from the changelog) | Best for open-source libraries; the schema evolves with the library |
+
+For the NuGet content package approach, include the schema file in your `.csproj`:
+
+```xml
+<ItemGroup>
+  <Content Include="migration/*.wrapgod-migration.json">
+    <PackagePath>contentFiles/any/any/migration/</PackagePath>
+  </Content>
+</ItemGroup>
+```
+
+---
+
+## Common Gotchas
+
+### Ambiguous receivers
+
+`renameMember` and `changeParameter` rely on syntactic receiver-type inference. If your library has members with common names (e.g., `ToString`, `Equals`, `Name`) that also exist on many unrelated types, the rewriter will skip many call sites as ambiguous. To reduce false positives:
+
+- Use `confidence: "manual"` so the rule lists matched files without applying.
+- Add a `note` field explaining the disambiguation step.
+- Consider using `moveMember` instead when the rename is on a static or extension method.
+
+### Cross-namespace renames
+
+When a type moves AND is renamed simultaneously (e.g., `Acme.Legacy.FooWidget` → `Acme.Modern.BarWidget`), use a single `renameType` rule with the fully-qualified old and new names. Do NOT pair a `renameNamespace` rule with a `renameType` rule for the same type — the sequential rewriter pipeline will apply both rules and produce incorrect output.
+
+### Rule ID stability
+
+Once you publish a schema, never reuse a rule ID — consumers may have state files that reference it. If you retire a rule, delete it from the `rules` array but keep a comment or changelog noting what it was.
+
+### Rule ordering
+
+Rules are applied in the order they appear in the `rules` array. Place more-specific rules (targeting a specific type) before broader rules (targeting all types in a namespace) to avoid the broader rule interfering with the specific one.
+
+### Parameter position indices
+
+`addRequiredParameter` uses zero-based `position` indices. Verify the position against the new method signature, not the old one.
+
+---
+
+## Testing Your Schema
+
+### Dry-run verification
+
+```bash
+wrap-god migrate apply \
+  --schema mylib.2.0-to-3.0.wrapgod-migration.json \
+  --project-dir ./test-project \
+  --dry-run
+```
+
+Review the diff output. Check that:
+- Expected files appear in the modified list
+- `SkippedRewrite` entries are expected (not unexpected false-negatives)
+- `manual` rule matches reference the correct files
+
+### Synthetic fixture pattern
+
+The integration tests in `WrapGod.Tests` use a pattern of paired `Before.cs` / `After.cs` fixtures. You can replicate this:
+
+1. Create a `fixtures/before/` folder with representative old API usage.
+2. Run `migrate apply` targeting that folder (save a copy first).
+3. Diff the result against a `fixtures/after/` folder you pre-authored.
+4. Any deviation is a bug in your schema.
+
+### Docs coverage test
+
+The `WrapGod.Tests.MigrationDocsCoverageTests` class includes tests that verify every `MigrationRuleKind` enum value appears in `authoring.md` — catching schema-model drift early. If you add a new rule kind to the engine, add the corresponding section to this guide.
+
+---
+
+## See Also
+
+- [Migration Schema Reference](schema.md) — canonical JSON format and serialization API
+- [Schema Generation](schema-generation.md) — `MigrationSchemaGenerator.FromDiff` API
+- [Rewriters](rewriters.md) — how each rule kind is implemented by the engine
+- [Applying Migrations](applying.md) — consumer workflow
+- [Migration Engine](engine.md) — engine architecture and extension points
+- [CLI Reference: migrate generate](../guide/cli.md#migrate-generate) — full flag reference
+- [Back to Migration index](./index.md)

--- a/docs/migration/engine.md
+++ b/docs/migration/engine.md
@@ -2,9 +2,98 @@
 
 `WrapGod.Migration.Engine` is the Roslyn-backed rewrite pipeline that consumes a
 `MigrationSchema` (authored or generated via `WrapGod.Migration`) and applies its rules
-against C# source files. This page documents the scaffold contracts that ship in
-issue #194; the concrete rewriters and the orchestrator that wire everything together
-arrive in later issues (see "What's next" below).
+against C# source files.
+
+## Overview
+
+The migration engine automates the mechanical part of upgrading a codebase from one version of a library to another. Given a [migration schema](schema.md) that describes the breaking changes (renames, moves, removals, restructurings), the engine:
+
+1. Walks every `.cs` file in your project
+2. Parses each file into a Roslyn syntax tree (no compilation needed)
+3. Applies each applicable rule through its dedicated rewriter
+4. Preserves all whitespace and comments
+5. Injects any missing `using` directives for new namespaces
+6. Writes the result back to disk atomically
+
+The engine is purely syntactic — it never requires a compilable project or a `SemanticModel`. It handles broken code gracefully, which matters when part of your upgrade is fixing the very errors the migration introduces.
+
+### When to use the migration engine
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Upgrading a NuGet package that shipped a migration schema | Use `migrate apply` directly |
+| Upgrading a package with no schema available | Use `migrate generate` to draft a schema first |
+| Bulk-renaming types across a large codebase after an internal refactor | Author a schema manually; run `migrate apply` |
+| Complex structural changes (method splits, parameter objects) | Author B-level rules; run `migrate apply` with `confidence: "manual"` first |
+| Programmatic integration (CI, build scripts) | Use the `MigrationEngine` or `StatefulMigrationEngine` API directly |
+
+## Architecture Diagram
+
+```
+ ┌─────────────────────────────────────────────────────────────────────────┐
+ │  User inputs                                                             │
+ │  ─────────                                                               │
+ │  MigrationSchema JSON           Source files (.cs)                       │
+ └──────────┬──────────────────────────────────┬───────────────────────────┘
+            │                                  │
+            ▼                                  ▼
+ ┌─────────────────────┐          ┌────────────────────────┐
+ │ MigrationSchema     │          │ IMigrationFileSystem   │
+ │ (deserialized)      │          │ ReadAllText()          │
+ └──────────┬──────────┘          └──────────┬─────────────┘
+            │                               │
+            ▼                               ▼
+ ┌─────────────────────────────────────────────────────────┐
+ │                     MigrationEngine                      │
+ │  ┌───────────────────────────────────────────────────┐  │
+ │  │  Per-file loop (deduplicated paths)               │  │
+ │  │  ┌─────────────────────────────────────────────┐  │  │
+ │  │  │  CSharpSyntaxTree.ParseText()               │  │  │
+ │  │  │         │                                   │  │  │
+ │  │  │  Manual-rule scan → MatchedFiles            │  │  │
+ │  │  │         │                                   │  │  │
+ │  │  │  Auto-rule chain (sequential):              │  │  │
+ │  │  │    rule1 → IRuleRewriter.TryRewrite()       │  │  │
+ │  │  │    rule2 → IRuleRewriter.TryRewrite()       │  │  │
+ │  │  │    ...                                      │  │  │
+ │  │  │         │                                   │  │  │
+ │  │  │  Using injection post-pass                  │  │  │
+ │  │  │         │                                   │  │  │
+ │  │  │  WriteAllTextAtomic() (Apply mode only)     │  │  │
+ │  │  └─────────────────────────────────────────────┘  │  │
+ │  └───────────────────────────────────────────────────┘  │
+ │                          │                               │
+ │            MigrationResult aggregate                     │
+ └──────────────────────────┬──────────────────────────────┘
+                            │
+            ┌───────────────┼───────────────┐
+            ▼               ▼               ▼
+         Applied[]       Skipped[]       Manual[]
+```
+
+## Full Lifecycle
+
+For each file in the deduplicated `filePaths` set:
+
+1. **Read** — `IMigrationFileSystem.ReadAllText(filePath)`. `IOException` → records a `SkippedRewrite` with `RuleId = "<io>"` and continues to the next file.
+
+2. **Parse** — `CSharpSyntaxTree.ParseText(text)`. Syntax-only; no project references or compilation required. Broken code is accepted.
+
+3. **Manual scan** — For every rule with `Confidence = Manual`, the matching `IRuleRewriter` performs a read-only tree-walk to identify whether the file contains matching patterns. Matches populate `ManualRewrite.MatchedFiles`. Nothing is written.
+
+4. **Auto-rule chain** — For every rule with `Confidence = Auto` or `Verified`, in schema order:
+   - Lookup the `IRuleRewriter` whose `Kind` matches `camelCase(rule.Kind)`.
+   - If no rewriter is registered → record `SkippedRewrite("no rewriter for kind '…'")`.
+   - If found → call `TryRewrite(currentRoot, rule, ctx)`. The returned node replaces `currentRoot` for the next rule in the chain.
+   - This sequential strategy lets each rule see the output of previous rules (e.g., `Foo → Bar` then `Bar → Baz` in two passes).
+
+5. **Using injection** — After all rules run, inspect the final `CompilationUnitSyntax`. For any namespace introduced by an applied `ChangeTypeReferenceRule`, `RenameNamespaceRule`, or `RenameTypeRule` that is not already present in the file, inject a `using` directive at the top.
+
+6. **Write** — In `Apply` mode (not dry-run), write the modified file atomically: write to `{path}.tmp`, then `File.Move(tmp, path, overwrite: true)`. In `DryRun` mode, skip the write.
+
+After all files: aggregate `Applied`, `Skipped`, `Manual`, and `RewrittenFiles` into a `MigrationResult`.
+
+---
 
 ## Public contracts
 
@@ -214,11 +303,94 @@ The engine runs a syntax-only "would this rule match?" scan and populates
 `MigrationResult.Manual[].MatchedFiles` with every file where the pattern was
 detected. The `Applied` list contains no entries for manual rules.
 
-## What's next
+## Extension Points
 
-- **#202** — B-level structural rewriters (`SplitMethod`,
-  `ExtractParameterObject`, `PropertyToMethod`, `MoveMember`).
-- **#203** — End-to-end example with a real library migration (Serilog v2 → v3).
+### Writing a Custom `IRuleRewriter`
+
+If the eleven built-in rewriters do not cover your transformation, you can implement `IRuleRewriter` yourself:
+
+```csharp
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using WrapGod.Migration;
+using WrapGod.Migration.Engine;
+
+public sealed class MyCustomRewriter : IRuleRewriter
+{
+    // Must match the camelCase "kind" string in your schema JSON.
+    public string Kind => "myCustomKind";
+
+    public SyntaxNode? TryRewrite(SyntaxNode node, MigrationRule rule, RewriteContext ctx)
+    {
+        // Cast to your rule type (define it in WrapGod.Migration or a sibling project).
+        if (rule is not MyCustomRule typed)
+            return null;
+
+        // Only handle the node type you care about.
+        if (node is not SomeSpecificSyntaxNode target)
+            return null;
+
+        // Perform the transformation.
+        var replacement = BuildReplacement(target, typed);
+
+        // REQUIRED: preserve trivia so whitespace and comments are not corrupted.
+        replacement = replacement.WithTriviaFrom(target);
+
+        // Record the outcome.
+        ctx.RecordApplied(
+            rule,
+            target.Span,
+            originalText: target.ToString(),
+            replacementText: replacement.ToString(),
+            line: target.GetLocation().GetLineSpan().StartLinePosition.Line + 1);
+
+        return replacement;
+    }
+}
+```
+
+Key obligations:
+
+| Obligation | Why |
+|-----------|-----|
+| Preserve trivia via `WithTriviaFrom` | Corrupting trivia mangling whitespace or stripping comments |
+| Return `null` when no match | The orchestrator uses `null` to skip file writes when no rule matched |
+| Record `SkippedRewrite` for ambiguous matches | Ambiguous matches should be visible to the author — don't silently skip |
+| No `SemanticModel` access | The engine never has a compilation; rewriters must be syntax-only |
+| Never throw | Exceptions propagate to the orchestrator and abort the entire file |
+
+### Registering a Custom Rewriter
+
+Inject your rewriter into a `MigrationEngine` instead of using `CreateDefault()`:
+
+```csharp
+var engine = new MigrationEngine(
+    MigrationEngine.CreateDefault().Rewriters
+        .Append(new MyCustomRewriter()));
+```
+
+Or build from scratch if you only need a subset of rewriters:
+
+```csharp
+var engine = new MigrationEngine([
+    new RenameTypeRewriter(),
+    new RenameMemberRewriter(),
+    new MyCustomRewriter(),
+]);
+```
+
+### Injecting a Custom File System
+
+For testing or virtual file system scenarios, pass an `IMigrationFileSystem` via the internal constructor (exposed to `WrapGod.Tests` via `InternalsVisibleTo`):
+
+```csharp
+// In test code
+var engine = new MigrationEngine(
+    rewriters: [new RenameTypeRewriter()],
+    fileSystem: new InMemoryFileSystem(files));
+```
+
+`IMigrationFileSystem` exposes `ReadAllText(path)` and `WriteAllTextAtomic(path, content)`. The default `RealFileSystem` implementation uses `System.IO.File` with atomic writes.
 
 ## State-tracking (idempotent re-runs)
 
@@ -227,3 +399,12 @@ base engine with persistent state so that `apply` runs are idempotent. The
 state is stored in a sibling file next to the schema (e.g.
 `schema.json.state.json`). See [Migration State](state.md) for the full
 specification, hash semantics, and API reference.
+
+## See Also
+
+- [Migration Schema](schema.md) — schema format and all rule kinds
+- [Authoring a Migration Schema](authoring.md) — guide for library maintainers
+- [Rewriters](rewriters.md) — per-rewriter documentation with before/after examples
+- [Migration State](state.md) — idempotency, state file format, hash semantics
+- [Applying Migrations](applying.md) — consumer workflow
+- [Back to Migration index](./index.md)

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -1,13 +1,68 @@
-# Migration
+# Migration Engine
 
-Strategies and automation for migrating codebases between library versions and across libraries.
+The WrapGod Migration Engine automates the mechanical part of upgrading a .NET codebase when a library ships breaking changes. Given a [migration schema](schema.md) that describes what changed — renames, moves, removals, structural restructurings — the engine walks your source files, applies the rules via Roslyn syntax rewriting, and writes the results back atomically.
 
-- [Migration Playbook](playbook.md) — strategy selection, safety model, validation checklist
-- [Automation Guide](automation.md) — end-to-end automation for eliminating library tech debt
-- [Migration Schema](schema.md) — `WrapGod.Migration` schema model and rule kinds reference
-- [Migration Engine](engine.md) — `WrapGod.Migration.Engine` rewrite pipeline contracts (`IRuleRewriter`, `RewriteContext`, `MigrationResult`)
-- [Schema Generation](schema-generation.md) — `MigrationSchemaGenerator.FromDiff` — diff → schema mapping, similarity thresholds, deterministic IDs
-- [A-Level Rewriters](rewriters.md) — Seven concrete `IRuleRewriter` implementations: `RenameType`, `RenameNamespace`, `RenameMember`, `ChangeParameter`, `RemoveMember`, `AddRequiredParameter`, `ChangeTypeReference`
-- [Migration State](state.md) — `MigrationState`, `MigrationStateStore`, `StatefulMigrationEngine`: state file location, SHA-256 schema hash, idempotent re-runs, corruption recovery
-- [Applying Migrations](applying.md) — `wrap-god migrate apply` consumer workflow: dry-run, glob filtering, idempotence, state management
-- [Examples](examples.md) — End-to-end, CI-validated examples (Serilog v2 → v3 upgrade walkthrough + bidirectional comparisons)
+The engine is syntax-only (no compilation required). It handles broken code gracefully, preserves all whitespace and comments, and injects missing `using` directives automatically.
+
+## Quick Start
+
+```bash
+# Generate a draft schema from two NuGet versions
+wrap-god migrate generate --package MudBlazor --from 6.0.0 --to 7.0.0
+
+# Preview the changes
+wrap-god migrate apply --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json --dry-run
+
+# Apply for real
+wrap-god migrate apply --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json
+
+# Check progress
+wrap-god migrate status --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json
+
+# Correlate compiler errors to migration rules
+wrap-god migrate verify --schema mudblazor.6.0.0-to-7.0.0.wrapgod-migration.json
+```
+
+## Documentation
+
+### For Migration Consumers
+
+| Page | What you'll find |
+|------|-----------------|
+| [Applying Migrations](applying.md) | End-to-end consumer workflow: dry-run, apply, status, verify; glob filtering, CI integration |
+| [Migration State](state.md) | State file format, SHA-256 hash semantics, idempotent re-runs, corruption recovery |
+| [Verifying a Migration](verifying.md) | Post-apply build correlation: attribution algorithm, baseline workflow, JSON output |
+
+### For Migration Pack Authors
+
+| Page | What you'll find |
+|------|-----------------|
+| [Authoring a Migration Schema](authoring.md) | All 11 rule kinds with JSON examples and before/after C# snippets; confidence guidelines; authoring workflow; common gotchas |
+| [Migration Schema Reference](schema.md) | Canonical JSON format, field reference, serialization API, JSON Schema validation |
+| [Schema Generation](schema-generation.md) | `MigrationSchemaGenerator.FromDiff` — diff-to-schema mapping, similarity thresholds, deterministic IDs |
+
+### Engine Internals
+
+| Page | What you'll find |
+|------|-----------------|
+| [Migration Engine](engine.md) | Architecture diagram, full lifecycle, public API (`MigrationEngine`, `StatefulMigrationEngine`, `IRuleRewriter`, `MigrationResult`), performance, extension points |
+| [Rewriters](rewriters.md) | All 11 concrete `IRuleRewriter` implementations with per-rewriter contracts and before/after examples |
+
+### Strategy and Context
+
+| Page | What you'll find |
+|------|-----------------|
+| [Migration Playbook](playbook.md) | Strategy selection, safety model, validation checklist |
+| [Automation Guide](automation.md) | End-to-end automation for eliminating library tech debt |
+| [Examples](examples.md) | End-to-end, CI-validated examples (Serilog v2 → v3 upgrade walkthrough + bidirectional comparisons) |
+
+## CLI Reference
+
+The `wrap-god` CLI exposes four `migrate` subcommands:
+
+| Command | Purpose |
+|---------|---------|
+| [`migrate generate`](../guide/cli.md#migrate-generate) | Generate a draft schema from two library versions (NuGet or local DLLs) |
+| [`migrate apply`](../guide/cli.md#migrate-apply) | Apply a schema to a project directory, with dry-run support |
+| [`migrate status`](../guide/cli.md#migrate-status) | Read-only progress report from the state file |
+| [`migrate verify`](../guide/cli.md#migrate-verify) | Build the project and correlate compiler diagnostics to migration rules |

--- a/docs/migration/toc.yml
+++ b/docs/migration/toc.yml
@@ -1,20 +1,38 @@
 - name: Overview
   href: index.md
 
+- name: Applying Migrations
+  href: applying.md
+
+- name: Authoring a Migration Schema
+  href: authoring.md
+
+- name: Migration Schema Reference
+  href: schema.md
+
+- name: Migration Engine
+  href: engine.md
+
+- name: Rewriters
+  href: rewriters.md
+
+- name: Schema Generation
+  href: schema-generation.md
+
+- name: Migration State
+  href: state.md
+
+- name: Verifying a Migration
+  href: verifying.md
+
 - name: Migration Playbook
   href: playbook.md
 
 - name: Automation Guide
   href: automation.md
 
-- name: Migration Schema
-  href: schema.md
-
-- name: Migration Engine
-  href: engine.md
-
-- name: A-Level Rewriters
-  href: rewriters.md
-
 - name: Examples
   href: examples.md
+
+- name: CLI Reference
+  href: ../guide/cli.md


### PR DESCRIPTION
## Summary

Implements #204 — comprehensive migration documentation suite.

- **docs/migration/authoring.md** (NEW, ~700 lines): Complete guide for schema authors. Covers all 11 rule kinds with JSON shapes, before/after C# snippets, confidence guidelines, common gotchas, authoring workflow, and distribution options.
- **docs/migration/engine.md** (EXTENDED): Added full ASCII architecture diagram, per-step lifecycle walkthrough, extension points (custom IRuleRewriter, custom IMigrationFileSystem), updated See Also links.
- **docs/migration/applying.md** (CONSOLIDATED): Complete consumer workflow (generate -> dry-run -> apply -> status -> verify), handling skipped/manual rules, state file lifecycle, CI integration YAML examples.
- **docs/migration/index.md** (UPGRADED): Landing page with quick-start, organized tables for consumers / authors / engine internals / strategy, and CLI subcommand reference.
- **docs/migration/toc.yml** (UPDATED): Full TOC with all pages in logical reading order.
- **docs/CLI.md** (UPDATED): Added migrate apply/status/verify to command surface and exit code tables.
- **README.md** (UPDATED): New Migration Engine section with quickstart; updated CLI table with all four migrate subcommands; expanded Documentation section.
- **WrapGod.Tests/MigrationDocsCoverageTests.cs** (NEW): 17 static-text tests verifying every MigrationRuleKind appears in authoring.md, schema.md has JSON examples per kind, CLI doc and README list all four migrate subcommands, index.md links all sub-pages.

## Test plan

- [x] dotnet build WrapGod.slnx -c Release -warnaserror — green (0 warnings, 0 errors)
- [x] dotnet test --filter MigrationDocsCoverageTests — 17/17 passed
- [x] No .cs production files modified
- [x] All 11 MigrationRuleKind values documented in authoring.md
- [x] All 4 migrate subcommands listed in README.md CLI table and docs/CLI.md
- [x] index.md links to all sub-pages

Closes #204

Generated with [Claude Code](https://claude.com/claude-code)