### PR TITLE
[WrapGod] bump SQLitePCLRaw.lib.e_sqlite3 to 3.50.3 (GHSA-2m69-gcr7-jv3q)

### DIFF
--- a/examples/migrations/efcore-dapper-bidirectional/DapperApp/DapperApp.csproj
+++ b/examples/migrations/efcore-dapper-bidirectional/DapperApp/DapperApp.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.8" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Pins `SQLitePCLRaw.lib.e_sqlite3` to **3.50.3** (patched) in the `efcore-dapper-bidirectional` DapperApp example
- `Microsoft.Data.Sqlite 9.0.8` transitively pulls `SQLitePCLRaw.lib.e_sqlite3 2.1.10` which is affected by GHSA-2m69-gcr7-jv3q
- Explicit `PackageReference` forces NuGet to resolve the patched version

## Test plan
- [x] `dotnet restore` — NU1903 warning gone
- [x] `dotnet build` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)