### PR TITLE
refactor: dogfood PatternKit migration chain

### DIFF
--- a/WrapGod.Migration.Engine/MigrationEngine.cs
+++ b/WrapGod.Migration.Engine/MigrationEngine.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using PatternKit.Behavioral.Chain;
 using WrapGod.Migration;
 using WrapGod.Migration.Engine.Rewriters;
 using WrapGod.Migration.Engine.Rewriters.Structural;
@@ -13,11 +14,11 @@ namespace WrapGod.Migration.Engine;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <strong>Composition strategy (Option A — sequential chain):</strong>
-/// Rules execute in schema order; rewriter N receives the output of rewriter N−1.
-/// One tree-walk per (file, rule) pair.  Option A was chosen because it is simple,
-/// the existing rewriters each encapsulate their own walk, and the perf target
-/// (&lt;5 s for 1 000 files) is met comfortably.
+/// <strong>Composition strategy (Option A — PatternKit sequential chain):</strong>
+/// Auto rules execute in schema order through a PatternKit async action chain; rewriter
+/// N receives the output of rewriter N−1. One tree-walk per (file, rule) pair. Option A
+/// was chosen because it is simple, the existing rewriters each encapsulate their own
+/// walk, and the perf target (&lt;5 s for 1 000 files) is met comfortably.
 /// </para>
 /// <para>
 /// <strong>File I/O:</strong> Inject <see cref="IMigrationFileSystem"/> for testability.
@@ -265,31 +266,13 @@ public sealed class MigrationEngine
                 }
             }
 
-            // ── Auto rules (Option A: sequential chain) ───────────────────────
+            // ── Auto rules (Option A: PatternKit sequential chain) ────────────
             var ctx2 = new RewriteContext(filePath, alreadyApplied);
-            var currentRoot = root;
-            bool fileModified = false;
-
-            foreach (var rule in autoRules)
-            {
-                var kindKey = KindKey(rule);
-                if (!_rewritersByKind.TryGetValue(kindKey, out var rewriter))
-                {
-                    // Schema-level skip already emitted up-front; do not duplicate.
-                    continue;
-                }
-
-                // State-tracking: skip rules already applied to this file in a prior run.
-                if (ctx2.IsAlreadyApplied(rule.Id))
-                    continue;
-
-                var newRoot = InternalRewriterDispatcher.Apply(rewriter, currentRoot, rule, ctx2);
-                if (!ReferenceEquals(newRoot, currentRoot))
-                {
-                    currentRoot = newRoot;
-                    fileModified = true;
-                }
-            }
+            var autoState = new AutoRewriteChainState(root, ctx2);
+            var autoChain = BuildAutoRewriteChain(autoRules);
+            autoChain.ExecuteAsync(autoState).AsTask().GetAwaiter().GetResult();
+            var currentRoot = autoState.Root;
+            var fileModified = autoState.FileModified;
 
             // ── Cross-namespace using injection ───────────────────────────────
             // After all per-rule rewrites, ensure that every namespace introduced
@@ -523,6 +506,56 @@ public sealed class MigrationEngine
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private AsyncActionChain<AutoRewriteChainState> BuildAutoRewriteChain(
+        IReadOnlyList<MigrationRule> autoRules)
+    {
+        var builder = AsyncActionChain<AutoRewriteChainState>.Create();
+
+        foreach (var rule in autoRules)
+        {
+            builder.Use((state, ct, next) =>
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var kindKey = KindKey(rule);
+                if (_rewritersByKind.TryGetValue(kindKey, out var rewriter) &&
+                    !state.Context.IsAlreadyApplied(rule.Id))
+                {
+                    var newRoot = InternalRewriterDispatcher.Apply(
+                        rewriter,
+                        state.Root,
+                        rule,
+                        state.Context);
+
+                    if (!ReferenceEquals(newRoot, state.Root))
+                    {
+                        state.Root = newRoot;
+                        state.FileModified = true;
+                    }
+                }
+
+                return next(state, ct);
+            });
+        }
+
+        builder.Finally((_, _) => ValueTask.CompletedTask);
+
+        return builder.Build();
+    }
+
+    private sealed class AutoRewriteChainState
+    {
+        public AutoRewriteChainState(SyntaxNode root, RewriteContext context)
+        {
+            Root = root;
+            Context = context;
+        }
+
+        public SyntaxNode Root { get; set; }
+        public RewriteContext Context { get; }
+        public bool FileModified { get; set; }
+    }
 
     /// <summary>
     /// Converts a <see cref="MigrationRule.Kind"/> enum value to the camelCase

--- a/WrapGod.Migration.Engine/WrapGod.Migration.Engine.csproj
+++ b/WrapGod.Migration.Engine/WrapGod.Migration.Engine.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="PatternKit.Core" Version="0.147.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WrapGod.Tests/Migration/Engine/MigrationEngineTests.cs
+++ b/WrapGod.Tests/Migration/Engine/MigrationEngineTests.cs
@@ -136,6 +136,41 @@ public sealed class MigrationEngineTests(ITestOutputHelper output) : TinyBddXuni
         .And("final content does not contain Foo", content => !content.Contains("Foo"))
         .AssertPassed();
 
+    [Scenario("Happy-04b: PatternKit auto-rule chain skips prior-state rule and continues to next rule")]
+    [Fact]
+    public Task Happy04b_PatternKitAutoRuleChain_SkipsAlreadyAppliedAndContinues() =>
+        Given("two auto rules where the first is already applied for the file", () =>
+        {
+            var executed = new List<string>();
+            var rewriter = new LambdaRewriter("renameType", (node, rule, ctx) =>
+            {
+                executed.Add(rule.Id);
+                ctx.RecordApplied(rule, default, "old", "new", 1);
+                return node;
+            });
+            var schema = new MigrationSchema
+            {
+                Library = "Test", From = "1.0", To = "2.0",
+                Rules =
+                [
+                    new RenameTypeRule { Id = "RT-SKIP", OldName = "A", NewName = "B" },
+                    new RenameTypeRule { Id = "RT-RUN", OldName = "B", NewName = "C" },
+                ]
+            };
+            var alreadyApplied = new HashSet<(string RuleId, string File)>
+            {
+                ("RT-SKIP", "chain.cs")
+            };
+            var fs = new InMemoryFileSystem().WithFile("chain.cs", "class C { A value; }");
+            var engine = new MigrationEngine([rewriter], fs);
+            var result = engine.DryRun(schema, ["chain.cs"], alreadyApplied);
+            return (result, executed);
+        })
+        .Then("only the second rule executed", t => t.executed.SequenceEqual(["RT-RUN"]))
+        .And("only the second rule was recorded as applied", t =>
+            t.result.Applied.Select(a => a.RuleId).SequenceEqual(["RT-RUN"]))
+        .AssertPassed();
+
     [Scenario("Happy-05: multiple files → all matching files rewritten, count correct")]
     [Fact]
     public Task Happy05_MultipleFiles_AllMatchesRewritten() =>

--- a/docs/migration/engine.md
+++ b/docs/migration/engine.md
@@ -244,7 +244,7 @@ foreach file in filePaths (deduplicated):
      └─ IOException → record SkippedRewrite("<io>", …) and continue
   2. CSharpSyntaxTree.ParseText() — syntax-only, no compilation
   3. Manual rules: scan file with matching rewriter, collect MatchedFiles
-  4. Auto rules (schema order, Option A — sequential chain):
+  4. Auto rules (schema order, Option A — PatternKit sequential chain):
      for each rule:
        - lookup IRuleRewriter by camelCase(rule.Kind)
        - missing → SkippedRewrite("no rewriter for kind '…'", …)
@@ -256,7 +256,8 @@ Aggregate Applied, Skipped, Manual into MigrationResult
 
 ### Composition strategy
 
-**Option A — sequential chain** was chosen over Option B (single-pass dispatcher)
+**Option A — sequential chain** is implemented with PatternKit's
+`AsyncActionChain<T>` primitive and was chosen over Option B (single-pass dispatcher)
 because:
 
 - Every existing `IRuleRewriter` already encapsulates its own `CSharpSyntaxRewriter`
@@ -266,6 +267,11 @@ because:
 - The perf budget (&lt;5 s for 1 000 files) is met with room to spare
   (~620 ms measured in CI on this machine).
 - Option B can be introduced incrementally if profiling identifies a bottleneck.
+
+The public `MigrationEngine`, `IRuleRewriter`, and `RewriteContext` contracts remain
+unchanged. PatternKit owns only the per-file auto-rule composition: unknown rule kinds
+are still reported once per schema up front, already-applied rules are skipped, and each
+matching rule receives the root produced by the previous rule.
 
 Each (file, rule) pair performs one tree-walk. For a schema with `N` rules and `F` files:
 total walks = `N × F`.


### PR DESCRIPTION
## Summary
- compose migration auto-rule execution with PatternKit.Core's async action chain
- preserve MigrationEngine, IRuleRewriter, and RewriteContext contracts
- add TinyBDD coverage for already-applied rule skipping while the chain continues
- document the PatternKit-backed sequential chain in the migration guide

Refs #220.

## Validation
- dotnet build WrapGod.slnx --configuration Release --no-restore
- dotnet test WrapGod.Tests\\WrapGod.Tests.csproj --configuration Release --no-build
- git diff --check