### PR TITLE
refactor: reuse migration rule chain per run

### DIFF
--- a/WrapGod.Migration.Engine/MigrationEngine.cs
+++ b/WrapGod.Migration.Engine/MigrationEngine.cs
@@ -223,6 +223,8 @@ public sealed class MigrationEngine
                 $"no rewriter for kind '{KindKey(rule)}'"));
         }
 
+        var autoChain = BuildAutoRewriteChain(autoRules);
+
         foreach (var filePath in filePaths)
         {
             if (!dedupedPaths.Add(filePath))
@@ -269,7 +271,6 @@ public sealed class MigrationEngine
             // ── Auto rules (Option A: PatternKit sequential chain) ────────────
             var ctx2 = new RewriteContext(filePath, alreadyApplied);
             var autoState = new AutoRewriteChainState(root, ctx2);
-            var autoChain = BuildAutoRewriteChain(autoRules);
             autoChain.ExecuteAsync(autoState).AsTask().GetAwaiter().GetResult();
             var currentRoot = autoState.Root;
             var fileModified = autoState.FileModified;


### PR DESCRIPTION
## Summary
- build the PatternKit auto-rule chain once per migration run instead of once per file
- keep per-file rewrite state isolated
- reduce repeated allocation while preserving rule ordering and audit behavior

## Validation
- dotnet test WrapGod.Tests\WrapGod.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Migration.Engine"
- git diff --check